### PR TITLE
Avoid panics in layer parsing/combining

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ services:
         # override the existing service spec in the plan with the same name.
         override: merge | replace
 
-        # (Optional) The command to run the service. This is optional in an
-        # individual layer, but required in the combined layer. The command is
-        # executed directly; use "/bin/sh -c '...'" to run via the shell.
+        # (Required in combined layer) The command to run the service. The
+        # command is executed directly; use "/bin/sh -c '...'" to run via the
+        # shell.
         #
         # Example: /usr/bin/somecommand -b -t 30
         command: <commmand>

--- a/README.md
+++ b/README.md
@@ -151,8 +151,15 @@ services:
         #
         # The value 'merge' will ensure that values in this layer specification
         # are merged over existing definitions, whereas 'replace' will entirely
-        # override the existing service spec in the plan with the same name
+        # override the existing service spec in the plan with the same name.
         override: merge | replace
+
+        # (Optional) The command to run the service. This is optional in an
+        # individual layer, but required in the combined layer. The command is
+        # executed directly; use "/bin/sh -c '...'" to run via the shell.
+        #
+        # Example: /usr/bin/somecommand -b -t 30
+        command: <commmand>
 
         # (Optional) A short summary of the service
         summary: <summary>
@@ -160,10 +167,6 @@ services:
         # (Optional) A detailed description of the service
         description: |
             <description>
-
-        # (Optional) The command to run the service.
-        # Example: /usr/bin/somecommand -b -t 30
-        command: <commmand>
 
         # (Optional) Control whether the service is started automatically when
         # Pebble starts. 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -83,7 +83,7 @@ func (e *FormatError) Error() string {
 	return e.Message
 }
 
-// CombineLayers combines the given layers into a plan, with the later layers
+// CombineLayers combines the given layers into a single layer, with the later
 // layers overriding earlier ones.
 func CombineLayers(layers ...*Layer) (*Layer, error) {
 	combined := &Layer{

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -327,6 +327,15 @@ var planTests = []planTest{{
 		services:
 			svc1: ~
 	`},
+}, {
+	summary: `Cannot use empty string as service name`,
+	error:   "cannot use empty string as service name",
+	input: []string{`
+		services:
+			"":
+				override: replace
+				command: cmd
+	`},
 }}
 
 func (s *S) TestParseLayer(c *C) {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -320,6 +320,13 @@ var planTests = []planTest{{
 			pebble:
 				command: cmd
 	`},
+}, {
+	summary: `Cannot have null service definition`,
+	error:   `service object cannot be null for service "svc1"`,
+	input: []string{`
+		services:
+			svc1: ~
+	`},
 }}
 
 func (s *S) TestParseLayer(c *C) {
@@ -401,10 +408,45 @@ services:
     srv1:
         command: cmd
 `))
+	c.Assert(err, IsNil)
 	_, err = plan.CombineLayers(layer1, layer2)
 	c.Check(err, ErrorMatches, `layer "label2" must define \"override\" for service "srv1"`)
 	_, ok := err.(*plan.FormatError)
 	c.Check(ok, Equals, true, Commentf("error must be *plan.FormatError, not %T", err))
+}
+
+func (s *S) TestMissingCommand(c *C) {
+	// Combine fails if no command in combined plan
+	layer1, err := plan.ParseLayer(1, "label1", []byte("{}"))
+	c.Assert(err, IsNil)
+	layer2, err := plan.ParseLayer(2, "label2", []byte(`
+services:
+    srv1:
+        override: merge
+`))
+	c.Assert(err, IsNil)
+	_, err = plan.CombineLayers(layer1, layer2)
+	c.Check(err, ErrorMatches, `plan must define "command" for service "srv1"`)
+	_, ok := err.(*plan.FormatError)
+	c.Check(ok, Equals, true, Commentf("error must be *plan.FormatError, not %T", err))
+
+	// Combine succeeds if there is a command in combined plan
+	layer1, err = plan.ParseLayer(1, "label1", []byte(`
+services:
+    srv1:
+        override: merge
+        command: foo --bar
+`))
+	c.Assert(err, IsNil)
+	layer2, err = plan.ParseLayer(2, "label2", []byte(`
+services:
+    srv1:
+        override: merge
+`))
+	c.Assert(err, IsNil)
+	combined, err := plan.CombineLayers(layer1, layer2)
+	c.Assert(err, IsNil)
+	c.Assert(combined.Services["srv1"].Command, Equals, "foo --bar")
 }
 
 func (s *S) TestReadDir(c *C) {


### PR DESCRIPTION
* Fix panic when command is not set in combined layer
* Fix panic when service object/dict is null
* Also disallow use of empty string as service name

Fixes #50