### PR TITLE
Files API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
 
     - name: Test and build
       run: |
-        umask 000  # Clear umask so permission tests do what we expect
         go fmt ./...
         git diff --exit-code  # Ensure no formatting changes
         go test -race ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,7 @@ jobs:
 
     - name: Test and build
       run: |
-        umask # TODO: temporary
-        umask 002
+        umask 000  # Clear umask so permission tests do what we expect
         go fmt ./...
         git diff --exit-code  # Ensure no formatting changes
         go test -race ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
 
     - name: Test and build
       run: |
+        umask # TODO: temporary
         go fmt ./...
         git diff --exit-code  # Ensure no formatting changes
         go test -race ./...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Test and build
       run: |
         umask # TODO: temporary
+        umask 002
         go fmt ./...
         git diff --exit-code  # Ensure no formatting changes
         go test -race ./...

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Here are some of the things coming soon:
   - [x] Dynamic layer support over the API
   - [x] Configuration retrieval commands to investigate current settings
   - [x] Status command that displays active services and their current status
-  - [ ] General system modification commands (writing configuration files, etc)
+  - [x] General system modification commands (writing configuration files, etc)
   - [ ] Improve signal handling, e.g., sending SIGHUP to a service
   - [ ] Terminate all services before exiting run command
   - [ ] More tests for existing CLI commands

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -59,6 +59,11 @@ var api = []*Command{{
 	Path:   "/v1/layers",
 	UserOK: true,
 	POST:   v1PostLayers,
+}, {
+	Path:   "/v1/files",
+	UserOK: true,
+	GET:    v1GetFiles,
+	POST:   v1PostFiles,
 }}
 
 var (

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -140,7 +140,7 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if file.Error != nil {
 			continue
 		}
-		fw, err := mw.CreateFormFile("p:"+file.Path, path.Base(file.Path))
+		fw, err := mw.CreateFormFile("path:"+file.Path, path.Base(file.Path))
 		if err != nil {
 			http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+)
+
+func v1GetFiles(c *Command, r *http.Request, _ *userState) Response {
+	query := r.URL.Query()
+	action := query.Get("action")
+	switch action {
+	case "read":
+		paths := query["path"]
+		if len(paths) == 0 {
+			return statusBadRequest("must specify one or more paths")
+		}
+		return getFiles(paths)
+	case "list":
+		return listFiles(query.Get("pattern"))
+	default:
+		return statusBadRequest("invalid action %q", action)
+	}
+}
+
+func getFiles(paths []string) Response {
+	return nil
+}
+
+func errorResponse(kind errorKind, message string) Response {
+	status := 400
+	switch kind {
+	case errorKindNotFound:
+		status = 404
+	case errorKindPermissionDenied:
+		status = 403
+	}
+	return &resp{
+		Type: ResponseTypeError,
+		Result: &errorResult{
+			Message: message,
+			Kind:    kind,
+		},
+		Status: status,
+	}
+}
+
+// TODO: should we include "." and ".."?
+func listFiles(pattern string) Response {
+	st, err := os.Stat(pattern)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return errorResponse(errorKindPermissionDenied, err.Error())
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return statusBadRequest("fetching path information: %v", err)
+		}
+	} else if st.IsDir() {
+		pattern = path.Join(pattern, "*")
+	}
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return statusBadRequest("listing files: %v", err)
+	}
+	type listFilesResult struct {
+		Path         string `json:"path"`
+		Name         string `json:"name"`
+		Type         string `json:"type"`
+		Size         *int64 `json:"size,omitempty"`
+		Permissions  string `json:"permissions"`
+		LastModified string `json:"last-modified"`
+	}
+	var result []listFilesResult
+	for _, match := range matches {
+		st, err := os.Lstat(match)
+		if err != nil {
+			return statusBadRequest("fetching file information: %v", err)
+		}
+		fileType := "file"
+		var psize *int64
+		if st.IsDir() {
+			fileType = "directory"
+			psize = nil
+		} else {
+			size := st.Size()
+			psize = &size
+		}
+		r := listFilesResult{
+			Path:         match,
+			Name:         path.Base(match),
+			Type:         fileType,
+			Size:         psize,
+			Permissions:  fmt.Sprintf("%03o", st.Mode().Perm()),
+			LastModified: st.ModTime().Format(time.RFC3339), // TODO: format?
+		}
+		result = append(result, r)
+	}
+	return SyncResponse(result)
+}
+
+func v1PostFiles(c *Command, r *http.Request, _ *userState) Response {
+	return statusBadRequest("TODO: not yet implemented")
+}

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -106,7 +106,9 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	mh.Set("Content-Disposition", `form-data; name="response"`)
 	part, err := mw.CreatePart(mh)
 	if err != nil {
-		http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+		// Can't write metadata -- writing the error message on a new line is
+		// about the best we can do.
+		fmt.Fprint(w, "\n", err)
 		return
 	}
 	encoder := json.NewEncoder(part)
@@ -118,14 +120,14 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	err = encoder.Encode(metadata)
 	if err != nil {
-		http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+		fmt.Fprint(w, "\n", err)
 		return
 	}
 
 	// Write the multipart trailer (last boundary marker).
 	err = mw.Close()
 	if err != nil {
-		http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+		fmt.Fprint(w, "\n", err)
 		return
 	}
 }

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -550,19 +550,26 @@ func makeDir(dir makeDirsItem) error {
 	return nil
 }
 
+// Because it's hard to test os.Chown with running the tests as root.
+var (
+	chown       = os.Chown
+	lookupUser  = user.Lookup
+	lookupGroup = user.LookupGroup
+)
+
 func updateUserAndGroup(path string, uid int, username string, gid int, group string) error {
 	if uid == 0 && username == "" && gid == 0 && group == "" {
 		return nil
 	}
 	if uid == 0 && username != "" {
-		u, err := user.Lookup(username)
+		u, err := lookupUser(username)
 		if err != nil {
 			return err
 		}
 		uid, _ = strconv.Atoi(u.Uid)
 	}
 	if gid == 0 && group != "" {
-		g, err := user.LookupGroup(group)
+		g, err := lookupGroup(group)
 		if err != nil {
 			return err
 		}
@@ -571,7 +578,7 @@ func updateUserAndGroup(path string, uid int, username string, gid int, group st
 	if uid == 0 || gid == 0 {
 		return fmt.Errorf("must set both user and group together")
 	}
-	err := os.Chown(path, uid, gid)
+	err := chown(path, uid, gid)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -73,7 +73,7 @@ type readFilesResponse struct {
 
 func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Header.Get("Accept") != "multipart/form-data" {
-		errResp := statusBadRequest(`must accept \"multipart/form-data\"`)
+		errResp := statusBadRequest(`must accept multipart/form-data`)
 		errResp.ServeHTTP(w, req)
 		return
 	}

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -19,12 +19,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -55,12 +59,13 @@ func v1GetFiles(c *Command, r *http.Request, _ *userState) Response {
 	}
 }
 
-type readFileResult struct {
+type fileResult struct {
 	Path  string       `json:"path"`
 	Error *errorResult `json:"error,omitempty"`
 	f     *os.File
 }
 
+// Custom Response implementation to serve the multipart.
 type readFilesResponse struct {
 	paths []string
 }
@@ -69,7 +74,7 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	// We open all the files first so we can detect not-found and
 	// permission-denied errors for each file, as we send the metadata and
 	// errors first.
-	result := make([]readFileResult, len(r.paths))
+	result := make([]fileResult, len(r.paths))
 	var firstErr error
 	for i, path := range r.paths {
 		f, err := os.Open(path)
@@ -80,7 +85,7 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 		} else {
 			defer f.Close()
 		}
-		result[i] = readFileResult{
+		result[i] = fileResult{
 			Path:  path,
 			Error: fileErrorToResult(err),
 			f:     f,
@@ -131,7 +136,7 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
 			return
 		}
-		_, err = io.Copy(fw, file.f)
+		_, err = io.Copy(fw, file.f) // TODO: limit amount of data?
 		if err != nil {
 			http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
 			return
@@ -154,24 +159,21 @@ func fileErrorToStatus(err error) int {
 }
 
 func fileErrorToResult(err error) *errorResult {
+	if err == nil {
+		return nil
+	}
+	var kind errorKind
 	switch {
 	case errors.Is(err, os.ErrPermission):
-		return &errorResult{
-			Kind:    errorKindPermissionDenied,
-			Message: err.Error(),
-		}
+		kind = errorKindPermissionDenied
 	case errors.Is(err, os.ErrNotExist):
-		return &errorResult{
-			Kind:    errorKindNotFound,
-			Message: err.Error(),
-		}
-	case err != nil:
-		return &errorResult{
-			Kind:    errorKindGenericFileError,
-			Message: err.Error(),
-		}
+		kind = errorKindNotFound
 	default:
-		return nil
+		kind = errorKindGenericFileError
+	}
+	return &errorResult{
+		Kind:    kind,
+		Message: err.Error(),
 	}
 }
 
@@ -193,7 +195,7 @@ func errorResponse(kind errorKind, message string) Response {
 	}
 }
 
-type fileResult struct {
+type fileInfoResult struct {
 	Path         string   `json:"path"`
 	Name         string   `json:"name"`
 	Type         fileType `json:"type"`
@@ -233,14 +235,14 @@ func fileModeToType(mode os.FileMode) fileType {
 	}
 }
 
-func fileInfoToResult(fullPath string, info os.FileInfo) fileResult {
+func fileInfoToResult(fullPath string, info os.FileInfo) fileInfoResult {
 	mode := info.Mode()
 	var psize *int64
 	if mode.IsRegular() {
 		size := info.Size()
 		psize = &size
 	}
-	result := fileResult{
+	result := fileInfoResult{
 		Path:         fullPath,
 		Name:         path.Base(fullPath),
 		Type:         fileModeToType(mode),
@@ -274,7 +276,7 @@ func listFiles(pattern string, directoryItself bool) Response {
 	}
 
 	// Loop through files, get stat info, and convert to result.
-	result := make([]fileResult, len(matches))
+	result := make([]fileInfoResult, len(matches))
 	for i, match := range matches {
 		info, err := os.Lstat(match)
 		if err != nil {
@@ -286,5 +288,244 @@ func listFiles(pattern string, directoryItself bool) Response {
 }
 
 func v1PostFiles(c *Command, r *http.Request, _ *userState) Response {
-	return statusBadRequest("TODO: not yet implemented")
+	contentType := r.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return statusBadRequest("invalid Content-Type: %q", contentType)
+	}
+
+	switch mediaType {
+	case "multipart/form-data":
+		return writeFiles(r.Body, params["boundary"])
+	case "application/json":
+		var payload struct {
+			Action string        `json:"action"`
+			Dirs   []makeDirsDir `json:"dirs"`
+			Paths  []removePath  `json:"paths"`
+		}
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&payload); err != nil {
+			return statusBadRequest("cannot decode request body: %v", err)
+		}
+		switch payload.Action {
+		case "make-dirs":
+			return makeDirs(payload.Dirs)
+		case "remove":
+			return removePaths(payload.Paths)
+		case "write":
+			return statusBadRequest(`must use multipart with "write" action`)
+		default:
+			return statusBadRequest("invalid action: %q", payload.Action)
+		}
+	default:
+		return statusBadRequest("invalid media type: %q", mediaType)
+	}
+}
+
+type writeFilesFile struct {
+	Path        string `json:"path"`
+	MakeDirs    bool   `json:"make-dirs"`
+	Permissions string `json:"permissions"`
+	UserID      int    `json:"user-id"`
+	User        string `json:"user"`
+	GroupID     int    `json:"group-id"`
+	Group       string `json:"group"`
+}
+
+func writeFiles(body io.Reader, boundary string) Response {
+	// Read metadata part (field name "request").
+	mr := multipart.NewReader(body, boundary)
+	part, err := mr.NextPart()
+	if err != nil {
+		return statusBadRequest("cannot read request metadata: %v", err)
+	}
+	if part.FormName() != "request" {
+		return statusBadRequest(`first part's field name must be "request", not %q`, part.FormName())
+	}
+
+	// Decode metadata about files to write.
+	var payload struct {
+		Action string           `json:"action"`
+		Files  []writeFilesFile `json:"files"`
+	}
+	decoder := json.NewDecoder(part)
+	if err := decoder.Decode(&payload); err != nil {
+		return statusBadRequest("cannot decode request metadata: %v", err)
+	}
+	if payload.Action != "write" {
+		return statusBadRequest(`multipart action must be "write", not %q`, payload.Action)
+	}
+	if len(payload.Files) == 0 {
+		return statusBadRequest("must specify one or more files")
+	}
+	infos := make(map[string]writeFilesFile)
+	for _, file := range payload.Files {
+		infos[file.Path] = file
+		_, err = parsePermissions(file.Permissions, 0o644)
+		if err != nil {
+			return statusBadRequest(err.Error())
+		}
+	}
+
+	errors := make(map[string]error)
+	for i := 0; ; i++ {
+		part, err = mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return statusBadRequest("cannot read file part %d: %v", i, err)
+		}
+		if !strings.HasPrefix(part.FormName(), "file:") {
+			return statusBadRequest(`field name must be in format "file:path", not %q`, part.FormName())
+		}
+		path := part.FormName()[len("file:"):]
+		info, ok := infos[path]
+		if !ok {
+			return statusBadRequest("no metadata for path %q", path)
+		}
+
+		if info.MakeDirs {
+			// TODO: make dirs - os.MkdirAll()
+		}
+
+		// Create file and write contents.
+		perm, _ := parsePermissions(info.Permissions, 0o644) // already validated above
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
+		if err != nil {
+			// TODO: handle (dir) not-found and permissions errors
+			errors[path] = fmt.Errorf("error creating file: %w", err)
+			continue
+		}
+		_, err = io.Copy(f, part) // TODO: limit / ensure it's not too big
+		if err != nil {
+			f.Close()
+			errors[path] = fmt.Errorf("error writing file: %w", err)
+			continue
+		}
+		err = f.Close()
+		if err != nil {
+			errors[path] = fmt.Errorf("error closing file: %w", err)
+			continue
+		}
+
+		if info.GroupID != 0 || info.Group != "" || info.UserID != 0 || info.User != "" {
+			errors[path] = fmt.Errorf("group and user handling not yet implemented") // TODO
+			continue
+		}
+
+		// Success!
+		errors[path] = nil
+	}
+
+	// Build list of results with any errors.
+	result := make([]fileResult, len(payload.Files))
+	respType := ResponseTypeSync
+	status := http.StatusOK
+	for i, file := range payload.Files {
+		err, ok := errors[file.Path]
+		if !ok {
+			// Ensure we wrote all the files in the metadata.
+			err = fmt.Errorf("no file content for path %q", file.Path)
+		}
+		if err != nil {
+			respType = ResponseTypeError
+			status = http.StatusBadRequest
+		}
+		result[i] = fileResult{
+			Path:  file.Path,
+			Error: fileErrorToResult(err),
+		}
+	}
+	return &resp{
+		Type:   respType,
+		Status: status,
+		Result: result,
+	}
+}
+
+func parsePermissions(permissions string, defaultMode os.FileMode) (os.FileMode, error) {
+	if permissions == "" {
+		return defaultMode, nil
+	}
+	perm, err := strconv.ParseUint(permissions, 8, 32)
+	if err != nil || len(permissions) != 3 {
+		return 0, fmt.Errorf("permissions must be a 3-digit octal string, not %q", permissions)
+	}
+	return os.FileMode(perm), nil
+}
+
+type makeDirsDir struct {
+	Path        string `json:"path"`
+	MakeParents bool   `json:"make-parents"`
+	Permissions string `json:"permissions"`
+	UserID      int    `json:"user-id"`
+	User        string `json:"user"`
+	GroupID     int    `json:"group-id"`
+	Group       string `json:"group"`
+}
+
+func makeDirs(dirs []makeDirsDir) Response {
+	result := make([]fileResult, len(dirs))
+	respType := ResponseTypeSync
+	status := http.StatusOK
+	for i, dir := range dirs {
+		perm, err := parsePermissions(dir.Permissions, 0o775)
+		// TODO: clean this up -- helper function to do one directory
+		if err == nil {
+			if dir.MakeParents {
+				err = os.MkdirAll(dir.Path, perm)
+			} else {
+				err = os.Mkdir(dir.Path, perm)
+			}
+		}
+		if err != nil {
+			respType = ResponseTypeError
+			status = http.StatusBadRequest
+		}
+		result[i] = fileResult{
+			Path:  dir.Path,
+			Error: fileErrorToResult(err),
+		}
+	}
+	return &resp{
+		Type:   respType,
+		Status: status,
+		Result: result,
+	}
+}
+
+type removePath struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive"`
+}
+
+func removePaths(paths []removePath) Response {
+	result := make([]fileResult, len(paths))
+	respType := ResponseTypeSync
+	status := http.StatusOK
+	log.Printf("removePaths: %#v", paths)
+	for i, p := range paths {
+		var err error
+		if p.Recursive {
+			log.Printf("removePath recursive: %q", p.Path)
+			err = os.RemoveAll(p.Path)
+		} else {
+			log.Printf("removePath non-recursive: %q", p.Path)
+			err = os.Remove(p.Path)
+		}
+		if err != nil {
+			respType = ResponseTypeError
+			status = http.StatusBadRequest
+		}
+		result[i] = fileResult{
+			Path:  p.Path,
+			Error: fileErrorToResult(err),
+		}
+	}
+	return &resp{
+		Type:   respType,
+		Status: status,
+		Result: result,
+	}
 }

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -29,7 +29,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/canonical/pebble/internal/osutil"
@@ -149,7 +148,7 @@ func readFile(p string, mw *multipart.Writer) error {
 	}
 	defer f.Close()
 
-	fw, err := mw.CreateFormFile("path:"+p, path.Base(p))
+	fw, err := mw.CreateFormFile("files", p)
 	if err != nil {
 		return err
 	}
@@ -407,10 +406,10 @@ func writeFiles(body io.Reader, boundary string) Response {
 		if err != nil {
 			return statusBadRequest("cannot read file part %d: %v", i, err)
 		}
-		p := strings.TrimPrefix(part.FormName(), "path:")
-		if p == part.FormName() {
-			return statusBadRequest(`field name must be in format "path:/PATH", got %q`, part.FormName())
+		if part.FormName() != "files" {
+			return statusBadRequest(`field name must be "files", got %q`, part.FormName())
 		}
+		p := part.FileName()
 		info, ok := infos[p]
 		if !ok {
 			return statusBadRequest("no metadata for path %q", p)

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -15,9 +15,13 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,16 +37,142 @@ func v1GetFiles(c *Command, r *http.Request, _ *userState) Response {
 		if len(paths) == 0 {
 			return statusBadRequest("must specify one or more paths")
 		}
-		return getFiles(paths)
+		for _, p := range paths {
+			if !path.IsAbs(p) {
+				return statusBadRequest("paths must be absolute (%q is not)", p)
+			}
+		}
+		return readFilesResponse{paths: paths}
 	case "list":
-		return listFiles(query.Get("pattern"))
+		pattern := query.Get("pattern")
+		if !path.IsAbs(pattern) {
+			return statusBadRequest("pattern must be absolute (%q is not)", pattern)
+		}
+		directoryItself := query.Get("directory") == "true"
+		return listFiles(pattern, directoryItself)
 	default:
 		return statusBadRequest("invalid action %q", action)
 	}
 }
 
-func getFiles(paths []string) Response {
-	return nil
+type readFileResult struct {
+	Path  string       `json:"path"`
+	Error *errorResult `json:"error,omitempty"`
+	f     *os.File
+}
+
+type readFilesResponse struct {
+	paths []string
+}
+
+func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	// We open all the files first so we can detect not-found and
+	// permission-denied errors for each file, as we send the metadata and
+	// errors first.
+	result := make([]readFileResult, len(r.paths))
+	var firstErr error
+	for i, path := range r.paths {
+		f, err := os.Open(path)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+		} else {
+			defer f.Close()
+		}
+		result[i] = readFileResult{
+			Path:  path,
+			Error: fileErrorToResult(err),
+			f:     f,
+		}
+	}
+
+	// Write HTTP status and headers.
+	mw := multipart.NewWriter(w)
+	header := w.Header()
+	header.Set("Content-Type", mw.FormDataContentType())
+	status := fileErrorToStatus(firstErr)
+	w.WriteHeader(status)
+
+	// Write first part: response metadata in JSON format.
+	mh := textproto.MIMEHeader{}
+	mh.Set("Content-Type", "application/json")
+	mh.Set("Content-Disposition", `form-data; name="response"`)
+	part, err := mw.CreatePart(mh)
+	if err != nil {
+		http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	encoder := json.NewEncoder(part)
+	encoder.SetIndent("", "    ") // TODO(benhoyt) - remove after testing
+	respType := ResponseTypeSync
+	if firstErr != nil {
+		respType = ResponseTypeError
+	}
+	resp := respJSON{
+		Type:       respType,
+		Status:     status,
+		StatusText: http.StatusText(status),
+		Result:     result,
+	}
+	err = encoder.Encode(resp)
+	if err != nil {
+		http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Write file content for each path.
+	for _, file := range result {
+		if file.Error != nil {
+			continue
+		}
+		fw, err := mw.CreateFormFile("path:"+file.Path, path.Base(file.Path))
+		if err != nil {
+			http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = io.Copy(fw, file.f)
+		if err != nil {
+			http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Write the multipart trailer (last boundary marker).
+	err = mw.Close()
+	if err != nil {
+		http.Error(w, "\n"+err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func fileErrorToStatus(err error) int {
+	if err != nil {
+		return http.StatusBadRequest
+	}
+	return http.StatusOK
+}
+
+func fileErrorToResult(err error) *errorResult {
+	switch {
+	case errors.Is(err, os.ErrPermission):
+		return &errorResult{
+			Kind:    errorKindPermissionDenied,
+			Message: err.Error(),
+		}
+	case errors.Is(err, os.ErrNotExist):
+		return &errorResult{
+			Kind:    errorKindNotFound,
+			Message: err.Error(),
+		}
+	case err != nil:
+		return &errorResult{
+			Kind:    errorKindGenericFileError,
+			Message: err.Error(),
+		}
+	default:
+		return nil
+	}
 }
 
 func errorResponse(kind errorKind, message string) Response {
@@ -63,55 +193,94 @@ func errorResponse(kind errorKind, message string) Response {
 	}
 }
 
-// TODO: should we include "." and ".."?
-func listFiles(pattern string) Response {
+type fileResult struct {
+	Path         string   `json:"path"`
+	Name         string   `json:"name"`
+	Type         fileType `json:"type"`
+	Size         *int64   `json:"size,omitempty"`
+	Permissions  string   `json:"permissions"`
+	LastModified string   `json:"last-modified"`
+}
+
+type fileType string
+
+const (
+	fileTypeFile      fileType = "file"
+	fileTypeDirectory fileType = "directory"
+	fileTypeSymlink   fileType = "symlink"
+	fileTypeSocket    fileType = "socket"
+	fileTypeNamedPipe fileType = "named-pipe"
+	fileTypeDevice    fileType = "device"
+	fileTypeUnknown   fileType = "unknown"
+)
+
+func fileModeToType(mode os.FileMode) fileType {
+	switch {
+	case mode&os.ModeType == 0:
+		return fileTypeFile
+	case mode&os.ModeDir != 0:
+		return fileTypeDirectory
+	case mode&os.ModeSymlink != 0:
+		return fileTypeSymlink
+	case mode&os.ModeSocket != 0:
+		return fileTypeSocket
+	case mode&os.ModeNamedPipe != 0:
+		return fileTypeNamedPipe
+	case mode&os.ModeDevice != 0:
+		return fileTypeDevice
+	default:
+		return fileTypeUnknown
+	}
+}
+
+func fileInfoToResult(fullPath string, info os.FileInfo) fileResult {
+	mode := info.Mode()
+	var psize *int64
+	if mode.IsRegular() {
+		size := info.Size()
+		psize = &size
+	}
+	result := fileResult{
+		Path:         fullPath,
+		Name:         path.Base(fullPath),
+		Type:         fileModeToType(mode),
+		Size:         psize,
+		Permissions:  fmt.Sprintf("%03o", mode.Perm()),
+		LastModified: info.ModTime().Format(time.RFC3339),
+	}
+	return result
+}
+
+func listFiles(pattern string, directoryItself bool) Response {
 	st, err := os.Stat(pattern)
 	if err != nil {
 		if errors.Is(err, os.ErrPermission) {
+			// Pattern path exists but we don't have access.
 			return errorResponse(errorKindPermissionDenied, err.Error())
 		}
 		if !errors.Is(err, os.ErrNotExist) {
-			return statusBadRequest("fetching path information: %v", err)
+			// Some other error (NotExist is okay).
+			return statusBadRequest("cannot fetch path information: %v", err)
 		}
-	} else if st.IsDir() {
+	} else if st.IsDir() && !directoryItself {
+		// If pattern is a directory, use "dir/*" as the glob.
 		pattern = path.Join(pattern, "*")
 	}
+
+	// List files that match this glob pattern.
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		return statusBadRequest("listing files: %v", err)
+		return statusBadRequest("cannot list files: %v", err)
 	}
-	type listFilesResult struct {
-		Path         string `json:"path"`
-		Name         string `json:"name"`
-		Type         string `json:"type"`
-		Size         *int64 `json:"size,omitempty"`
-		Permissions  string `json:"permissions"`
-		LastModified string `json:"last-modified"`
-	}
-	var result []listFilesResult
-	for _, match := range matches {
-		st, err := os.Lstat(match)
+
+	// Loop through files, get stat info, and convert to result.
+	result := make([]fileResult, len(matches))
+	for i, match := range matches {
+		info, err := os.Lstat(match)
 		if err != nil {
-			return statusBadRequest("fetching file information: %v", err)
+			return statusBadRequest("cannot fetch file information: %v", err)
 		}
-		fileType := "file"
-		var psize *int64
-		if st.IsDir() {
-			fileType = "directory"
-			psize = nil
-		} else {
-			size := st.Size()
-			psize = &size
-		}
-		r := listFilesResult{
-			Path:         match,
-			Name:         path.Base(match),
-			Type:         fileType,
-			Size:         psize,
-			Permissions:  fmt.Sprintf("%03o", st.Mode().Perm()),
-			LastModified: st.ModTime().Format(time.RFC3339), // TODO: format?
-		}
-		result = append(result, r)
+		result[i] = fileInfoToResult(match, info)
 	}
 	return SyncResponse(result)
 }

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -69,6 +69,8 @@ type readFilesResponse struct {
 	paths []string
 }
 
+// Reading files
+
 func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if req.Header.Get("Accept") != "multipart/form-data" {
 		errResp := statusBadRequest(`must accept multipart/form-data`)
@@ -183,6 +185,8 @@ func fileErrorToResult(err error) *errorResult {
 		Message: err.Error(),
 	}
 }
+
+// Listing files
 
 func listErrorResponse(err error) Response {
 	status := http.StatusBadRequest
@@ -358,6 +362,8 @@ func v1PostFiles(_ *Command, req *http.Request, _ *userState) Response {
 	}
 }
 
+// Writing files
+
 type writeFilesItem struct {
 	Path        string `json:"path"`
 	MakeDirs    bool   `json:"make-dirs"`
@@ -501,6 +507,8 @@ func parsePermissions(permissions string, defaultMode os.FileMode) (os.FileMode,
 	return os.FileMode(perm), nil
 }
 
+// Creating directories
+
 type makeDirsItem struct {
 	Path        string `json:"path"`
 	MakeParents bool   `json:"make-parents"`
@@ -584,6 +592,8 @@ func updateUserAndGroup(path string, uid int, username string, gid int, group st
 	}
 	return nil
 }
+
+// Removing paths
 
 type removePathsItem struct {
 	Path      string `json:"path"`

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -135,8 +135,12 @@ func readFile(path string, mw *multipart.Writer) error {
 	if !pathpkg.IsAbs(path) {
 		return nonAbsolutePathError(path)
 	}
-	if osutil.IsDir(path) {
-		return fmt.Errorf("cannot read a directory: %q", path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("can only read a regular file: %q", path)
 	}
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -55,11 +55,11 @@ func v1GetFiles(_ *Command, req *http.Request, _ *userState) Response {
 			return statusBadRequest("must specify path")
 		}
 		pattern := query.Get("pattern")
-		directory := query.Get("directory")
-		if directory != "true" && directory != "false" && directory != "" {
-			return statusBadRequest(`directory parameter must be "true" or "false"`)
+		itself := query.Get("itself")
+		if itself != "true" && itself != "false" && itself != "" {
+			return statusBadRequest(`itself parameter must be "true" or "false"`)
 		}
-		return listFilesResponse(path, pattern, directory == "true")
+		return listFilesResponse(path, pattern, itself == "true")
 	default:
 		return statusBadRequest("invalid action %q", action)
 	}
@@ -259,18 +259,18 @@ func fileInfoToResult(fullPath string, info os.FileInfo) fileInfoResult {
 	return result
 }
 
-func listFilesResponse(path, pattern string, directoryItself bool) Response {
+func listFilesResponse(path, pattern string, itself bool) Response {
 	if !pathpkg.IsAbs(path) {
 		return statusBadRequest("path must be absolute, got %q", path)
 	}
-	result, err := listFiles(path, pattern, directoryItself)
+	result, err := listFiles(path, pattern, itself)
 	if err != nil {
 		return listErrorResponse(err)
 	}
 	return SyncResponse(result)
 }
 
-func listFiles(path, pattern string, directoryItself bool) ([]fileInfoResult, error) {
+func listFiles(path, pattern string, itself bool) ([]fileInfoResult, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func listFiles(path, pattern string, directoryItself bool) ([]fileInfoResult, er
 
 	var infos []os.FileInfo
 	var dir string
-	if !info.IsDir() || directoryItself {
+	if !info.IsDir() || itself {
 		// Info about a single file (or directory entry itself).
 		infos = []os.FileInfo{info}
 		dir = pathpkg.Dir(path)

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -34,7 +34,7 @@ import (
 	"github.com/canonical/pebble/internal/osutil/sys"
 )
 
-const minBoundaryLength = 8
+const minBoundaryLength = 32
 
 func v1GetFiles(_ *Command, req *http.Request, _ *userState) Response {
 	query := req.URL.Query()

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -31,6 +31,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/canonical/pebble/internal/osutil"
 )
 
 func v1GetFiles(_ *Command, req *http.Request, _ *userState) Response {
@@ -163,6 +165,11 @@ func nonAbsolutePathError(p string) error {
 func openForRead(p string) (*os.File, error) {
 	if !path.IsAbs(p) {
 		return nil, nonAbsolutePathError(p)
+	}
+	// Pro-actively disallow reading directories (other errors will be caught
+	// during read / io.Copy).
+	if osutil.IsDir(p) {
+		return nil, fmt.Errorf("cannot read a directory: %q", p)
 	}
 	return os.Open(p)
 }

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -87,12 +87,8 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// Read each file's contents to multipart response.
 	result := make([]fileResult, len(r.paths))
-	status := http.StatusOK
 	for i, path := range r.paths {
 		err := readFile(path, mw)
-		if err != nil {
-			status = http.StatusBadRequest
-		}
 		result[i] = fileResult{
 			Path:  path,
 			Error: fileErrorToResult(err),
@@ -113,8 +109,8 @@ func (r readFilesResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	encoder := json.NewEncoder(part)
 	metadata := respJSON{
 		Type:       ResponseTypeSync,
-		Status:     status,
-		StatusText: http.StatusText(status),
+		Status:     http.StatusOK,
+		StatusText: http.StatusText(http.StatusOK),
 		Result:     result,
 	}
 	err = encoder.Encode(metadata)

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -440,7 +440,7 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 
 	// Create parent directory if needed
 	if item.MakeDirs {
-		err := os.MkdirAll(path.Dir(item.Path), 0o775)
+		err := os.MkdirAll(path.Dir(item.Path), 0o755)
 		if err != nil {
 			return fmt.Errorf("error creating directory: %w", err)
 		}
@@ -514,7 +514,7 @@ func makeDir(dir makeDirsItem) error {
 	if !path.IsAbs(dir.Path) {
 		return fmt.Errorf("paths must be absolute (%q is not)", dir.Path)
 	}
-	perm, err := parsePermissions(dir.Permissions, 0o775)
+	perm, err := parsePermissions(dir.Permissions, 0o755)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -37,12 +37,6 @@ var _ = Suite(&filesSuite{})
 
 type filesSuite struct{}
 
-func (s *filesSuite) SetUpTest(c *C) {
-}
-
-func (s *filesSuite) TearDownTest(c *C) {
-}
-
 func (s *filesSuite) TestGetFilesInvalidAction(c *C) {
 	query := url.Values{"action": []string{"foo"}}
 	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -316,7 +316,7 @@ func (s *filesSuite) TestReadErrors(c *C) {
 	checkFileResult(c, r.Result[1], tmpDir+"/foo", "", "")
 	checkFileResult(c, r.Result[2], tmpDir+"/no-access", "permission-denied", ".*: permission denied")
 	checkFileResult(c, r.Result[3], "relative-path", "generic-file-error", "paths must be absolute, got .*")
-	checkFileResult(c, r.Result[4], tmpDir, "generic-file-error", "cannot read a directory: .*")
+	checkFileResult(c, r.Result[4], tmpDir, "generic-file-error", "can only read a regular file: .*")
 
 	c.Check(files, DeepEquals, map[string]string{
 		tmpDir + "/foo": "a",

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -253,7 +253,12 @@ func (s *filesSuite) TestReadFilesErrors(c *C) {
 
 	query := url.Values{
 		"action": []string{"read"},
-		"path":   []string{tmpDir + "/no-exist", tmpDir + "/foo", tmpDir + "/no-access"},
+		"path":   []string{
+			tmpDir + "/no-exist",
+			tmpDir + "/foo",
+			tmpDir + "/no-access",
+			"relative-path",
+		},
 	}
 	headers := http.Header{
 		"Accept": []string{"multipart/form-data"},
@@ -266,7 +271,7 @@ func (s *filesSuite) TestReadFilesErrors(c *C) {
 	c.Check(r.Type, Equals, "error")
 	c.Check(r.StatusCode, Equals, http.StatusBadRequest)
 	c.Check(r.Status, Equals, "Bad Request")
-	c.Check(r.Result, HasLen, 3)
+	c.Check(r.Result, HasLen, 4)
 	c.Check(r.Result[0].Path, Equals, tmpDir+"/no-exist")
 	c.Check(r.Result[0].Error.Kind, Equals, "not-found")
 	c.Check(r.Result[0].Error.Message, Matches, ".*: no such file or directory")
@@ -275,6 +280,9 @@ func (s *filesSuite) TestReadFilesErrors(c *C) {
 	c.Check(r.Result[2].Path, Equals, tmpDir+"/no-access")
 	c.Check(r.Result[2].Error.Kind, Equals, "permission-denied")
 	c.Check(r.Result[2].Error.Message, Matches, ".*: permission denied")
+	c.Check(r.Result[3].Path, Equals, "relative-path")
+	c.Check(r.Result[3].Error.Kind, Equals, "generic-file-error")
+	c.Check(r.Result[3].Error.Message, Matches, "paths must be absolute .*")
 
 	c.Check(files, DeepEquals, map[string]string{
 		"path:" + tmpDir + "/foo": "a",

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -110,7 +110,7 @@ func (s *filesSuite) TestListFilesDir(c *C) {
 		assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "664", 1)
 		assertListResult(c, r.Result, 1, "file", tmpDir, "one.txt", "600", 2)
 		assertListResult(c, r.Result, 2, "directory", tmpDir, "sub", "775", -1)
-		assertListResult(c, r.Result, 3, "file", tmpDir, "two.txt", "775", 3)
+		assertListResult(c, r.Result, 3, "file", tmpDir, "two.txt", "755", 3)
 	}
 }
 
@@ -141,7 +141,7 @@ func (s *filesSuite) TestListFilesGlob(c *C) {
 
 	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
 	assertListResult(c, r.Result, 0, "file", tmpDir, "one.txt", "600", 2)
-	assertListResult(c, r.Result, 1, "file", tmpDir, "two.txt", "775", 3)
+	assertListResult(c, r.Result, 1, "file", tmpDir, "two.txt", "755", 3)
 }
 
 func (s *filesSuite) TestListFilesFile(c *C) {
@@ -194,7 +194,7 @@ func createTestFiles(c *C) string {
 	writeTempFile(c, tmpDir, "foo", "a", 0o664)
 	writeTempFile(c, tmpDir, "one.txt", "be", 0o600)
 	c.Assert(os.Mkdir(filepath.Join(tmpDir, "sub"), 0o775), IsNil)
-	writeTempFile(c, tmpDir, "two.txt", "cee", 0o775)
+	writeTempFile(c, tmpDir, "two.txt", "cee", 0o755)
 	return tmpDir
 }
 

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -571,7 +571,7 @@ func (s *filesSuite) TestRemoveMultiple(c *C) {
 
 func (s *filesSuite) TestWriteNoMetadata(c *C) {
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers, []byte{})
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
@@ -596,15 +596,15 @@ func (s *filesSuite) TestWriteInvalidBoundary(c *C) {
 
 func (s *filesSuite) TestWriteInvalidRequestField(c *C) {
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="foo"
 
 {"foo": "bar"}
---BOUNDARY--
+--01234567890123456789012345678901--
 `))
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
 	assertError(c, body, http.StatusBadRequest, "", `metadata field name must be "request", got "foo"`)
@@ -612,21 +612,21 @@ Content-Disposition: form-data; name="foo"
 
 func (s *filesSuite) TestWriteInvalidFileField(c *C) {
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {"action": "write", "files": [
 	{"path": "/foo/bar"}
 ]}
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="bad"; filename="foo"
 
 Bad file field
---BOUNDARY--
+--01234567890123456789012345678901--
 `))
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
 	assertError(c, body, http.StatusBadRequest, "", `field name must be "files", got "bad"`)
@@ -634,21 +634,21 @@ Bad file field
 
 func (s *filesSuite) TestWriteNoMetadataForPath(c *C) {
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {"action": "write", "files": [
 	{"path": "/foo/bar"}
 ]}
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="/no-metadata"
 
 No metadata
---BOUNDARY--
+--01234567890123456789012345678901--
 `))
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
 	assertError(c, body, http.StatusBadRequest, "", `no metadata for path "/no-metadata"`)
@@ -656,26 +656,26 @@ No metadata
 
 func (s *filesSuite) TestWriteInvalidMetadata(c *C) {
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 not json
---BOUNDARY--
+--01234567890123456789012345678901--
 `))
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
 	assertError(c, body, http.StatusBadRequest, "", `cannot decode request metadata.*`)
 
 	response, body = doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {"action": "foo"}
---BOUNDARY--
+--01234567890123456789012345678901--
 `))
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
 	assertError(c, body, http.StatusBadRequest, "", `multipart action must be "write", got "foo"`)
@@ -683,15 +683,15 @@ Content-Disposition: form-data; name="request"
 
 func (s *filesSuite) TestWriteNoFiles(c *C) {
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {"action": "write"}
---BOUNDARY--
+--01234567890123456789012345678901--
 `))
 	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
 	assertError(c, body, http.StatusBadRequest, "", "must specify one or more files")
@@ -702,21 +702,21 @@ func (s *filesSuite) TestWriteSingle(c *C) {
 	path := tmpDir + "/hello.txt"
 
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(fmt.Sprintf(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {"action": "write", "files": [
 	{"path": "%[1]s"}
 ]}
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[1]s"
 
 Hello world
---BOUNDARY--
+--01234567890123456789012345678901--
 `, path)))
 	c.Check(response.StatusCode, Equals, http.StatusOK)
 
@@ -737,11 +737,11 @@ func (s *filesSuite) TestWriteMultiple(c *C) {
 	path2 := tmpDir + "/foo/bar.txt"
 
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(fmt.Sprintf(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {
@@ -752,20 +752,20 @@ Content-Disposition: form-data; name="request"
 		{"path": "%[3]s", "make-dirs": true}
 	]
 }
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[1]s"
 
 Hello
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[2]s"
 
 Bye bye
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[3]s"
 
 Foo
 Bar
---BOUNDARY--
+--01234567890123456789012345678901--
 `, path0, path1, path2)))
 	c.Check(response.StatusCode, Equals, http.StatusOK)
 
@@ -873,11 +873,11 @@ func (s *filesSuite) testWriteUserGroup(c *C, uid, gid int, user, group string) 
 	pathUserGroup := tmpDir + "/user-group"
 
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(fmt.Sprintf(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {
@@ -888,19 +888,19 @@ Content-Disposition: form-data; name="request"
 		{"path": "%[5]s", "user": "%[6]s", "group": "%[7]s"}
 	]
 }
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[1]s"
 
 normal
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[2]s"
 
 uid gid
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[5]s"
 
 user group
---BOUNDARY--
+--01234567890123456789012345678901--
 `, pathNormal, pathUidGid, uid, gid, pathUserGroup, user, group)))
 	c.Check(response.StatusCode, Equals, http.StatusOK)
 
@@ -933,11 +933,11 @@ func (s *filesSuite) TestWriteErrors(c *C) {
 	pathOnlyGroup := tmpDir + "/only-group"
 
 	headers := http.Header{
-		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},
+		"Content-Type": []string{"multipart/form-data; boundary=01234567890123456789012345678901"},
 	}
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers,
 		[]byte(fmt.Sprintf(`
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="request"
 
 {
@@ -953,35 +953,35 @@ Content-Disposition: form-data; name="request"
 		{"path": "%[8]s", "group": "nogroup"}
 	]
 }
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[2]s"
 
 path not absolute
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[3]s"
 
 dir not found
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[4]s"
 
 permission denied
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[5]s"
 
 user not found
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[6]s"
 
 group not found
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[7]s"
 
 only user specified
---BOUNDARY
+--01234567890123456789012345678901
 Content-Disposition: form-data; name="files"; filename="%[8]s"
 
 only group specified
---BOUNDARY--
+--01234567890123456789012345678901--
 `, pathNoContent, pathNotAbsolute, pathNotFound, pathPermissionDenied,
 			pathUserNotFound, pathGroupNotFound, pathOnlyUser, pathOnlyGroup)))
 	c.Check(response.StatusCode, Equals, http.StatusOK)

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -121,9 +121,9 @@ func (s *filesSuite) TestListFilesDirItself(c *C) {
 	tmpDir := createTestFiles(c)
 
 	query := url.Values{
-		"action":    []string{"list"},
-		"path":      []string{tmpDir + "/sub"},
-		"directory": []string{"true"},
+		"action": []string{"list"},
+		"path":   []string{tmpDir + "/sub"},
+		"itself": []string{"true"},
 	}
 	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -676,10 +676,11 @@ Bar
 
 func (s *filesSuite) TestWriteErrors(c *C) {
 	tmpDir := c.MkDir()
+	c.Assert(os.Mkdir(tmpDir+"/permission-denied", 0), IsNil)
 	pathNoContent := tmpDir + "/no-content"
 	pathNotAbsolute := "path-not-absolute"
 	pathNotFound := tmpDir + "/not-found/foo"
-	pathPermissionDenied := "/dev/permission-denied"
+	pathPermissionDenied := tmpDir + "/permission-denied/file"
 
 	headers := http.Header{
 		"Content-Type": []string{"multipart/form-data; boundary=BOUNDARY"},

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+var _ = Suite(&filesSuite{})
+
+type filesSuite struct{}
+
+func (s *filesSuite) SetUpTest(c *C) {
+}
+
+func (s *filesSuite) TearDownTest(c *C) {
+}
+
+func (s *filesSuite) TestGetFilesInvalidAction(c *C) {
+	query := url.Values{"action": []string{"foo"}}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusBadRequest)
+	assertError(c, body, http.StatusBadRequest, "", `invalid action "foo"`)
+}
+
+func (s *filesSuite) TestListFilesNoPattern(c *C) {
+	query := url.Values{
+		"action":  []string{"list"},
+		"pattern": []string{""},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusBadRequest)
+	assertError(c, body, http.StatusBadRequest, "", `must specify pattern`)
+}
+
+func (s *filesSuite) TestListFilesNonAbsPattern(c *C) {
+	query := url.Values{
+		"action":  []string{"list"},
+		"pattern": []string{"bar"},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusBadRequest)
+	assertError(c, body, http.StatusBadRequest, "", `pattern must be absolute .*`)
+}
+
+func (s *filesSuite) TestListFilesPermissionDenied(c *C) {
+	tmpDir := c.MkDir()
+	noAccessDir := filepath.Join(tmpDir, "noaccess")
+	c.Assert(os.Mkdir(noAccessDir, 0o775), IsNil)
+	c.Assert(os.Chmod(noAccessDir, 0), IsNil)
+
+	query := url.Values{
+		"action":  []string{"list"},
+		"pattern": []string{noAccessDir},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusForbidden)
+	assertError(c, body, http.StatusForbidden, "permission-denied", ".*: permission denied")
+}
+
+func (s *filesSuite) TestListFilesNotFound(c *C) {
+	tmpDir := createTestFiles(c)
+
+	for _, pattern := range []string{tmpDir + "/notfound", tmpDir + "/*.xyz"} {
+		query := url.Values{
+			"action":  []string{"list"},
+			"pattern": []string{pattern},
+		}
+		response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+		c.Assert(response.StatusCode, Equals, http.StatusNotFound)
+		assertError(c, body, http.StatusNotFound, "not-found", "file does not exist")
+	}
+}
+
+func (s *filesSuite) TestListFilesDir(c *C) {
+	tmpDir := createTestFiles(c)
+
+	for _, pattern := range []string{tmpDir, tmpDir + "/*"} {
+		query := url.Values{
+			"action":  []string{"list"},
+			"pattern": []string{pattern},
+		}
+		response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+		c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+		r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
+		assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "664", 1)
+		assertListResult(c, r.Result, 1, "file", tmpDir, "one.txt", "600", 2)
+		assertListResult(c, r.Result, 2, "directory", tmpDir, "sub", "775", -1)
+		assertListResult(c, r.Result, 3, "file", tmpDir, "two.txt", "775", 3)
+	}
+}
+
+func (s *filesSuite) TestListFilesDirItself(c *C) {
+	tmpDir := createTestFiles(c)
+
+	query := url.Values{
+		"action":    []string{"list"},
+		"pattern":   []string{tmpDir + "/sub"},
+		"directory": []string{"true"},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
+	assertListResult(c, r.Result, 0, "directory", tmpDir, "sub", "775", -1)
+}
+
+func (s *filesSuite) TestListFilesGlob(c *C) {
+	tmpDir := createTestFiles(c)
+
+	query := url.Values{
+		"action":  []string{"list"},
+		"pattern": []string{tmpDir + "/*.txt"},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
+	assertListResult(c, r.Result, 0, "file", tmpDir, "one.txt", "600", 2)
+	assertListResult(c, r.Result, 1, "file", tmpDir, "two.txt", "775", 3)
+}
+
+func (s *filesSuite) TestListFilesFile(c *C) {
+	tmpDir := createTestFiles(c)
+
+	query := url.Values{
+		"action":  []string{"list"},
+		"pattern": []string{tmpDir + "/foo"},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
+	assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "664", 1)
+}
+
+func doRequest(c *C, f ResponseFunc, method, url string, query url.Values, headers http.Header, body []byte) (*http.Response, *bytes.Buffer) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewBuffer(body)
+	}
+	req, err := http.NewRequest(method, url, bodyReader)
+	c.Assert(err, IsNil)
+	if query != nil {
+		req.URL.RawQuery = query.Encode()
+	}
+	req.Header = headers
+	handler := f(apiCmd(url), req, nil)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	response := recorder.Result()
+	return response, recorder.Body
+}
+
+func assertError(c *C, body io.Reader, status int, kind, message string) {
+	var r respJSON
+	c.Assert(json.NewDecoder(body).Decode(&r), IsNil)
+	c.Assert(r.Status, Equals, status)
+	c.Assert(r.StatusText, Equals, http.StatusText(status))
+	c.Assert(r.Type, Equals, ResponseTypeError)
+	result := r.Result.(map[string]interface{})
+	if kind != "" {
+		c.Assert(result["kind"], Equals, kind)
+	}
+	c.Assert(result["message"], Matches, message)
+}
+
+func createTestFiles(c *C) string {
+	tmpDir := c.MkDir()
+	writeTempFile(c, tmpDir, "foo", "a", 0o664)
+	writeTempFile(c, tmpDir, "one.txt", "be", 0o600)
+	c.Assert(os.Mkdir(filepath.Join(tmpDir, "sub"), 0o775), IsNil)
+	writeTempFile(c, tmpDir, "two.txt", "cee", 0o775)
+	return tmpDir
+}
+
+func writeTempFile(c *C, dir, filename, content string, perm os.FileMode) {
+	err := ioutil.WriteFile(filepath.Join(dir, filename), []byte(content), perm)
+	c.Assert(err, IsNil)
+}
+
+func assertListResult(c *C, result interface{}, index int, typ, dir, name, perms string, size int) {
+	x := result.([]interface{})[index].(map[string]interface{})
+	c.Assert(x["type"], Equals, typ)
+	c.Assert(x["name"], Equals, name)
+	c.Assert(x["path"], Equals, filepath.Join(dir, name))
+	c.Assert(x["permissions"], Equals, perms)
+	if size >= 0 {
+		c.Assert(int(x["size"].(float64)), Equals, size)
+	} else {
+		_, ok := x["size"]
+		c.Assert(ok, Equals, false)
+	}
+	_, err := time.Parse(time.RFC3339, x["last-modified"].(string))
+	c.Assert(err, IsNil)
+}
+
+func decodeResp(c *C, body io.Reader, status int, typ ResponseType) respJSON {
+	var r respJSON
+	c.Assert(json.NewDecoder(body).Decode(&r), IsNil)
+	c.Assert(r.Status, Equals, status)
+	c.Assert(r.StatusText, Equals, http.StatusText(status))
+	c.Assert(r.Type, Equals, typ)
+	return r
+}

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -401,11 +401,11 @@ func (s *filesSuite) TestMakeDirsMultiple(c *C) {
 	reqBody, err := json.Marshal(payload)
 	c.Assert(err, IsNil)
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers, reqBody)
-	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
+	c.Check(response.StatusCode, Equals, http.StatusOK)
 
 	var r testFilesResponse
 	c.Assert(json.NewDecoder(body).Decode(&r), IsNil)
-	c.Check(r.StatusCode, Equals, http.StatusBadRequest)
+	c.Check(r.StatusCode, Equals, http.StatusOK)
 	c.Check(r.Type, Equals, "sync")
 	c.Check(r.Result, HasLen, 3)
 	checkFileResult(c, r.Result[0], tmpDir+"/newdir", "", "")
@@ -551,11 +551,11 @@ func (s *filesSuite) TestRemoveMultiple(c *C) {
 	reqBody, err := json.Marshal(payload)
 	c.Assert(err, IsNil)
 	response, body := doRequest(c, v1PostFiles, "POST", "/v1/files", nil, headers, reqBody)
-	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
+	c.Check(response.StatusCode, Equals, http.StatusOK)
 
 	var r testFilesResponse
 	c.Assert(json.NewDecoder(body).Decode(&r), IsNil)
-	c.Check(r.StatusCode, Equals, http.StatusBadRequest)
+	c.Check(r.StatusCode, Equals, http.StatusOK)
 	c.Check(r.Type, Equals, "sync")
 	c.Check(r.Result, HasLen, 4)
 	checkFileResult(c, r.Result[0], tmpDir+"/file", "", "")
@@ -984,11 +984,11 @@ only group specified
 --BOUNDARY--
 `, pathNoContent, pathNotAbsolute, pathNotFound, pathPermissionDenied,
 			pathUserNotFound, pathGroupNotFound, pathOnlyUser, pathOnlyGroup)))
-	c.Check(response.StatusCode, Equals, http.StatusBadRequest)
+	c.Check(response.StatusCode, Equals, http.StatusOK)
 
 	var r testFilesResponse
 	c.Assert(json.NewDecoder(body).Decode(&r), IsNil)
-	c.Check(r.StatusCode, Equals, http.StatusBadRequest)
+	c.Check(r.StatusCode, Equals, http.StatusOK)
 	c.Check(r.Type, Equals, "sync")
 	c.Check(r.Result, HasLen, 8)
 	checkFileResult(c, r.Result[0], pathNoContent, "generic-file-error", "no file content for path.*")

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -239,8 +239,8 @@ func (s *filesSuite) TestReadErrorOnRead(c *C) {
 	var r testFilesResponse
 	files := readMultipart(c, response, body, &r)
 	c.Check(r.Type, Equals, "sync")
-	c.Check(r.StatusCode, Equals, http.StatusBadRequest)
-	c.Check(r.Status, Equals, "Bad Request")
+	c.Check(r.StatusCode, Equals, http.StatusOK)
+	c.Check(r.Status, Equals, "OK")
 	c.Check(r.Result, HasLen, 1)
 	checkFileResult(c, r.Result[0], "/proc/self/mem", "generic-file-error", ".*input/output error")
 
@@ -309,8 +309,8 @@ func (s *filesSuite) TestReadErrors(c *C) {
 	var r testFilesResponse
 	files := readMultipart(c, response, body, &r)
 	c.Check(r.Type, Equals, "sync")
-	c.Check(r.StatusCode, Equals, http.StatusBadRequest)
-	c.Check(r.Status, Equals, "Bad Request")
+	c.Check(r.StatusCode, Equals, http.StatusOK)
+	c.Check(r.Status, Equals, "OK")
 	c.Check(r.Result, HasLen, 5)
 	checkFileResult(c, r.Result[0], tmpDir+"/no-exist", "not-found", ".*: no such file or directory")
 	checkFileResult(c, r.Result[1], tmpDir+"/foo", "", "")

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -111,9 +111,9 @@ func (s *filesSuite) TestListFilesDir(c *C) {
 		c.Assert(response.StatusCode, Equals, http.StatusOK)
 
 		r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
-		assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "664", 1)
+		assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "644", 1)
 		assertListResult(c, r.Result, 1, "file", tmpDir, "one.txt", "600", 2)
-		assertListResult(c, r.Result, 2, "directory", tmpDir, "sub", "775", -1)
+		assertListResult(c, r.Result, 2, "directory", tmpDir, "sub", "755", -1)
 		assertListResult(c, r.Result, 3, "file", tmpDir, "two.txt", "755", 3)
 	}
 }
@@ -130,7 +130,7 @@ func (s *filesSuite) TestListFilesDirItself(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
 	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
-	assertListResult(c, r.Result, 0, "directory", tmpDir, "sub", "775", -1)
+	assertListResult(c, r.Result, 0, "directory", tmpDir, "sub", "755", -1)
 }
 
 func (s *filesSuite) TestListFilesGlob(c *C) {
@@ -159,7 +159,7 @@ func (s *filesSuite) TestListFilesFile(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 
 	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
-	assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "664", 1)
+	assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "644", 1)
 }
 
 func (s *filesSuite) TestReadNoPaths(c *C) {
@@ -360,7 +360,7 @@ func (s *filesSuite) TestMakeDirsMultiple(c *C) {
 		Dirs: []makeDirsItem{
 			{Path: tmpDir + "/newdir"},
 			{Path: tmpDir + "/will/not/work"},
-			{Path: tmpDir + "/make/my/parents", MakeParents: true, Permissions: "755"},
+			{Path: tmpDir + "/make/my/parents", MakeParents: true, Permissions: "700"},
 		},
 	}
 	reqBody, err := json.Marshal(payload)
@@ -382,10 +382,10 @@ func (s *filesSuite) TestMakeDirsMultiple(c *C) {
 	c.Check(osutil.IsDir(tmpDir+"/make/my/parents"), Equals, true)
 	st, err := os.Stat(tmpDir + "/newdir")
 	c.Assert(err, IsNil)
-	c.Check(st.Mode().Perm(), Equals, os.FileMode(0o775))
+	c.Check(st.Mode().Perm(), Equals, os.FileMode(0o755))
 	st, err = os.Stat(tmpDir + "/make/my/parents")
 	c.Assert(err, IsNil)
-	c.Check(st.Mode().Perm(), Equals, os.FileMode(0o755))
+	c.Check(st.Mode().Perm(), Equals, os.FileMode(0o700))
 }
 
 func (s *filesSuite) TestRemoveSingle(c *C) {
@@ -422,10 +422,10 @@ func (s *filesSuite) TestRemoveSingle(c *C) {
 func (s *filesSuite) TestRemoveMultiple(c *C) {
 	tmpDir := c.MkDir()
 	writeTempFile(c, tmpDir, "file", "a", 0o644)
-	c.Assert(os.Mkdir(tmpDir+"/empty", 0o775), IsNil)
-	c.Assert(os.Mkdir(tmpDir+"/non-empty", 0o775), IsNil)
+	c.Assert(os.Mkdir(tmpDir+"/empty", 0o755), IsNil)
+	c.Assert(os.Mkdir(tmpDir+"/non-empty", 0o755), IsNil)
 	writeTempFile(c, tmpDir, "non-empty/bar", "b", 0o644)
-	c.Assert(os.Mkdir(tmpDir+"/recursive", 0o775), IsNil)
+	c.Assert(os.Mkdir(tmpDir+"/recursive", 0o755), IsNil)
 	writeTempFile(c, tmpDir, "recursive/car", "c", 0o644)
 
 	headers := http.Header{
@@ -671,7 +671,7 @@ Bar
 	assertFile(c, path2, 0o644, "Foo\nBar")
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, IsNil)
-	c.Assert(info.Mode().Perm(), Equals, os.FileMode(0o775))
+	c.Assert(info.Mode().Perm(), Equals, os.FileMode(0o755))
 }
 
 func (s *filesSuite) TestWriteErrors(c *C) {
@@ -801,9 +801,9 @@ func assertError(c *C, body io.Reader, status int, kind, message string) {
 
 func createTestFiles(c *C) string {
 	tmpDir := c.MkDir()
-	writeTempFile(c, tmpDir, "foo", "a", 0o664)
+	writeTempFile(c, tmpDir, "foo", "a", 0o644)
 	writeTempFile(c, tmpDir, "one.txt", "be", 0o600)
-	c.Assert(os.Mkdir(tmpDir+"/sub", 0o775), IsNil)
+	c.Assert(os.Mkdir(tmpDir+"/sub", 0o755), IsNil)
 	writeTempFile(c, tmpDir, "two.txt", "cee", 0o755)
 	return tmpDir
 }

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -150,19 +150,6 @@ func SyncResponse(result interface{}) Response {
 	}
 }
 
-func syncResponseWithError(result interface{}, err error) Response {
-	status := http.StatusOK
-	if err != nil {
-		status = http.StatusBadRequest
-	}
-	return &resp{
-		// Type is still "sync", not "error", because result is not an errorResult
-		Type:   ResponseTypeSync,
-		Status: status,
-		Result: result,
-	}
-}
-
 func AsyncResponse(result map[string]interface{}, change string) Response {
 	return &resp{
 		Type:   ResponseTypeAsync,

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -123,6 +123,7 @@ const (
 	errorKindNoDefaultServices = errorKind("no-default-services")
 	errorKindNotFound          = errorKind("not-found")
 	errorKindPermissionDenied  = errorKind("permission-denied")
+	errorKindGenericFileError  = errorKind("generic-file-error")
 )
 
 type errorValue interface{}

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -121,6 +121,8 @@ const (
 	errorKindDaemonRestart     = errorKind("daemon-restart")
 	errorKindSystemRestart     = errorKind("system-restart")
 	errorKindNoDefaultServices = errorKind("no-default-services")
+	errorKindNotFound          = errorKind("not-found")
+	errorKindPermissionDenied  = errorKind("permission-denied")
 )
 
 type errorValue interface{}

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -151,15 +151,20 @@ func SyncResponse(result interface{}) Response {
 }
 
 func syncResponseWithError(result interface{}, err error) Response {
-	respType := ResponseTypeSync
-	status := http.StatusOK
 	if err != nil {
-		respType = ResponseTypeError
-		status = http.StatusBadRequest
+		// Wrap result inside the error.
+		return &resp{
+			Type:   ResponseTypeError,
+			Status: http.StatusBadRequest,
+			Result: &errorResult{
+				Message: err.Error(),
+				Value:   result,
+			},
+		}
 	}
 	return &resp{
-		Type:   respType,
-		Status: status,
+		Type:   ResponseTypeSync,
+		Status: http.StatusOK,
 		Result: result,
 	}
 }

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -151,14 +151,13 @@ func SyncResponse(result interface{}) Response {
 }
 
 func syncResponseWithError(result interface{}, err error) Response {
-	respType := ResponseTypeSync
 	status := http.StatusOK
 	if err != nil {
-		respType = ResponseTypeError
 		status = http.StatusBadRequest
 	}
 	return &resp{
-		Type:   respType,
+		// Type is still "sync", not "error", because result is not an errorResult
+		Type:   ResponseTypeSync,
 		Status: status,
 		Result: result,
 	}

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -150,6 +150,20 @@ func SyncResponse(result interface{}) Response {
 	}
 }
 
+func syncResponseWithError(result interface{}, err error) Response {
+	respType := ResponseTypeSync
+	status := http.StatusOK
+	if err != nil {
+		respType = ResponseTypeError
+		status = http.StatusBadRequest
+	}
+	return &resp{
+		Type:   respType,
+		Status: status,
+		Result: result,
+	}
+}
+
 func AsyncResponse(result map[string]interface{}, change string) Response {
 	return &resp{
 		Type:   ResponseTypeAsync,

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -151,20 +151,15 @@ func SyncResponse(result interface{}) Response {
 }
 
 func syncResponseWithError(result interface{}, err error) Response {
+	respType := ResponseTypeSync
+	status := http.StatusOK
 	if err != nil {
-		// Wrap result inside the error.
-		return &resp{
-			Type:   ResponseTypeError,
-			Status: http.StatusBadRequest,
-			Result: &errorResult{
-				Message: err.Error(),
-				Value:   result,
-			},
-		}
+		respType = ResponseTypeError
+		status = http.StatusBadRequest
 	}
 	return &resp{
-		Type:   ResponseTypeSync,
-		Status: http.StatusOK,
+		Type:   respType,
+		Status: status,
 		Result: result,
 	}
 }


### PR DESCRIPTION
This implements the Pebble file I/O API as per the [spec](https://docs.google.com/document/d/1NPPZZB_qCwtTru-YsKkRSAb6mXJzBiE0fG3GTZnx4fM/edit#heading=h.tqx73o2f3f0q).

The code is done, and tests for all features (including error handling) are in place. The one thing I'm not yet testing is setting of user/group -- will try to add tests for that tomorrow.

This PR doesn't incldue the Pebble Go client or Pebble CLI commands in this PR. To keep things moving, I plan to do that in a subsequent PR.

Note that per discussion with Gustavo, it'd be nice if, for consistency, all endpoints could optionally be sent as `multipart/form-data`. However, this is not necessary right now, and can be done later if we want.