### PR TITLE
Makefile for building pebble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build/
 cmd/pebble/pebble
 cmd/version_generated.go
 cmd/VERSION

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@
 PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 PROJECT := github.com/canonical/pebble
 
-GOOS=$(shell go env GOOS)
-GOARCH=$(shell go env GOARCH)
-GOHOSTOS=$(shell go env GOHOSTOS)
-GOHOSTARCH=$(shell go env GOHOSTARCH)
 export CGO_ENABLED=0
 
 BUILD_DIR ?= $(PROJECT_DIR)/_build
@@ -26,10 +22,6 @@ BUILD_TAGS ?=
 # Build number passed in must be a monotonic int representing
 # the build.
 PEBBLE_BUILD_NUMBER ?=
-
-# Build flag passed to go -mod
-# CI should set this to vendor
-PEBBLE_GOMOD_MODE ?= mod
 
 COMPILE_FLAGS = -gcflags "all=-N -l"
 LINK_FLAGS = -ldflags "-X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) -X $(PROJECT)/version.build=$(PEBBLE_BUILD_NUMBER)"
@@ -50,8 +42,8 @@ run-tests:
 ## run-tests: Run the unit tests
 	$(eval TMP := $(shell mktemp -d $${TMPDIR:-/tmp}/pbbl-XXX))
 	$(eval TEST_PACKAGES := $(shell go list $(PROJECT)/... | grep -v $(PROJECT)$$ | grep -v mocks))
-	@echo 'go test -mod=$(PEBBLE_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES'
-	@TMPDIR=$(TMP) go test -mod=$(PEBBLE_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES)
+	@echo 'go test -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES'
+	@TMPDIR=$(TMP) go test -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES)
 	@rm -r $(TMP)
 
 
@@ -63,5 +55,5 @@ clean:
 go-build:
 ## build: Build PEBBLE binaries without updating dependencies
 	@mkdir -p ${BIN_DIR}
-	@echo 'go build -mod=$(PEBBLE_GOMOD_MODE) -o ${BIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $$MAIN_PACKAGES'
-	@go build -mod=$(PEBBLE_GOMOD_MODE) -o ${BIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $(strip $(MAIN_PACKAGES))
+	@echo 'go build -o ${BIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $$MAIN_PACKAGES'
+	@go build -o ${BIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $(strip $(MAIN_PACKAGES))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+#
+# Makefile for pebble.
+#
+PROJECT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+PROJECT := github.com/canonical/pebble
+
+GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env GOARCH)
+GOHOSTOS=$(shell go env GOHOSTOS)
+GOHOSTARCH=$(shell go env GOHOSTARCH)
+export CGO_ENABLED=0
+
+BUILD_DIR ?= $(PROJECT_DIR)/_build
+BIN_DIR = ${BUILD_DIR}/${GOOS}_${GOARCH}/bin
+
+define MAIN_PACKAGES
+	github.com/canonical/pebble/cmd/pebble
+endef
+
+GIT_COMMIT ?= $(shell git -C $(PROJECT_DIR) rev-parse HEAD 2>/dev/null)
+
+# Build tags passed to go install/build.
+# Example: BUILD_TAGS="minimal provider_kubernetes"
+BUILD_TAGS ?=
+
+# Build number passed in must be a monotonic int representing
+# the build.
+PEBBLE_BUILD_NUMBER ?=
+
+# Build flag passed to go -mod
+# CI should set this to vendor
+PEBBLE_GOMOD_MODE ?= mod
+
+COMPILE_FLAGS = -gcflags "all=-N -l"
+LINK_FLAGS = -ldflags "-X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) -X $(PROJECT)/version.build=$(PEBBLE_BUILD_NUMBER)"
+
+TEST_TIMEOUT ?= 2700s
+
+default: build
+
+.PHONY: test
+
+build: go-build
+## build: Create Pebble binaries
+
+test: run-tests
+## test: Verify PEBBLE code using unit tests
+
+run-tests:
+## run-tests: Run the unit tests
+	$(eval TMP := $(shell mktemp -d $${TMPDIR:-/tmp}/pbbl-XXX))
+	$(eval TEST_PACKAGES := $(shell go list $(PROJECT)/... | grep -v $(PROJECT)$$ | grep -v mocks))
+	@echo 'go test -mod=$(PEBBLE_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $$TEST_PACKAGES'
+	@TMPDIR=$(TMP) go test -mod=$(PEBBLE_GOMOD_MODE) -tags "$(BUILD_TAGS)" $(CHECK_ARGS) -test.timeout=$(TEST_TIMEOUT) $(TEST_PACKAGES)
+	@rm -r $(TMP)
+
+
+clean:
+## clean: Clean the cache and test caches
+	go clean -n -r --cache --testcache $(PROJECT)/...
+
+
+go-build:
+## build: Build PEBBLE binaries without updating dependencies
+	@mkdir -p ${BIN_DIR}
+	@echo 'go build -mod=$(PEBBLE_GOMOD_MODE) -o ${BIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $$MAIN_PACKAGES'
+	@go build -mod=$(PEBBLE_GOMOD_MODE) -o ${BIN_DIR} -tags "$(BUILD_TAGS)" $(COMPILE_FLAGS) $(LINK_FLAGS) -v $(strip $(MAIN_PACKAGES))


### PR DESCRIPTION
This PR includes the following changes:

- A Makefile for building the project locally, based on https://github.com/juju/juju/blob/develop/Makefile
- go.mod with the project dependencies, set to 1.14 to match Juju 

