### PR TITLE
Add Replan operation to restart changed services.

### DIFF
--- a/client/services.go
+++ b/client/services.go
@@ -46,6 +46,11 @@ func (client *Client) Restart(opts *ServiceOptions) (changeID string, err error)
 	return changeID, err
 }
 
+func (client *Client) Replan(opts *ServiceOptions) (changeID string, err error) {
+	_, changeID, err = client.doMultiServiceAction("replan", opts.Names)
+	return changeID, err
+}
+
 type multiActionData struct {
 	Action   string   `json:"action"`
 	Services []string `json:"services"`

--- a/client/services_test.go
+++ b/client/services_test.go
@@ -135,3 +135,26 @@ func (cs *clientSuite) TestRestart(c *check.C) {
 	c.Check(body["action"], check.Equals, "restart")
 	c.Check(body["services"], check.DeepEquals, []interface{}{"one", "two"})
 }
+
+func (cs *clientSuite) TestReplan(c *check.C) {
+	cs.rsp = `{
+		"result": {},
+		"status": "OK",
+		"status-code": 202,
+		"type": "async",
+		"change": "42"
+	}`
+
+	opts := client.ServiceOptions{}
+
+	changeId, err := cs.cli.Replan(&opts)
+	c.Check(err, check.IsNil)
+	c.Check(changeId, check.Equals, "42")
+	c.Check(cs.req.Method, check.Equals, "POST")
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/services")
+
+	var body map[string]interface{}
+	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
+	c.Check(body, check.HasLen, 2)
+	c.Check(body["action"], check.Equals, "replan")
+}

--- a/cmd/pebble/cmd_replan.go
+++ b/cmd/pebble/cmd_replan.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"github.com/canonical/pebble/client"
+	"github.com/jessevdk/go-flags"
+)
+
+var shortReplanHelp = "Ensure running services match the current plan"
+var longReplanHelp = `
+The replan command starts, stops, or restarts services that have changed,
+so that running services match exactly the desired configuration in the current plan.
+`
+
+type cmdReplan struct {
+	waitMixin
+}
+
+func init() {
+	addCommand("replan", shortReplanHelp, longReplanHelp, func() flags.Commander { return &cmdReplan{} }, nil, nil)
+}
+
+func (cmd cmdReplan) Execute(args []string) error {
+	if len(args) > 1 {
+		return ErrExtraArgs
+	}
+
+	servopts := client.ServiceOptions{}
+	changeID, err := cmd.client.Replan(&servopts)
+	if err != nil {
+		return err
+	}
+
+	if _, err := cmd.wait(changeID); err != nil {
+		if err == noWait {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/pebble/internal/overlord"
 	"github.com/canonical/pebble/internal/overlord/state"
 )
 
@@ -79,6 +80,8 @@ var (
 	stateAllWarnings     = (*state.State).AllWarnings
 	statePendingWarnings = (*state.State).PendingWarnings
 	stateEnsureBefore    = (*state.State).EnsureBefore
+
+	overlordServiceManager = (*overlord.Overlord).ServiceManager
 
 	muxVars = mux.Vars
 )

--- a/internal/daemon/api_logs.go
+++ b/internal/daemon/api_logs.go
@@ -40,9 +40,9 @@ type serviceManager interface {
 	ServiceLogs(services []string, last int) (map[string]servicelog.Iterator, error)
 }
 
-func v1GetLogs(cmd *Command, _ *http.Request, _ *userState) Response {
+func v1GetLogs(c *Command, _ *http.Request, _ *userState) Response {
 	return logsResponse{
-		svcMgr: cmd.d.overlord.ServiceManager(),
+		svcMgr: overlordServiceManager(c.d.overlord),
 	}
 }
 

--- a/internal/daemon/api_plan.go
+++ b/internal/daemon/api_plan.go
@@ -30,7 +30,7 @@ func v1GetPlan(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("invalid format %q", format)
 	}
 
-	servmgr := c.d.overlord.ServiceManager()
+	servmgr := overlordServiceManager(c.d.overlord)
 	plan, err := servmgr.Plan()
 	if err != nil {
 		return statusInternalError("%v", err)
@@ -69,7 +69,7 @@ func v1PostLayers(c *Command, r *http.Request, _ *userState) Response {
 		return statusBadRequest("cannot parse layer YAML: %v", err)
 	}
 
-	servmgr := c.d.overlord.ServiceManager()
+	servmgr := overlordServiceManager(c.d.overlord)
 	if payload.Combine {
 		err = servmgr.CombineLayer(layer)
 	} else {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -78,7 +78,8 @@ func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	if service, previous := m.services[req.Name]; previous {
 		select {
 		case <-service.done:
-			// Service exited but not yet removed, safe to override.
+			// Service exited but not yet removed. It's safe to replace it
+			// because the removal will check if the cmd still matches.
 		default:
 			// Already started
 			m.state.Lock()

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -133,10 +133,10 @@ func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	active := &activeService{
-		plannedService: service.Copy(),
-		cmd:            cmd,
-		done:           make(chan struct{}),
-		logBuffer:      logBuffer,
+		originalPlan: service.Copy(),
+		cmd:          cmd,
+		done:         make(chan struct{}),
+		logBuffer:    logBuffer,
 	}
 	m.services[req.Name] = active
 	go func() {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -133,9 +133,10 @@ func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 	}
 
 	active := &activeService{
-		cmd:       cmd,
-		done:      make(chan struct{}),
-		logBuffer: logBuffer,
+		plannedService: service.Copy(),
+		cmd:            cmd,
+		done:           make(chan struct{}),
+		logBuffer:      logBuffer,
 	}
 	m.services[req.Name] = active
 	go func() {

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -357,9 +357,14 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 		}
 	}
 
-	stop, err = m.plan.StopOrder(stop, false)
+	stop, err = m.plan.StopOrder(stop)
 	if err != nil {
 		return nil, nil, err
+	}
+	for i, name := range stop {
+		if !needsRestart[name] {
+			stop = append(stop[:i], stop[i+1:]...)
+		}
 	}
 
 	start, err = m.plan.StartOrder(start)

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -351,8 +351,7 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 
 	var start []string
 	for name, service := range m.plan.Services {
-		if needsRestart[name] ||
-			service.Startup == plan.StartupEnabled {
+		if needsRestart[name] || service.Startup == plan.StartupEnabled {
 			start = append(start, name)
 		}
 	}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -55,6 +56,37 @@ type Service struct {
 	User        string            `yaml:"user,omitempty"`
 	GroupID     *int              `yaml:"group-id,omitempty"`
 	Group       string            `yaml:"group,omitempty"`
+}
+
+// Copy returns a deep copy of the service.
+func (s *Service) Copy() *Service {
+	copy := *s
+	copy.After = append([]string(nil), s.After...)
+	copy.Before = append([]string(nil), s.Before...)
+	copy.Requires = append([]string(nil), s.Requires...)
+	if s.Environment != nil {
+		copy.Environment = make(map[string]string)
+		for k, v := range s.Environment {
+			copy.Environment[k] = v
+		}
+	}
+	if s.UserID != nil {
+		userID := *s.UserID
+		copy.UserID = &userID
+	}
+	if s.GroupID != nil {
+		groupID := *s.GroupID
+		copy.GroupID = &groupID
+	}
+	return &copy
+}
+
+// Equal returns true when the two services are equal in value.
+func (s *Service) Equal(other *Service) bool {
+	if s == other {
+		return true
+	}
+	return reflect.DeepEqual(s, other)
 }
 
 type ServiceStartup string
@@ -100,41 +132,42 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			switch service.Override {
 			case MergeOverride:
 				if old, ok := combined.Services[name]; ok {
+					copy := old.Copy()
 					if service.Summary != "" {
-						old.Summary = service.Summary
+						copy.Summary = service.Summary
 					}
 					if service.Description != "" {
-						old.Description = service.Description
+						copy.Description = service.Description
 					}
 					if service.Startup != StartupUnknown {
-						old.Startup = service.Startup
+						copy.Startup = service.Startup
 					}
 					if service.Command != "" {
-						old.Command = service.Command
+						copy.Command = service.Command
 					}
 					if service.UserID != nil {
-						old.UserID = service.UserID
+						copy.UserID = service.UserID
 					}
 					if service.User != "" {
-						old.User = service.User
+						copy.User = service.User
 					}
 					if service.GroupID != nil {
-						old.GroupID = service.GroupID
+						copy.GroupID = service.GroupID
 					}
 					if service.Group != "" {
-						old.Group = service.Group
+						copy.Group = service.Group
 					}
-					old.Before = append(old.Before, service.Before...)
-					old.After = append(old.After, service.After...)
+					copy.Before = append(copy.Before, service.Before...)
+					copy.After = append(copy.After, service.After...)
 					for k, v := range service.Environment {
-						old.Environment[k] = v
+						copy.Environment[k] = v
 					}
+					combined.Services[name] = copy
 					break
 				}
 				fallthrough
 			case ReplaceOverride:
-				copy := *service
-				combined.Services[name] = &copy
+				combined.Services[name] = service.Copy()
 			case UnknownOverride:
 				return nil, &FormatError{
 					Message: fmt.Sprintf(`layer %q must define "override" for service %q`,


### PR DESCRIPTION
This change adds the **replan** command for restarting services that have changed or removed (we don't have remove AFAIK yet) since when they were started.

Replan acts much the same as **autostart** with the added restarting of changes.

Based on #58

Compare changes:
https://github.com/canonical/pebble/compare/hpidcock:restart...hpidcock:replan