### PR TITLE
Change default: start/stop to startup: enabled/disabled

### DIFF
--- a/internal/daemon/api_services_test.go
+++ b/internal/daemon/api_services_test.go
@@ -34,7 +34,7 @@ services:
     test1:
         override: replace
         command: /bin/sh -c "echo test1 >> %s; sleep 300"
-        default: start
+        startup: enabled
         requires:
             - test2
         before:

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -232,7 +232,7 @@ func (m *ServiceManager) Services(names []string) ([]*ServiceInfo, error) {
 			Startup: StartupDisabled,
 			Current: StatusInactive,
 		}
-		if service.Default == plan.StartAction {
+		if service.Startup == plan.StartupEnabled {
 			info.Startup = StartupEnabled
 		}
 		if _, ok := m.services[name]; ok {
@@ -257,7 +257,7 @@ func (m *ServiceManager) DefaultServiceNames() ([]string, error) {
 
 	var names []string
 	for name, service := range m.plan.Services {
-		if service.Default == plan.StartAction {
+		if service.Startup == plan.StartupEnabled {
 			names = append(names, name)
 		}
 	}

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -53,7 +53,7 @@ services:
     test1:
         override: replace
         command: /bin/sh -c "echo test1 >> %s; sleep 300"
-        default: start
+        startup: enabled
         requires:
             - test2
         before:
@@ -243,7 +243,7 @@ func (s *S) TestPlan(c *C) {
 	expected := fmt.Sprintf(`
 services:
     test1:
-        default: start
+        startup: enabled
         override: replace
         command: /bin/sh -c "echo test1 >> %s; sleep 300"
         before:

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -44,7 +44,7 @@ type Service struct {
 	Name        string           `yaml:"-"`
 	Summary     string           `yaml:"summary,omitempty"`
 	Description string           `yaml:"description,omitempty"`
-	Default     ServiceAction    `yaml:"default,omitempty"`
+	Startup     ServiceStartup   `yaml:"startup,omitempty"`
 	Override    ServiceOverride  `yaml:"override,omitempty"`
 	Command     string           `yaml:"command,omitempty"`
 	After       []string         `yaml:"after,omitempty"`
@@ -53,12 +53,12 @@ type Service struct {
 	Environment []StringVariable `yaml:"environment,omitempty"`
 }
 
-type ServiceAction string
+type ServiceStartup string
 
 const (
-	UnknownAction ServiceAction = ""
-	StartAction   ServiceAction = "start"
-	StopAction    ServiceAction = "stop"
+	StartupUnknown  ServiceStartup = ""
+	StartupEnabled  ServiceStartup = "enabled"
+	StartupDisabled ServiceStartup = "disabled"
 )
 
 type ServiceOverride string
@@ -124,8 +124,8 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 					if service.Description != "" {
 						old.Description = service.Description
 					}
-					if service.Default != UnknownAction {
-						old.Default = service.Default
+					if service.Startup != StartupUnknown {
+						old.Startup = service.Startup
 					}
 					if service.Command != "" {
 						old.Command = service.Command

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -81,7 +81,7 @@ var planTests = []planTest{{
 				override: replace
 				summary: Service summary
 				command: cmd arg1 "arg2 arg3"
-				default: start
+				startup: enabled
 				after:
 					- srv2
 				before:
@@ -95,7 +95,7 @@ var planTests = []planTest{{
 					- var2: val2
 			srv2:
 				override: replace
-				default: start
+				startup: enabled
 				command: cmd
 				before:
 					- srv3
@@ -116,13 +116,13 @@ var planTests = []planTest{{
 					- srv5
 			srv2:
 				override: replace
-				default: stop
+				startup: disabled
 				command: cmd
 				summary: Replaced service
 			srv4:
 				override: replace
 				command: cmd
-				default: start
+				startup: enabled
 			srv5:
 				override: replace
 				command: cmd
@@ -138,7 +138,7 @@ var planTests = []planTest{{
 				Summary:  "Service summary",
 				Override: "replace",
 				Command:  `cmd arg1 "arg2 arg3"`,
-				Default:  plan.StartAction,
+				Startup:  plan.StartupEnabled,
 				Before:   []string{"srv3"},
 				After:    []string{"srv2"},
 				Requires: []string{"srv2", "srv3"},
@@ -152,14 +152,14 @@ var planTests = []planTest{{
 				Name:     "srv2",
 				Override: "replace",
 				Command:  "cmd",
-				Default:  plan.StartAction,
+				Startup:  plan.StartupEnabled,
 				Before:   []string{"srv3"},
 			},
 			"srv3": {
 				Name:     "srv3",
 				Override: "replace",
 				Command:  "cmd",
-				Default:  plan.UnknownAction,
+				Startup:  plan.StartupUnknown,
 			},
 		},
 	}, {
@@ -182,13 +182,13 @@ var planTests = []planTest{{
 				Summary:  "Replaced service",
 				Override: "replace",
 				Command:  "cmd",
-				Default:  plan.StopAction,
+				Startup:  plan.StartupDisabled,
 			},
 			"srv4": {
 				Name:     "srv4",
 				Override: "replace",
 				Command:  "cmd",
-				Default:  plan.StartAction,
+				Startup:  plan.StartupEnabled,
 			},
 			"srv5": {
 				Name:     "srv5",
@@ -206,7 +206,7 @@ var planTests = []planTest{{
 				Summary:  "Service summary",
 				Override: "replace",
 				Command:  `cmd arg1 "arg2 arg3"`,
-				Default:  "start",
+				Startup:  plan.StartupEnabled,
 				After:    []string{"srv2", "srv4"},
 				Before:   []string{"srv3", "srv5"},
 				Requires: []string{"srv2", "srv3"},
@@ -222,7 +222,7 @@ var planTests = []planTest{{
 				Summary:  "Replaced service",
 				Override: "replace",
 				Command:  "cmd",
-				Default:  "stop",
+				Startup:  plan.StartupDisabled,
 			},
 			"srv3": {
 				Name:     "srv3",
@@ -233,7 +233,7 @@ var planTests = []planTest{{
 				Name:     "srv4",
 				Override: "replace",
 				Command:  "cmd",
-				Default:  "start",
+				Startup:  plan.StartupEnabled,
 			},
 			"srv5": {
 				Name:     "srv5",
@@ -487,7 +487,7 @@ func (s *S) TestMarshalLayer(c *C) {
 		services:
 			srv1:
 				summary: Service summary
-				default: start
+				startup: enabled
 				override: replace
 				command: cmd arg1 "arg2 arg3"
 				after:


### PR DESCRIPTION
I missed this in the previous PR when adding "pebble services": https://github.com/canonical/pebble/pull/14

This is a breaking change, but given the rc/early status of this, we are okay with that. (There are only a few internal charms that use Pebble right now.)