### PR TITLE
 Define and enforce layer filename format

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,16 @@ designed with unique features that help with more specific use cases.
 Pebble is organized as a single binary that works as a daemon and also as a
 client to itself. When the daemon runs it loads its own configuration from the
 _$PEBBLE_ directory, as defined in the environment, and also writes down in
-that same directory its state and unix sockets for communication.
+that same directory its state and unix sockets for communication. If that variable
+is not defined, Pebble will attempt to look for its configuration from a default
+system-level setup at _/var/lib/pebble/default_. Using that directory is encouraged
+for whole-system setup such as when using Pebble to control services in a container.
 
-The _$PEBBLE_ directory must also contain a _layers/_ subdirectory that holds a
-list of yaml files conventionally named as `2020-12-01T15:00:00.yaml`.  The reason
-for the timestamp in the filename is that these configuration files are layered,
-as the directory name implies. That is, each layer sits above the former
-layer, and has the chance to improve or redefine the service configuration as
-desired.
-
-For now, naming files as _01.yaml_, _02.yaml_, etc, will work just as well, but we
-will most likely enforce _some_ convention before the first stable release is ready.
-An interesting feature of timestamps is that it's easy to create a latest one without
-knowing what was there before.
+The _$PEBBLE_ directory must contain a _layers/_ subdirectory that holds a stack of
+configuration files with names similar to `001-base-layer.yaml`, where the digits define
+the order of the layer and the following label uniquely identifies it.  Each
+layer in the stack sits above the former one, and has the chance to improve or
+redefine the service configuration as desired.
 
 ## Layer configuration
 
@@ -129,12 +126,16 @@ explore around.
 
 Here are some of the things coming soon:
 
+  - [x] Support `$PEBBLE_SOCKET` and default `$PEBBLE` to /var/lib/pebble/default.
+  - [x] Define and enforce convention for layer names
+  - [ ] Dynamic layer support over the API
   - [ ] Terminate all services before exiting run command
   - [ ] Status command that displays active services and their current status
   - [ ] Configuration retrieval commands to investigate current settings
   - [ ] General system modification commands (writing files, etc)
-  - [ ] Define and enforce convention for layer names
   - [ ] More tests for existing CLI commands
+  - [ ] Better log caching and retrieval support
+  - [ ] Consider showing unified log as output of `pebble run`
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ designed with unique features that help with more specific use cases.
 
 Pebble is organized as a single binary that works as a daemon and also as a
 client to itself. When the daemon runs it loads its own configuration from the
-_$PEBBLE_ directory, as defined in the environment, and also writes down in
+`$PEBBLE` directory, as defined in the environment, and also writes down in
 that same directory its state and unix sockets for communication. If that variable
 is not defined, Pebble will attempt to look for its configuration from a default
-system-level setup at _/var/lib/pebble/default_. Using that directory is encouraged
+system-level setup at `/var/lib/pebble/default`. Using that directory is encouraged
 for whole-system setup such as when using Pebble to control services in a container.
 
-The _$PEBBLE_ directory must contain a _layers/_ subdirectory that holds a stack of
+The `$PEBBLE` directory must contain a `layers/` subdirectory that holds a stack of
 configuration files with names similar to `001-base-layer.yaml`, where the digits define
 the order of the layer and the following label uniquely identifies it.  Each
 layer in the stack sits above the former one, and has the chance to improve or
@@ -63,7 +63,7 @@ services:
         command: cmd
 ```
 
-The file should be almost entirely obvious. One interesting detail there is the _override_
+The file should be almost entirely obvious. One interesting detail there is the `override`
 field (for now required) which defines whether this entry _overrides_ the previous
 service of the same name (if any - missing is okay), or merges with it. Any of the fields can
 be replaced individually in a merged service configuration.
@@ -102,7 +102,7 @@ services:
 
 ## Running pebble
 
-Once the _$PEBBLE_ directory is setup, running it is easy:
+Once the `$PEBBLE` directory is setup, running it is easy:
 
     $ pebble run
 
@@ -126,7 +126,7 @@ explore around.
 
 Here are some of the things coming soon:
 
-  - [x] Support `$PEBBLE_SOCKET` and default `$PEBBLE` to /var/lib/pebble/default.
+  - [x] Support `$PEBBLE_SOCKET` and default `$PEBBLE` to `/var/lib/pebble/default`
   - [x] Define and enforce convention for layer names
   - [ ] Dynamic layer support over the API
   - [ ] Terminate all services before exiting run command

--- a/internal/daemon/api_services_test.go
+++ b/internal/daemon/api_services_test.go
@@ -57,7 +57,7 @@ services:
 func writeTestLayer(pebbleDir string) {
 	err := os.Mkdir(filepath.Join(pebbleDir, "layers"), 0755)
 	if err == nil {
-		err = ioutil.WriteFile(filepath.Join(pebbleDir, "layers", "1.yaml"), []byte(setupLayer), 0644)
+		err = ioutil.WriteFile(filepath.Join(pebbleDir, "layers", "001-base.yaml"), []byte(setupLayer), 0644)
 	}
 	if err != nil {
 		panic(err)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -110,7 +110,7 @@ type Log struct {
 // Debug only prints if SNAPD_DEBUG is set
 func (l Log) Debug(msg string) {
 	if os.Getenv("PEBBLE_DEBUG") == "1" {
-		l.log.Output(3, "DEBUG: "+msg)
+		l.log.Output(3, "DEBUG "+msg)
 	}
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -93,15 +93,15 @@ func (s *LogSuite) TestDebugfEnv(c *C) {
 	defer os.Unsetenv("SNAPD_DEBUG")
 
 	logger.Debugf("xyzzy")
-	c.Check(s.logbuf.String(), Matches, `(?s).*DEBUG: xyzzy.*`)
+	c.Check(s.logbuf.String(), Matches, `(?s).*DEBUG xyzzy.*`)
 }
 
 func (s *LogSuite) TestNoticef(c *C) {
 	logger.Noticef("xyzzy")
-	c.Check(s.logbuf.String(), Matches, `(?m).*logger_test\.go:\d+: xyzzy`)
+	c.Check(s.logbuf.String(), Matches, `(?m)20\d\d/\d\d/\d\d \d\d:\d\d:\d\d xyzzy`)
 }
 
 func (s *LogSuite) TestPanicf(c *C) {
 	c.Check(func() { logger.Panicf("xyzzy") }, Panics, "xyzzy")
-	c.Check(s.logbuf.String(), Matches, `(?m).*logger_test\.go:\d+: PANIC xyzzy`)
+	c.Check(s.logbuf.String(), Matches, `(?m)20\d\d/\d\d/\d\d \d\d:\d\d:\d\d PANIC xyzzy`)
 }

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -81,7 +81,7 @@ func (s *S) SetUpTest(c *C) {
 
 	s.log = filepath.Join(s.dir, "log.txt")
 	data := fmt.Sprintf(setupLayer, s.log, s.log)
-	err := ioutil.WriteFile(filepath.Join(s.dir, "layers", "1.yaml"), []byte(data), 0644)
+	err := ioutil.WriteFile(filepath.Join(s.dir, "layers", "001-base.yaml"), []byte(data), 0644)
 	c.Assert(err, IsNil)
 
 	s.runner = state.NewTaskRunner(s.st)

--- a/internal/systemd/sdnotify.go
+++ b/internal/systemd/sdnotify.go
@@ -40,10 +40,10 @@ func SdNotify(notifyState string) error {
 
 	notifySocket := osGetenv("NOTIFY_SOCKET")
 	if notifySocket == "" {
-		return fmt.Errorf("cannot find NOTIFY_SOCKET environment")
+		return fmt.Errorf("$NOTIFY_SOCKET not defined")
 	}
 	if !strings.HasPrefix(notifySocket, "@") && !strings.HasPrefix(notifySocket, "/") {
-		return fmt.Errorf("cannot use NOTIFY_SOCKET %q", notifySocket)
+		return fmt.Errorf("cannot use $NOTIFY_SOCKET value: %q", notifySocket)
 	}
 
 	raddr := &net.UnixAddr{

--- a/internal/systemd/sdnotify_test.go
+++ b/internal/systemd/sdnotify_test.go
@@ -61,12 +61,10 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWrongNotifySocket(c *C) {
 		env    string
 		errStr string
 	}{
-		{"", "cannot find NOTIFY_SOCKET environment"},
-		{"xxx", `cannot use NOTIFY_SOCKET "xxx"`},
+		{"", `\$NOTIFY_SOCKET not defined`},
+		{"xxx", `cannot use \$NOTIFY_SOCKET value: "xxx"`},
 	} {
-		os.Setenv("NOTIFY_SOCKET", t.env)
-		defer os.Unsetenv("NOTIFY_SOCKET")
-
+		sd.env["NOTIFY_SOCKET"] = t.env
 		c.Check(systemd.SdNotify("something"), ErrorMatches, t.errStr)
 	}
 }


### PR DESCRIPTION
This also splits layer keys into independent order and label
fields. The new file format looks like 001-some-label.yaml,
where both order and label are unique. This drops the benefit of
timestamps, originally described as it being easy to blindly
create, in favor of it being better to read and manipulate.
Seems like a good tradeoff to make.