### PR TITLE
Add "pebble services" command and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmd/VERSION
 *.swp
 *.swo
 .idea
+/pebble

--- a/README.md
+++ b/README.md
@@ -128,11 +128,12 @@ Here are some of the things coming soon:
 
   - [x] Support `$PEBBLE_SOCKET` and default `$PEBBLE` to `/var/lib/pebble/default`
   - [x] Define and enforce convention for layer names
-  - [ ] Dynamic layer support over the API
+  - [x] Dynamic layer support over the API
+  - [x] Configuration retrieval commands to investigate current settings
+  - [x] Status command that displays active services and their current status
+  - [ ] General system modification commands (writing configuration files, etc)
+  - [ ] Improve signal handling, e.g., sending SIGHUP to a service
   - [ ] Terminate all services before exiting run command
-  - [ ] Status command that displays active services and their current status
-  - [ ] Configuration retrieval commands to investigate current settings
-  - [ ] General system modification commands (writing files, etc)
   - [ ] More tests for existing CLI commands
   - [ ] Better log caching and retrieval support
   - [ ] Consider showing unified log as output of `pebble run`

--- a/client/services.go
+++ b/client/services.go
@@ -70,11 +70,27 @@ type ServicesOptions struct {
 
 // ServiceInfo holds status information for a single service.
 type ServiceInfo struct {
-	Name    string `json:"name"`    // service name
-	Default string `json:"default"` // default state: "start" or "stop"
-	Status  string `json:"status"`  // "active", "inactive", or "error"
-	Message string `json:"message"` // message (e.g., error) or empty string
+	Name    string         `json:"name"` // service name
+	Startup ServiceStartup `json:"startup"`
+	Current ServiceStatus  `json:"current"`
 }
+
+// ServiceStartup defines the different startup modes for a service.
+type ServiceStartup string
+
+const (
+	StartupEnabled  ServiceStartup = "enabled"
+	StartupDisabled ServiceStartup = "disabled"
+)
+
+// ServiceStatus defines the current states for a service.
+type ServiceStatus string
+
+const (
+	StatusActive   ServiceStatus = "active"
+	StatusInactive ServiceStatus = "inactive"
+	StatusError    ServiceStatus = "error"
+)
 
 // Services fetches information about specific services (or all of them),
 // ordered by service name.

--- a/client/services_test.go
+++ b/client/services_test.go
@@ -86,8 +86,8 @@ func (cs *clientSuite) TestAutostart(c *check.C) {
 func (cs *clientSuite) TestServicesGet(c *check.C) {
 	cs.rsp = `{
 		"result": [
-			{"name": "svc1", "default": "start", "status": "inactive"},
-			{"name": "svc2", "default": "stop", "status": "active"}
+			{"name": "svc1", "startup": "enabled", "current": "inactive"},
+			{"name": "svc2", "startup": "disabled", "current": "active"}
 		],
 		"status": "OK",
 		"status-code": 200,
@@ -100,8 +100,8 @@ func (cs *clientSuite) TestServicesGet(c *check.C) {
 	services, err := cs.cli.Services(&opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(services, check.DeepEquals, []*client.ServiceInfo{
-		{Name: "svc1", Default: "start", Status: "inactive"},
-		{Name: "svc2", Default: "stop", Status: "active"},
+		{Name: "svc1", Startup: client.StartupEnabled, Current: client.StatusInactive},
+		{Name: "svc2", Startup: client.StartupDisabled, Current: client.StatusActive},
 	})
 	c.Assert(cs.req.Method, check.Equals, "GET")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v1/services")

--- a/client/services_test.go
+++ b/client/services_test.go
@@ -16,6 +16,7 @@ package client_test
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"gopkg.in/check.v1"
 
@@ -59,7 +60,7 @@ func (cs *clientSuite) TestStartStop(c *check.C) {
 	}
 }
 
-func (cs *clientSuite) TestAutoStart(c *check.C) {
+func (cs *clientSuite) TestAutostart(c *check.C) {
 	cs.rsp = `{
 		"result": {},
 		"status": "OK",
@@ -80,4 +81,31 @@ func (cs *clientSuite) TestAutoStart(c *check.C) {
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "autostart")
+}
+
+func (cs *clientSuite) TestServicesGet(c *check.C) {
+	cs.rsp = `{
+		"result": [
+			{"name": "svc1", "default": "start", "status": "inactive"},
+			{"name": "svc2", "default": "stop", "status": "active"}
+		],
+		"status": "OK",
+		"status-code": 200,
+		"type": "sync"
+	}`
+
+	opts := client.ServicesOptions{
+		Names: []string{"svc1", "svc2"},
+	}
+	services, err := cs.cli.Services(&opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(services, check.DeepEquals, []*client.ServiceInfo{
+		{Name: "svc1", Default: "start", Status: "inactive"},
+		{Name: "svc2", Default: "stop", Status: "active"},
+	})
+	c.Assert(cs.req.Method, check.Equals, "GET")
+	c.Assert(cs.req.URL.Path, check.Equals, "/v1/services")
+	c.Assert(cs.req.URL.Query(), check.DeepEquals, url.Values{
+		"names": {"svc1,svc2"},
+	})
 }

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -167,16 +167,20 @@ type helpCategory struct {
 // helpCategories helps us by grouping commands
 var helpCategories = []helpCategory{{
 	Label:       "Basics",
-	Description: "basic management",
-	Commands:    []string{"start", "stop", "autostart"},
+	Description: "basic service management",
+	Commands:    []string{"autostart", "run", "start", "stop"},
+}, {
+	Label:       "Configuration",
+	Description: "manage configuration",
+	Commands:    []string{"add", "plan"},
 }, {
 	Label:       "Changes",
-	Description: "basic management",
-	Commands:    []string{"history", "tasks", "abort"},
+	Description: "view changes, tasks, and warnings",
+	Commands:    []string{"changes", "okay", "tasks", "warnings"},
 }, {
-	Label:       "...more",
-	Description: "slightly more advanced management",
-	Commands:    []string{"help"},
+	Label:       "Other",
+	Description: "miscellaneous commands",
+	Commands:    []string{"help", "version"},
 }}
 
 var (
@@ -196,7 +200,6 @@ func printHelpHeader() {
 	fmt.Fprintln(Stdout, pebbleUsage)
 	fmt.Fprintln(Stdout)
 	fmt.Fprintln(Stdout, pebbleHelpCategoriesIntro)
-	fmt.Fprintln(Stdout)
 }
 
 func printHelpAllFooter() {
@@ -212,6 +215,7 @@ func printHelpFooter() {
 // this is called when the Execute returns a flags.Error with ErrCommandRequired
 func printShortHelp() {
 	printHelpHeader()
+	fmt.Fprintln(Stdout)
 	maxLen := 0
 	for _, categ := range helpCategories {
 		if l := utf8.RuneCountInString(categ.Label); l > maxLen {

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -168,7 +168,7 @@ type helpCategory struct {
 var helpCategories = []helpCategory{{
 	Label:       "Basics",
 	Description: "basic service management",
-	Commands:    []string{"autostart", "run", "start", "stop"},
+	Commands:    []string{"autostart", "run", "services", "start", "stop"},
 }, {
 	Label:       "Configuration",
 	Description: "manage configuration",

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -167,20 +167,20 @@ type helpCategory struct {
 // helpCategories helps us by grouping commands
 var helpCategories = []helpCategory{{
 	Label:       "Basics",
-	Description: "basic service management",
-	Commands:    []string{"autostart", "run", "services", "start", "stop"},
+	Description: "basic management",
+	Commands:    []string{"run", "autostart", "start", "stop", "services"},
 }, {
 	Label:       "Configuration",
 	Description: "manage configuration",
 	Commands:    []string{"add", "plan"},
 }, {
 	Label:       "Changes",
-	Description: "view changes, tasks, and warnings",
-	Commands:    []string{"changes", "okay", "tasks", "warnings"},
+	Description: "view changes and tasks",
+	Commands:    []string{"changes", "tasks"},
 }, {
 	Label:       "Other",
-	Description: "miscellaneous commands",
-	Commands:    []string{"help", "version"},
+	Description: "other commands",
+	Commands:    []string{"warnings", "okay", "help", "version"},
 }}
 
 var (

--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -31,7 +31,7 @@ import (
 	"github.com/canonical/pebble/internal/systemd"
 )
 
-var shortRunHelp = "Run the pebble environment"
+var shortRunHelp = "Run the pebble server"
 var longRunHelp = `
 The run command starts pebble and runs the configured environment.
 `

--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -31,7 +31,7 @@ import (
 	"github.com/canonical/pebble/internal/systemd"
 )
 
-var shortRunHelp = "Run the pebble server"
+var shortRunHelp = "Run the pebble environment"
 var longRunHelp = `
 The run command starts pebble and runs the configured environment.
 `

--- a/cmd/pebble/cmd_services.go
+++ b/cmd/pebble/cmd_services.go
@@ -59,22 +59,10 @@ func (cmd *cmdServices) Execute(args []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	fmt.Fprintln(w, "Service\tStartup\tCurrent\tNotes")
+	fmt.Fprintln(w, "Service\tStartup\tCurrent")
 
 	for _, svc := range services {
-		startup := svc.Default
-		switch svc.Default {
-		case "start":
-			startup = "enabled"
-		case "stop":
-			startup = "disabled"
-		}
-		current := svc.Status
-		notes := svc.Message
-		if notes == "" {
-			notes = "-"
-		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", svc.Name, startup, current, notes)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", svc.Name, svc.Startup, svc.Current)
 	}
 	return nil
 }

--- a/cmd/pebble/cmd_services.go
+++ b/cmd/pebble/cmd_services.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/canonical/pebble/client"
+)
+
+type cmdServices struct {
+	clientMixin
+	Positional struct {
+		Services []string `positional-arg-name:"<service>"`
+	} `positional-args:"yes"`
+}
+
+var shortServicesHelp = "Query the status of configured services"
+var longServicesHelp = `
+The services command lists status information about the services specified, or
+about all services if none are specified.
+`
+
+func (cmd *cmdServices) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	opts := client.ServicesOptions{
+		Names: cmd.Positional.Services,
+	}
+	services, err := cmd.client.Services(&opts)
+	if err != nil {
+		return err
+	}
+	if len(services) == 0 {
+		if len(cmd.Positional.Services) == 0 {
+			fmt.Fprintln(Stderr, "Plan has no services")
+		} else {
+			fmt.Fprintln(Stderr, "No matching services")
+		}
+		return nil
+	}
+
+	w := tabWriter()
+	defer w.Flush()
+
+	fmt.Fprintln(w, "Service\tStartup\tCurrent\tNotes")
+
+	for _, svc := range services {
+		startup := svc.Default
+		switch svc.Default {
+		case "start":
+			startup = "enabled"
+		case "stop":
+			startup = "disabled"
+		}
+		current := svc.Status
+		notes := svc.Message
+		if notes == "" {
+			notes = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", svc.Name, startup, current, notes)
+	}
+	return nil
+}
+
+func init() {
+	addCommand("services", shortServicesHelp, longServicesHelp, func() flags.Commander { return &cmdServices{} }, nil, nil)
+}

--- a/cmd/pebble/cmd_services_test.go
+++ b/cmd/pebble/cmd_services_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"gopkg.in/check.v1"
+
+	pebble "github.com/canonical/pebble/cmd/pebble"
+)
+
+func (s *PebbleSuite) TestServices(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/services")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{"names": {""}})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [
+		{"name": "svc1", "status": "inactive", "default": "start"}
+	]
+}`)
+	})
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"services"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+Service  Startup  Current   Notes
+svc1     enabled  inactive  -
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestServicesNames(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/services")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{"names": {"foo,bar"}})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [
+		{"name": "bar", "status": "active", "default": "stop"},
+		{"name": "foo", "status": "inactive", "default": "start"}
+	]
+}`)
+	})
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"services", "foo", "bar"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+Service  Startup   Current   Notes
+bar      disabled  active    -
+foo      enabled   inactive  -
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}

--- a/cmd/pebble/cmd_services_test.go
+++ b/cmd/pebble/cmd_services_test.go
@@ -33,7 +33,7 @@ func (s *PebbleSuite) TestServices(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "svc1", "status": "inactive", "default": "start"}
+		{"name": "svc1", "current": "inactive", "startup": "enabled"}
 	]
 }`)
 	})
@@ -41,8 +41,8 @@ func (s *PebbleSuite) TestServices(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Service  Startup  Current   Notes
-svc1     enabled  inactive  -
+Service  Startup  Current
+svc1     enabled  inactive
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -56,8 +56,8 @@ func (s *PebbleSuite) TestServicesNames(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "bar", "status": "active", "default": "stop"},
-		{"name": "foo", "status": "inactive", "default": "start"}
+		{"name": "bar", "current": "active", "startup": "disabled"},
+		{"name": "foo", "current": "inactive", "startup": "enabled"}
 	]
 }`)
 	})
@@ -65,9 +65,9 @@ func (s *PebbleSuite) TestServicesNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Service  Startup   Current   Notes
-bar      disabled  active    -
-foo      enabled   inactive  -
+Service  Startup   Current
+bar      disabled  active
+foo      enabled   inactive
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/cmd/pebble/cmd_warnings.go
+++ b/cmd/pebble/cmd_warnings.go
@@ -45,7 +45,7 @@ var shortWarningsHelp = "List warnings"
 var longWarningsHelp = `
 The warnings command lists the warnings that have been reported to the system.
 
-Once warnings have been listed with 'snap warnings', 'snap okay' may be used to
+Once warnings have been listed with 'pebble warnings', 'pebble okay' may be used to
 silence them. A warning that's been silenced in this way will not be listed
 again unless it happens again, _and_ a cooldown time has passed.
 
@@ -54,7 +54,7 @@ Warnings expire automatically, and once expired they are forgotten.
 
 var shortOkayHelp = "Acknowledge warnings"
 var longOkayHelp = `
-The okay command acknowledges the warnings listed with 'snap warnings'.
+The okay command acknowledges the warnings listed with 'pebble warnings'.
 
 Once acknowledged a warning won't appear again unless it re-occurrs and
 sufficient time has passed.

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -44,6 +44,7 @@ var api = []*Command{{
 }, {
 	Path:   "/v1/services",
 	UserOK: true,
+	GET:    v1GetServices,
 	POST:   v1PostServices,
 }, {
 	Path:   "/v1/services/{name}",

--- a/internal/daemon/api_services.go
+++ b/internal/daemon/api_services.go
@@ -27,9 +27,8 @@ import (
 
 type serviceInfo struct {
 	Name    string `json:"name"`
-	Default string `json:"default"`
-	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
+	Startup string `json:"startup"`
+	Current string `json:"current"`
 }
 
 func v1GetServices(c *Command, r *http.Request, _ *userState) Response {
@@ -41,13 +40,12 @@ func v1GetServices(c *Command, r *http.Request, _ *userState) Response {
 		return statusInternalError(err.Error())
 	}
 
-	var infos []serviceInfo
+	infos := make([]serviceInfo, 0, len(services))
 	for _, svc := range services {
 		info := serviceInfo{
 			Name:    svc.Name,
-			Default: string(svc.Default),
-			Status:  string(svc.Status),
-			Message: svc.Message,
+			Startup: string(svc.Startup),
+			Current: string(svc.Current),
 		}
 		infos = append(infos, info)
 	}

--- a/internal/daemon/api_services_test.go
+++ b/internal/daemon/api_services_test.go
@@ -224,9 +224,9 @@ func (s *apiSuite) TestServicesGet(c *C) {
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, IsNil)
 	c.Check(body["result"], DeepEquals, []interface{}{
-		map[string]interface{}{"default": "start", "name": "test1", "status": "inactive"},
-		map[string]interface{}{"default": "stop", "name": "test2", "status": "inactive"},
-		map[string]interface{}{"default": "stop", "name": "test3", "status": "inactive"},
-		map[string]interface{}{"default": "stop", "name": "test4", "status": "inactive"},
+		map[string]interface{}{"startup": "enabled", "name": "test1", "current": "inactive"},
+		map[string]interface{}{"startup": "disabled", "name": "test2", "current": "inactive"},
+		map[string]interface{}{"startup": "disabled", "name": "test3", "current": "inactive"},
+		map[string]interface{}{"startup": "disabled", "name": "test4", "current": "inactive"},
 	})
 }

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -200,7 +200,7 @@ func (s *S) TestStartBadCommand(c *C) {
 	s.st.Unlock()
 
 	svc := s.serviceByName(c, "test3")
-	c.Assert(svc.Status, Equals, servstate.ServiceInactive)
+	c.Assert(svc.Current, Equals, servstate.StatusInactive)
 }
 
 func (s *S) serviceByName(c *C, name string) *servstate.ServiceInfo {
@@ -228,7 +228,7 @@ func (s *S) TestStartFastExitCommand(c *C) {
 	s.st.Unlock()
 
 	svc := s.serviceByName(c, "test4")
-	c.Assert(svc.Status, Equals, servstate.ServiceInactive)
+	c.Assert(svc.Current, Equals, servstate.StatusInactive)
 }
 
 func planYAML(c *C, manager *servstate.ServiceManager) string {
@@ -474,17 +474,17 @@ func (s *S) TestServices(c *C) {
 	services, err := s.manager.Services(nil)
 	c.Assert(err, IsNil)
 	c.Assert(services, DeepEquals, []*servstate.ServiceInfo{
-		{Name: "test1", Status: servstate.ServiceInactive, Default: plan.StartAction},
-		{Name: "test2", Status: servstate.ServiceInactive, Default: plan.StopAction},
-		{Name: "test3", Status: servstate.ServiceInactive, Default: plan.StopAction},
-		{Name: "test4", Status: servstate.ServiceInactive, Default: plan.StopAction},
+		{Name: "test1", Current: servstate.StatusInactive, Startup: servstate.StartupEnabled},
+		{Name: "test2", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
+		{Name: "test3", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
+		{Name: "test4", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
 	})
 
 	services, err = s.manager.Services([]string{"test2", "test3"})
 	c.Assert(err, IsNil)
 	c.Assert(services, DeepEquals, []*servstate.ServiceInfo{
-		{Name: "test2", Status: servstate.ServiceInactive, Default: plan.StopAction},
-		{Name: "test3", Status: servstate.ServiceInactive, Default: plan.StopAction},
+		{Name: "test2", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
+		{Name: "test3", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
 	})
 
 	// Start a service and ensure it's marked active
@@ -499,10 +499,9 @@ func (s *S) TestServices(c *C) {
 	services, err = s.manager.Services(nil)
 	c.Assert(err, IsNil)
 	c.Assert(services, DeepEquals, []*servstate.ServiceInfo{
-		{Name: "test1", Status: servstate.ServiceInactive, Default: plan.StartAction},
-		{Name: "test2", Status: servstate.ServiceActive, Default: plan.StopAction},
-		{Name: "test3", Status: servstate.ServiceInactive, Default: plan.StopAction},
-		{Name: "test4", Status: servstate.ServiceInactive, Default: plan.StopAction},
+		{Name: "test1", Current: servstate.StatusInactive, Startup: servstate.StartupEnabled},
+		{Name: "test2", Current: servstate.StatusActive, Startup: servstate.StartupDisabled},
+		{Name: "test3", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
+		{Name: "test4", Current: servstate.StatusInactive, Startup: servstate.StartupDisabled},
 	})
-
 }


### PR DESCRIPTION
This adds a new `GET /v1/services?name=foo,bar` API to fetch service status of all configured services, as well as the Go client and `pebble services` CLI command for the same. It's modeled after the `snap services` command.

See also the [design doc](https://docs.google.com/document/d/1OxaG9WUp2IR_S6qpeh9J5LgfmgW794KO9FJmGqPO_Ng/edit#).