### PR TITLE
Add "pebble help" docs for PEBBLE and PEBBLE_SOCKET environment vars

### DIFF
--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -190,8 +190,12 @@ the system that is running them.
 `)
 	pebbleUsage               = "Usage: pebble <command> [<options>...]"
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
-	pebbleHelpAllFooter       = "For more information about a command, run 'pebble help <command>'."
-	pebbleHelpFooter          = "For a short summary of all commands, run 'pebble help --all'."
+	pebbleHelpAllFooter       = "Set the PEBBLE environment variable to override the configuration directory \n" +
+		"(which defaults to " + defaultPebbleDir + "). Set PEBBLE_SOCKET to override \n" +
+		"the Unix socket used for the API (defaults to $PEBBLE/.pebble.socket).\n" +
+		"\n" +
+		"For more information about a command, run 'pebble help <command>'."
+	pebbleHelpFooter = "For a short summary of all commands, run 'pebble help --all'."
 )
 
 func printHelpHeader() {


### PR DESCRIPTION
Shown when run with `pebble`, `pebble help`, or `pebble help --all`. Note that `PEBBLE` only applies to `pebble run`, but `PEBBLE_SOCKET` applies to all commands. New paragraph is near the end of the help output:

```
$ ./pebble 
Pebble lets you control services and perform management actions on
the system that is running them.

Usage: pebble <command> [<options>...]

Commands can be classified as follows:

         Basics: run, autostart, start, stop, services, logs
  Configuration: add, plan
        Changes: changes, tasks
          Other: warnings, okay, help, version

Set the PEBBLE environment variable to override the configuration directory 
(which defaults to /var/lib/pebble/default). Set PEBBLE_SOCKET to override 
the Unix socket used for the API (defaults to $PEBBLE/.pebble.socket).

For more information about a command, run 'pebble help <command>'.
For a short summary of all commands, run 'pebble help --all'.
```

Fixes #26.