### PR TITLE
Ignore pid=0 in socket remote address.

### DIFF
--- a/internal/daemon/ucrednet.go
+++ b/internal/daemon/ucrednet.go
@@ -27,7 +27,9 @@ import (
 var errNoID = errors.New("no pid/uid found")
 
 const (
-	ucrednetNoProcess = int32(0)
+	// ucrednetNoProcess is -1 to avoid the case when pid=0 is returned from the kernel
+	// because the connecting process is in an unrelated process namespace.
+	ucrednetNoProcess = int32(-1)
 	ucrednetNobody    = uint32((1 << 32) - 1)
 )
 

--- a/internal/daemon/ucrednet_test.go
+++ b/internal/daemon/ucrednet_test.go
@@ -194,3 +194,11 @@ func (s *ucrednetSuite) TestGetSneak(c *check.C) {
 	c.Check(uid, check.Equals, ucrednetNobody)
 	c.Check(socket, check.Equals, "")
 }
+
+func (s *ucrednetSuite) TestGetWithZeroPid(c *check.C) {
+	pid, uid, socket, err := ucrednetGet("pid=0;uid=42;socket=/run/snap.socket;")
+	c.Check(err, check.IsNil)
+	c.Check(pid, check.Equals, int32(0))
+	c.Check(uid, check.Equals, uint32(42))
+	c.Check(socket, check.Equals, "/run/snap.socket")
+}


### PR DESCRIPTION
A UNIX socket connection between process namespaces _appears_ to always have a pid of 0.
I have tested with non-root users and they are passed correctly by the kernel, I only tested with containerd in microk8s, so this circumstance might be just related to that environment.

This change ignores `pid == ucrednetNoProcess` and solely relies on uid.
The remote address still has to be properly formed, this is enforced by the strict regex.