### PR TITLE
Files API: add user/group to list-files, and a few minor fixes

### DIFF
--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -28,6 +28,7 @@ import (
 	"os/user"
 	pathpkg "path"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/canonical/pebble/internal/osutil"
@@ -200,6 +201,8 @@ type fileInfoResult struct {
 	Size         *int64   `json:"size,omitempty"`
 	Permissions  string   `json:"permissions"`
 	LastModified string   `json:"last-modified"`
+	UserID       int      `json:"user-id"`
+	GroupID      int      `json:"group-id"`
 }
 
 type fileType string
@@ -247,6 +250,10 @@ func fileInfoToResult(fullPath string, info os.FileInfo) fileInfoResult {
 		Size:         psize,
 		Permissions:  fmt.Sprintf("%03o", mode.Perm()),
 		LastModified: info.ModTime().Format(time.RFC3339),
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		result.UserID = int(stat.Uid)
+		result.GroupID = int(stat.Gid)
 	}
 	return result
 }

--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -294,7 +294,7 @@ func listFiles(path, pattern string, itself bool) ([]fileInfoResult, error) {
 		dir = path
 	}
 
-	var result []fileInfoResult
+	result := make([]fileInfoResult, 0) // want "no results" to be [], not nil
 	for _, info = range infos {
 		name := info.Name()
 		matched := true

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -162,6 +162,20 @@ func (s *filesSuite) TestListFilesFile(c *C) {
 	assertListResult(c, r.Result, 0, "file", tmpDir, "foo", "644", 1)
 }
 
+func (s *filesSuite) TestListFilesNoResults(c *C) {
+	tmpDir := c.MkDir()
+
+	query := url.Values{
+		"action": []string{"list"},
+		"path":   []string{tmpDir},
+	}
+	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+
+	r := decodeResp(c, body, http.StatusOK, ResponseTypeSync)
+	c.Assert(r.Result, HasLen, 0) // should be empty slice, not nil
+}
+
 func (s *filesSuite) TestReadNoPaths(c *C) {
 	query := url.Values{"action": []string{"read"}}
 	response, body := doRequest(c, v1GetFiles, "GET", "/v1/files", query, nil, nil)

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -469,6 +469,7 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	headers := http.Header{
 		"Content-Type": []string{"application/json"},
 	}
+	uid, gid := 12, 34
 	payload := struct {
 		Action string
 		Dirs   []makeDirsItem
@@ -476,7 +477,7 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 		Action: "make-dirs",
 		Dirs: []makeDirsItem{
 			{Path: tmpDir + "/normal"},
-			{Path: tmpDir + "/uid-gid", UserID: 12, GroupID: 34},
+			{Path: tmpDir + "/uid-gid", UserID: &uid, GroupID: &gid},
 			{Path: tmpDir + "/user-group", User: "USER", Group: "GROUP"},
 		},
 	}
@@ -1085,7 +1086,7 @@ func readMultipart(c *C, response *http.Response, body io.Reader, result interfa
 		c.Assert(err, IsNil)
 		b, err := ioutil.ReadAll(f)
 		c.Assert(err, IsNil)
-		f.Close()
+		_ = f.Close()
 		files[fh.Filename] = string(b)
 	}
 	return files

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -1136,6 +1136,11 @@ func assertListResult(c *C, result interface{}, index int, typ, dir, name, perms
 	}
 	_, err := time.Parse(time.RFC3339, x["last-modified"].(string))
 	c.Assert(err, IsNil)
+
+	uid := int(x["user-id"].(float64))
+	c.Assert(uid, Equals, os.Getuid())
+	gid := int(x["group-id"].(float64))
+	c.Assert(gid, Equals, os.Getgid())
 }
 
 func decodeResp(c *C, body io.Reader, status int, typ ResponseType) respJSON {

--- a/internal/daemon/api_files_test.go
+++ b/internal/daemon/api_files_test.go
@@ -1155,6 +1155,13 @@ func assertListResult(c *C, result interface{}, index int, typ, dir, name, perms
 	c.Assert(uid, Equals, os.Getuid())
 	gid := int(x["group-id"].(float64))
 	c.Assert(gid, Equals, os.Getgid())
+
+	usr, err := user.LookupId(strconv.Itoa(uid))
+	c.Assert(err, IsNil)
+	c.Assert(x["user"], Equals, usr.Username)
+	group, err := user.LookupGroupId(strconv.Itoa(gid))
+	c.Assert(err, IsNil)
+	c.Assert(x["group"], Equals, group.Name)
 }
 
 func decodeResp(c *C, body io.Reader, status int, typ ResponseType) respJSON {


### PR DESCRIPTION
This PR includes the following:

* Add user-id, user, group-id, group fields to the list-files response (with user/group lookup cached per API call for efficiency).
* Minor fix to the list-files response to give `result: []` in the JSON instead of `result: null` when there are no results, e.g., the directory is empty.
* Change UserID/GroupID fields from int to *int as 0 is actually a valid value ("root"), so we couldn't distinguish between unset and someone trying to set both to "root".
* Add a couple more tests.