### PR TITLE
Return custom error for plan format issue; have API return 400, not 500

### DIFF
--- a/internal/daemon/api_plan.go
+++ b/internal/daemon/api_plan.go
@@ -79,6 +79,9 @@ func v1PostLayers(c *Command, r *http.Request, _ *userState) Response {
 		if _, ok := err.(*servstate.LabelExists); ok {
 			return statusBadRequest("%v", err)
 		}
+		if _, ok := err.(*plan.FormatError); ok {
+			return statusBadRequest("%v", err)
+		}
 		return statusInternalError("%v", err)
 	}
 	return SyncResponse(true)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -69,6 +69,16 @@ const (
 	ReplaceOverride ServiceOverride = "replace"
 )
 
+// FormatError is the error returned when a layer has a format error, such as
+// a missing "override" field.
+type FormatError struct {
+	Message string
+}
+
+func (e *FormatError) Error() string {
+	return e.Message
+}
+
 // CombineLayers combines the given layers into a Plan, with the later layers
 // layers overriding earlier ones.
 func CombineLayers(layers ...*Layer) (*Layer, error) {
@@ -110,11 +120,15 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 				copy := *service
 				combined.Services[name] = &copy
 			case UnknownOverride:
-				return nil, fmt.Errorf("layer %q must define 'override' for service %q",
-					layer.Label, service.Name)
+				return nil, &FormatError{
+					Message: fmt.Sprintf(`layer %q must define "override" for service %q`,
+						layer.Label, service.Name),
+				}
 			default:
-				return nil, fmt.Errorf("layer %q has invalid 'override' value on service %q: %q",
-					layer.Label, service.Name, service.Override)
+				return nil, &FormatError{
+					Message: fmt.Sprintf(`layer %q has invalid "override" value for service %q`,
+						layer.Label, service.Name),
+				}
 			}
 		}
 	}
@@ -169,7 +183,9 @@ func order(services map[string]*Service, names []string, stop bool) ([]string, e
 		} else {
 			service, ok := services[name]
 			if !ok {
-				return nil, fmt.Errorf("service %q does not exist", name)
+				return nil, &FormatError{
+					Message: fmt.Sprintf("service %q does not exist", name),
+				}
 			}
 			pending = append(pending, service.Requires...)
 		}
@@ -179,7 +195,9 @@ func order(services map[string]*Service, names []string, stop bool) ([]string, e
 	for name := range successors {
 		service, ok := services[name]
 		if !ok {
-			return nil, fmt.Errorf("service %q does not exist", name)
+			return nil, &FormatError{
+				Message: fmt.Sprintf("service %q does not exist", name),
+			}
 		}
 		succs := successors[name]
 		serviceAfter := service.After
@@ -204,7 +222,9 @@ func order(services map[string]*Service, names []string, stop bool) ([]string, e
 	var order []string
 	for _, names := range tarjanSort(successors) {
 		if len(names) > 1 {
-			return nil, fmt.Errorf("services in before/after loop: %s", strings.Join(names, ", "))
+			return nil, &FormatError{
+				Message: fmt.Sprintf("services in before/after loop: %s", strings.Join(names, ", ")),
+			}
 		}
 		order = append(order, names[0])
 	}
@@ -226,7 +246,9 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	dec.KnownFields(true)
 	err := dec.Decode(&layer)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse layer %q: %v", label, err)
+		return nil, &FormatError{
+			Message: fmt.Sprintf("cannot parse layer %q: %v", label, err),
+		}
 	}
 	layer.Order = order
 	layer.Label = label

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -381,6 +381,22 @@ services:
 `))
 	_, err = plan.CombineLayers(layer1, layer2)
 	c.Assert(err, ErrorMatches, `services in before/after loop: .*`)
+	_, ok := err.(*plan.FormatError)
+	c.Assert(ok, Equals, true, Commentf("error must be *plan.FormatError, not %T", err))
+}
+
+func (s *S) TestMissingOverride(c *C) {
+	layer1, err := plan.ParseLayer(1, "label1", []byte("{}"))
+	c.Assert(err, IsNil)
+	layer2, err := plan.ParseLayer(2, "label2", []byte(`
+services:
+    srv1:
+        command: cmd
+`))
+	_, err = plan.CombineLayers(layer1, layer2)
+	c.Check(err, ErrorMatches, `layer "label2" must define \"override\" for service "srv1"`)
+	_, ok := err.(*plan.FormatError)
+	c.Check(ok, Equals, true, Commentf("error must be *plan.FormatError, not %T", err))
 }
 
 func (s *S) TestReadDir(c *C) {


### PR DESCRIPTION
This addresses part of https://github.com/canonical/operator/issues/514 -- currently `POST /v1/layers` returns a generic HTTP 500 error if the layer format is incorrect, whereas it should be 400 bad request for better error handling on the client side. So add a custom error type for this case in the plan package, and handle it and return 400 in the API handler.