### PR TITLE
Support $PEBBLE_SOCKET and add $PEBBLE default.

### DIFF
--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -111,7 +111,11 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal) error {
 
 	t0 := time.Now().Truncate(time.Millisecond)
 
-	d, err := daemon.New(os.Getenv("PEBBLE"))
+	dopts := daemon.Options{
+		Dir:        os.Getenv("PEBBLE"),
+		SocketPath: os.Getenv("PEBBLE_SOCKET"),
+	}
+	d, err := daemon.New(&dopts)
 	if err != nil {
 		return err
 	}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -337,7 +337,7 @@ func run() error {
 	}
 
 	pebbleDir := os.Getenv("PEBBLE")
-	if pebbleDir == "" || !osutil.IsDir(pebbleDir) {
+	if pebbleDir != "" && !osutil.IsDir(pebbleDir) {
 		return fmt.Errorf("$PEBBLE must point to a pebble directory")
 	}
 	clientConfig.Socket = os.Getenv("PEBBLE_SOCKET")

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -340,7 +340,10 @@ func run() error {
 	if pebbleDir == "" || !osutil.IsDir(pebbleDir) {
 		return fmt.Errorf("$PEBBLE must point to a pebble directory")
 	}
-	clientConfig.Socket = filepath.Join(pebbleDir, ".pebble.socket")
+	clientConfig.Socket = os.Getenv("PEBBLE_SOCKET")
+	if clientConfig.Socket == "" {
+		clientConfig.Socket = filepath.Join(pebbleDir, ".pebble.socket")
+	}
 
 	cli := client.New(&clientConfig)
 	parser := Parser(cli)

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -53,7 +53,7 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	if s.d != nil {
 		panic("called daemon() twice")
 	}
-	d, err := New(s.pebbleDir)
+	d, err := New(&Options{Dir: s.pebbleDir})
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
 	s.d = d


### PR DESCRIPTION
$PEBBLE now defaults to /var/lib/pebble/default.