### PR TITLE
Don't log requests to /v1/system-info to avoid noise from health checks

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -299,13 +299,21 @@ func logit(handler http.Handler) http.Handler {
 		t0 := time.Now()
 		handler.ServeHTTP(ww, r)
 		t := time.Now().Sub(t0)
-		if !strings.Contains(r.URL.String(), "/v1/changes/") {
-			if strings.HasSuffix(r.RemoteAddr, ";") {
-				logger.Debugf("%s %s %s %s %d", r.RemoteAddr, r.Method, r.URL, t, ww.s)
-				logger.Noticef("%s %s %s %d", r.Method, r.URL, t, ww.s)
-			} else {
-				logger.Noticef("%s %s %s %s %d", r.RemoteAddr, r.Method, r.URL, t, ww.s)
-			}
+
+		if r.Method == "GET" && (strings.HasPrefix(r.URL.Path, "/v1/changes/") || r.URL.Path == "/v1/system-info") {
+			// Don't log GET /v1/changes/{change-id} as that's polled quickly
+			// by clients when waiting for a change (e.g., service starting).
+			// Also don't log GET /v1/system-info to avoid it filling logs with
+			// noise when that endpoint is used as a kind of health check
+			// (Juju hits it every 5s, for example).
+			return
+		}
+
+		if strings.HasSuffix(r.RemoteAddr, ";") {
+			logger.Debugf("%s %s %s %s %d", r.RemoteAddr, r.Method, r.URL, t, ww.s)
+			logger.Noticef("%s %s %s %d", r.Method, r.URL, t, ww.s)
+		} else {
+			logger.Noticef("%s %s %s %s %d", r.RemoteAddr, r.Method, r.URL, t, ww.s)
 		}
 	})
 }


### PR DESCRIPTION
Motivation: Juju hits Pebble's "GET /v1/system-info" endpoint every 5s
as a kind of health check (https://github.com/juju/juju/blob/develop/worker/uniter/pebblepoller.go#L105).
This creates a lot of noise when people want to look at the log output.

It's kind of a hack to filter it out in this way, but we're already
doing this with /v1/changes/{change-id}, so not too bad. We can fix
this properly later, for example with more fine-grained configuration
over Pebble request logging.

This change also tightens it up a little bit (only filters GETs, so
POST /v1/changes/{change-id} will still get logged.