### PR TITLE
Update layer config's "environment" to ordinary mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ services:
             - srv2
             - srv3
         environment:
-            - VAR1: val1
-            - VAR2: val2
-            - VAR3: val3
+            VAR1: val1
+            VAR2: val2
+            VAR3: val3
 
     srv2:
         override: replace
@@ -66,8 +66,6 @@ services:
 Some details worth highlighting:
 
   - The `startup` option can be `enabled` or `disabled`.
-  - Environment variables are defined in an ordered list in case there are any
-dependencies.
   - There is the `override` field (for now required) which defines whether this
     entry _overrides_ the previous service of the same name (if any - missing is
     okay), or merges with it.
@@ -83,7 +81,7 @@ services:
     srv1:
         override: merge
         environment:
-            - VAR3: val3
+            VAR3: val3
         after:
             - srv4
         before:

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -86,8 +86,8 @@ func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 
 	// Pass service description's environment variables to child process
 	cmd.Env = os.Environ()
-	for _, v := range service.Environment {
-		cmd.Env = append(cmd.Env, v.Name+"="+v.Value)
+	for k, v := range service.Environment {
+		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 
 	buffer := strutil.NewLimitedBuffer(160, 10*1024)

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -512,8 +512,8 @@ services:
         override: replace
         command: /bin/sh -c "env | grep PEBBLE_ENV_TEST | sort > %s; sleep 300"
         environment:
-            - PEBBLE_ENV_TEST_1: foo
-            - PEBBLE_ENV_TEST_2: bar bazz
+            PEBBLE_ENV_TEST_1: foo
+            PEBBLE_ENV_TEST_2: bar bazz
 `
 
 func (s *S) TestEnvironment(c *C) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -90,9 +90,9 @@ var planTests = []planTest{{
 					- srv2
 					- srv3
 				environment:
-					- var1: val1
-					- var0: val0
-					- var2: val2
+					var1: val1
+					var0: val0
+					var2: val2
 			srv2:
 				override: replace
 				startup: enabled
@@ -109,7 +109,7 @@ var planTests = []planTest{{
 			srv1:
 				override: merge
 				environment:
-					- var3: val3
+					var3: val3
 				after:
 					- srv4
 				before:
@@ -142,10 +142,10 @@ var planTests = []planTest{{
 				Before:   []string{"srv3"},
 				After:    []string{"srv2"},
 				Requires: []string{"srv2", "srv3"},
-				Environment: []plan.StringVariable{
-					{Name: "var1", Value: "val1"},
-					{Name: "var0", Value: "val0"},
-					{Name: "var2", Value: "val2"},
+				Environment: map[string]string{
+					"var1": "val1",
+					"var0": "val0",
+					"var2": "val2",
 				},
 			},
 			"srv2": {
@@ -173,8 +173,8 @@ var planTests = []planTest{{
 				Override: "merge",
 				Before:   []string{"srv5"},
 				After:    []string{"srv4"},
-				Environment: []plan.StringVariable{
-					{Name: "var3", Value: "val3"},
+				Environment: map[string]string{
+					"var3": "val3",
 				},
 			},
 			"srv2": {
@@ -210,11 +210,11 @@ var planTests = []planTest{{
 				After:    []string{"srv2", "srv4"},
 				Before:   []string{"srv3", "srv5"},
 				Requires: []string{"srv2", "srv3"},
-				Environment: []plan.StringVariable{
-					{Name: "var1", Value: "val1"},
-					{Name: "var0", Value: "val0"},
-					{Name: "var2", Value: "val2"},
-					{Name: "var3", Value: "val3"},
+				Environment: map[string]string{
+					"var1": "val1",
+					"var0": "val0",
+					"var2": "val2",
+					"var3": "val3",
 				},
 			},
 			"srv2": {
@@ -282,9 +282,9 @@ var planTests = []planTest{{
 				override: replace
 				command: cmd
 				environment:
-					- a: true
-					- b: 1.1
-					- c:
+					a: true
+					b: 1.1
+					c:
 	`},
 	layers: []*plan.Layer{{
 		Order: 0,
@@ -294,10 +294,10 @@ var planTests = []planTest{{
 				Name:     "srv1",
 				Override: "replace",
 				Command:  "cmd",
-				Environment: []plan.StringVariable{
-					{Name: "a", Value: "true"},
-					{Name: "b", Value: "1.1"},
-					{Name: "c", Value: ""},
+				Environment: map[string]string{
+					"a": "true",
+					"b": "1.1",
+					"c": "",
 				},
 			},
 		},
@@ -498,9 +498,9 @@ func (s *S) TestMarshalLayer(c *C) {
 					- srv2
 					- srv3
 				environment:
-					- var1: val1
-					- var0: val0
-					- var2: val2
+					var0: val0
+					var1: val1
+					var2: val2
 			srv2:
 				override: replace
 				command: srv2cmd


### PR DESCRIPTION
The original intention with the list of 1-item objects was so the
environment variables were ordered in case of dependencies, like
`PATH=$PATH:/foo/var` (not that we support interpolation right now).

However, it made for an awkward config format and awkward API,
especially in the Python Operator Framework. So we're going to a plain
dictionary for the environment, and we'll resolve any dependencies
using an explicit dependency check.

See https://github.com/canonical/pebble/issues/23