### PR TITLE
One-shot commands (pebble exec)

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -46,7 +46,7 @@ func (c *Change) Get(key string, value interface{}) error {
 	if raw == nil {
 		return ErrNoData
 	}
-	return json.Unmarshal([]byte(*raw), value)
+	return json.Unmarshal(*raw, value)
 }
 
 // A Task is an operation done to change the system's state.
@@ -60,6 +60,17 @@ type Task struct {
 
 	SpawnTime time.Time `json:"spawn-time,omitempty"`
 	ReadyTime time.Time `json:"ready-time,omitempty"`
+
+	Data map[string]*json.RawMessage
+}
+
+// Get unmarshals into value the kind-specific data with the provided key.
+func (t *Task) Get(key string, value interface{}) error {
+	raw := t.Data[key]
+	if raw == nil {
+		return ErrNoData
+	}
+	return json.Unmarshal(*raw, value)
 }
 
 type TaskProgress struct {

--- a/client/changes.go
+++ b/client/changes.go
@@ -18,11 +18,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/gorilla/websocket"
 )
 
 // A Change is a modification to the system state.
@@ -186,26 +183,4 @@ func (client *Client) WaitChange(id string, opts *WaitChangeOptions) (*Change, e
 
 	chgd.Change.data = chgd.Data
 	return &chgd.Change, nil
-}
-
-// getChangeWebsocket creates a websocket connection for the given change ID
-// and websocket ID combination.
-func (client *Client) getChangeWebsocket(changeID, websocketID string) (*websocket.Conn, error) {
-	// Set up a new websocket dialer based on the HTTP client
-	httpClient := client.doer.(*http.Client)
-	httpTransport := httpClient.Transport.(*http.Transport)
-	dialer := websocket.Dialer{
-		NetDial:          httpTransport.Dial,
-		Proxy:            httpTransport.Proxy,
-		TLSClientConfig:  httpTransport.TLSClientConfig,
-		HandshakeTimeout: 5 * time.Second,
-	}
-
-	// Establish the connection
-	url := fmt.Sprintf("ws://localhost/v1/changes/%s/websocket?id=%s", changeID, url.QueryEscape(websocketID))
-	conn, _, err := dialer.Dial(url, nil)
-	if err != nil {
-		return nil, err
-	}
-	return conn, err
 }

--- a/client/exec.go
+++ b/client/exec.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -267,28 +266,39 @@ type WebsocketWriter interface {
 }
 
 type execCommand struct {
-	Command string            `json:"command"`
-	Args    map[string]string `json:"args,omitempty"`
-	Signal  int               `json:"signal,omitempty"`
+	Command string          `json:"command"`
+	Signal  *execSignalArgs `json:"signal,omitempty"`
+	Resize  *execResizeArgs `json:"resize,omitempty"`
 }
 
-// ExecSendTermSize sends a window-resize message to the Exec control websocket.
-func ExecSendTermSize(conn WebsocketWriter, width, height int) error {
+type execSignalArgs struct {
+	Name string `json:"name"`
+}
+
+type execResizeArgs struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+// ExecSendResize sends a resize message to the Exec control websocket.
+func ExecSendResize(conn WebsocketWriter, width, height int) error {
 	msg := execCommand{
-		Command: "window-resize",
-		Args: map[string]string{
-			"width":  strconv.Itoa(width),
-			"height": strconv.Itoa(height),
+		Command: "resize",
+		Resize: &execResizeArgs{
+			Width:  width,
+			Height: height,
 		},
 	}
 	return conn.WriteJSON(msg)
 }
 
-// ExecForwardSignal forwards a signal to the Exec control websocket.
-func ExecForwardSignal(conn WebsocketWriter, signal int) error {
+// ExecSendSignal sends a signal to the Exec control websocket.
+func ExecSendSignal(conn WebsocketWriter, signal string) error {
 	msg := execCommand{
 		Command: "signal",
-		Signal:  signal,
+		Signal: &execSignalArgs{
+			Name: signal,
+		},
 	}
 	return conn.WriteJSON(msg)
 }

--- a/client/exec.go
+++ b/client/exec.go
@@ -74,17 +74,17 @@ type ExecOptions struct {
 
 type execPayload struct {
 	Command     []string          `json:"command"`
-	Environment map[string]string `json:"environment"`
-	WorkingDir  string            `json:"working-dir"`
-	Timeout     string            `json:"timeout"`
-	UserID      *int              `json:"user-id"`
-	User        string            `json:"user"`
-	GroupID     *int              `json:"group-id"`
-	Group       string            `json:"group"`
-	UseTerminal bool              `json:"use-terminal"`
-	SplitStderr bool              `json:"split-stderr"`
-	Width       int               `json:"width"`
-	Height      int               `json:"height"`
+	Environment map[string]string `json:"environment,omitempty"`
+	WorkingDir  string            `json:"working-dir,omitempty"`
+	Timeout     string            `json:"timeout,omitempty"`
+	UserID      *int              `json:"user-id,omitempty"`
+	User        string            `json:"user,omitempty"`
+	GroupID     *int              `json:"group-id,omitempty"`
+	Group       string            `json:"group,omitempty"`
+	UseTerminal bool              `json:"use-terminal,omitempty"`
+	SplitStderr bool              `json:"split-stderr,omitempty"`
+	Width       int               `json:"width,omitempty"`
+	Height      int               `json:"height,omitempty"`
 }
 
 type execResult struct {

--- a/client/exec.go
+++ b/client/exec.go
@@ -83,6 +83,25 @@ type ExecOptions struct {
 	DataDone chan bool
 }
 
+type execPayload struct {
+	Command        []string          `json:"command"`
+	Environment    map[string]string `json:"environment"`
+	WorkingDir     string            `json:"working-dir"`
+	Timeout        string            `json:"timeout"`
+	UserID         *int              `json:"user-id"`
+	User           string            `json:"user"`
+	GroupID        *int              `json:"group-id"`
+	Group          string            `json:"group"`
+	UseTerminal    bool              `json:"use-terminal"`
+	SeparateStderr bool              `json:"separate-stderr"`
+	Width          int               `json:"width"`
+	Height         int               `json:"height"`
+}
+
+type execResult struct {
+	WebsocketIDs map[string]string `json:"websocket-ids"`
+}
+
 // Exec starts a command execution with the given options and additional
 // control arguments, returning the execution's change ID.
 func (client *Client) Exec(opts *ExecOptions) (string, error) {
@@ -98,20 +117,7 @@ func (client *Client) Exec(opts *ExecOptions) (string, error) {
 		timeoutStr = opts.Timeout.String()
 	}
 
-	var payload = struct {
-		Command        []string          `json:"command"`
-		Environment    map[string]string `json:"environment"`
-		WorkingDir     string            `json:"working-dir"`
-		Timeout        string            `json:"timeout"`
-		UserID         *int              `json:"user-id"`
-		User           string            `json:"user"`
-		GroupID        *int              `json:"group-id"`
-		Group          string            `json:"group"`
-		UseTerminal    bool              `json:"use-terminal"`
-		SeparateStderr bool              `json:"separate-stderr"`
-		Width          int               `json:"width"`
-		Height         int               `json:"height"`
-	}{
+	payload := execPayload{
 		Command:        opts.Command,
 		Environment:    opts.Environment,
 		WorkingDir:     opts.WorkingDir,
@@ -137,9 +143,7 @@ func (client *Client) Exec(opts *ExecOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var result struct {
-		WebsocketIDs map[string]string `json:"websocket-ids"`
-	}
+	var result execResult
 	err = json.Unmarshal(resultBytes, &result)
 	if err != nil {
 		return "", err

--- a/client/exec.go
+++ b/client/exec.go
@@ -73,18 +73,18 @@ type ExecOptions struct {
 }
 
 type execPayload struct {
-	Command       []string          `json:"command"`
-	Environment   map[string]string `json:"environment"`
-	WorkingDir    string            `json:"working-dir"`
-	Timeout       string            `json:"timeout"`
-	UserID        *int              `json:"user-id"`
-	User          string            `json:"user"`
-	GroupID       *int              `json:"group-id"`
-	Group         string            `json:"group"`
-	UseTerminal   bool              `json:"use-terminal"`
-	CombineStderr bool              `json:"combine-stderr"`
-	Width         int               `json:"width"`
-	Height        int               `json:"height"`
+	Command     []string          `json:"command"`
+	Environment map[string]string `json:"environment"`
+	WorkingDir  string            `json:"working-dir"`
+	Timeout     string            `json:"timeout"`
+	UserID      *int              `json:"user-id"`
+	User        string            `json:"user"`
+	GroupID     *int              `json:"group-id"`
+	Group       string            `json:"group"`
+	UseTerminal bool              `json:"use-terminal"`
+	SplitStderr bool              `json:"split-stderr"`
+	Width       int               `json:"width"`
+	Height      int               `json:"height"`
 }
 
 type execResult struct {
@@ -124,18 +124,18 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 		timeoutStr = opts.Timeout.String()
 	}
 	payload := execPayload{
-		Command:       opts.Command,
-		Environment:   opts.Environment,
-		WorkingDir:    opts.WorkingDir,
-		Timeout:       timeoutStr,
-		UserID:        opts.UserID,
-		User:          opts.User,
-		GroupID:       opts.GroupID,
-		Group:         opts.Group,
-		UseTerminal:   opts.UseTerminal,
-		CombineStderr: opts.Stderr == nil,
-		Width:         opts.Width,
-		Height:        opts.Height,
+		Command:     opts.Command,
+		Environment: opts.Environment,
+		WorkingDir:  opts.WorkingDir,
+		Timeout:     timeoutStr,
+		UserID:      opts.UserID,
+		User:        opts.User,
+		GroupID:     opts.GroupID,
+		Group:       opts.Group,
+		UseTerminal: opts.UseTerminal,
+		SplitStderr: opts.Stderr != nil,
+		Width:       opts.Width,
+		Height:      opts.Height,
 	}
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(&payload)

--- a/client/exec.go
+++ b/client/exec.go
@@ -220,7 +220,10 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 		}
 
 		// Empty the stdin channel, but don't block on it as stdin may be
-		// stuck in Read.
+		// stuck in Read. This is due to the somewhat poor design of
+		// WebsocketSendStream, which writes to an unbuffered channel
+		// (instead of closing it or using a buffered channel). We'd rather
+		// not modify that package much, so it's closer to the LXD code.
 		go func() {
 			<-stdinDone // happens when reading stdin returns EOF
 		}()

--- a/client/exec.go
+++ b/client/exec.go
@@ -28,12 +28,12 @@ import (
 	"github.com/canonical/pebble/internal/wsutil"
 )
 
-// ExecOptions are the main options for the Exec call.
+// ExecOptions are the options for an Exec call.
 type ExecOptions struct {
-	// Required: command and arguments (first element is the executable)
+	// Required: command and arguments (first element is the executable).
 	Command []string
 
-	// Optional environment variables
+	// Optional environment variables.
 	Environment map[string]string
 
 	// Optional working directory (default is $HOME or "/" if $HOME not set).

--- a/client/exec.go
+++ b/client/exec.go
@@ -73,7 +73,7 @@ type ExecAdditionalArgs struct {
 	Stderr io.Writer
 
 	// Control message handler (for window resizing and signal forwarding)
-	Control func(conn WebsocketConn)
+	Control func(conn WebsocketWriter)
 
 	// Channel that will be closed when all data operations are done
 	DataDone chan bool
@@ -165,7 +165,7 @@ func (client *Client) Exec(opts *ExecOptions, args *ExecAdditionalArgs) (string,
 	} else {
 		// Handle non-terminal executions
 		dones := map[string]chan bool{}
-		conns := []WebsocketConn{}
+		conns := []*websocket.Conn{}
 
 		// Handle stdin and stdout
 		if fds["io"] != "" {
@@ -225,7 +225,7 @@ func (client *Client) Exec(opts *ExecOptions, args *ExecAdditionalArgs) (string,
 
 // getChangeWebsocket creates a websocket connection for the given change ID
 // and websocket ID combination.
-func (client *Client) getChangeWebsocket(changeID, websocketID string) (WebsocketConn, error) {
+func (client *Client) getChangeWebsocket(changeID, websocketID string) (*websocket.Conn, error) {
 	// Set up a new websocket dialer based on the HTTP client
 	httpClient := client.doer.(*http.Client)
 	httpTransport := httpClient.Transport.(*http.Transport)
@@ -245,11 +245,10 @@ func (client *Client) getChangeWebsocket(changeID, websocketID string) (Websocke
 	return conn, err
 }
 
-// WebsocketConn represents a websocket connection for use by this package
-// (and is implemented by *websocket.Conn).
-type WebsocketConn interface {
-	Close() error
-	NextReader() (messageType int, r io.Reader, err error)
+// WebsocketWriter is a websocket writer interface that can write a websocket
+// or a value as JSON, for example, for sending commands to an executing
+// program's "control" websocket.
+type WebsocketWriter interface {
 	WriteMessage(messageType int, data []byte) error
 	WriteJSON(v interface{}) error
 }
@@ -261,7 +260,7 @@ type execCommand struct {
 }
 
 // ExecSendTermSize sends a window-resize message to the Exec control websocket.
-func ExecSendTermSize(conn WebsocketConn, width, height int) error {
+func ExecSendTermSize(conn WebsocketWriter, width, height int) error {
 	msg := execCommand{
 		Command: "window-resize",
 		Args: map[string]string{
@@ -273,7 +272,7 @@ func ExecSendTermSize(conn WebsocketConn, width, height int) error {
 }
 
 // ExecForwardSignal forwards a signal to the Exec control websocket.
-func ExecForwardSignal(conn WebsocketConn, signal int) error {
+func ExecForwardSignal(conn WebsocketWriter, signal int) error {
 	msg := execCommand{
 		Command: "signal",
 		Signal:  signal,

--- a/client/exec.go
+++ b/client/exec.go
@@ -58,9 +58,15 @@ type ExecOptions struct {
 
 	// True to separate the process's stderr into a separate websocket. The
 	// default is to send combined stdout+stderr on a single websocket.
+	//
+	// Note: currently only the combinations Terminal=true, Stderr=false and
+	// Terminal=false, Stderr=true are supported.
 	Stderr bool
 
-	// Initial terminal width and height (only apply if Terminal is true)
+	// Initial terminal width and height (only apply if Terminal is true).
+	// If not specified, the Pebble server uses the target's default (usually
+	// 80x25). When using the "pebble exec" CLI, these are set to the host's
+	// terminal size automatically.
 	Width  int
 	Height int
 }

--- a/client/exec.go
+++ b/client/exec.go
@@ -73,7 +73,7 @@ type ExecAdditionalArgs struct {
 	Stderr io.Writer
 
 	// Control message handler (for window resizing and signal forwarding)
-	Control func(conn *websocket.Conn)
+	Control func(conn WebsocketWriter)
 
 	// Channel that will be closed when all data operations are done
 	DataDone chan bool
@@ -245,10 +245,11 @@ func (client *Client) getChangeWebsocket(changeID, websocketID string) (*websock
 	return conn, err
 }
 
-// JSONWriter is an interface that can write a value as JSON, for example,
-// a *websocket.Conn used for sending commands to an executing program's
-// "control" websocket.
-type JSONWriter interface {
+// WebsocketWriter is a websocket writer interface that can write a websocket
+// or a value as JSON, for example, for sending commands to an executing
+// program's "control" websocket.
+type WebsocketWriter interface {
+	WriteMessage(messageType int, data []byte) error
 	WriteJSON(v interface{}) error
 }
 
@@ -259,7 +260,7 @@ type execCommand struct {
 }
 
 // ExecSendTermSize sends a window-resize message to the Exec control websocket.
-func ExecSendTermSize(conn JSONWriter, width, height int) error {
+func ExecSendTermSize(conn WebsocketWriter, width, height int) error {
 	msg := execCommand{
 		Command: "window-resize",
 		Args: map[string]string{
@@ -271,7 +272,7 @@ func ExecSendTermSize(conn JSONWriter, width, height int) error {
 }
 
 // ExecForwardSignal forwards a signal to the Exec control websocket.
-func ExecForwardSignal(conn JSONWriter, signal int) error {
+func ExecForwardSignal(conn WebsocketWriter, signal int) error {
 	msg := execCommand{
 		Command: "signal",
 		Signal:  signal,

--- a/client/exec.go
+++ b/client/exec.go
@@ -17,7 +17,6 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -105,18 +104,10 @@ type execResult struct {
 // Exec starts a command execution with the given options and additional
 // control arguments, returning the execution's change ID.
 func (client *Client) Exec(opts *ExecOptions) (string, error) {
-	if opts.UseTerminal && opts.SeparateStderr {
-		return "", errors.New("separate stderr not currently supported in terminal mode")
-	}
-	if !opts.UseTerminal && !opts.SeparateStderr {
-		return "", errors.New("combined stderr not currently supported in non-terminal mode")
-	}
-
 	var timeoutStr string
 	if opts.Timeout != 0 {
 		timeoutStr = opts.Timeout.String()
 	}
-
 	payload := execPayload{
 		Command:        opts.Command,
 		Environment:    opts.Environment,

--- a/client/exec.go
+++ b/client/exec.go
@@ -160,8 +160,8 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	if wsIDs["control"] == "" {
 		return nil, fmt.Errorf(`exec response missing "control" websocket`)
 	}
-	if wsIDs["io"] == "" {
-		return nil, fmt.Errorf(`exec response missing "io" websocket`)
+	if wsIDs["stdio"] == "" {
+		return nil, fmt.Errorf(`exec response missing "stdio" websocket`)
 	}
 	if opts.Stderr != nil && wsIDs["stderr"] == "" {
 		return nil, fmt.Errorf(`exec response missing "stderr" websocket`)
@@ -174,9 +174,9 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	}
 
 	// Forward stdin and stdout.
-	ioConn, err := client.getChangeWebsocket(changeID, wsIDs["io"])
+	ioConn, err := client.getChangeWebsocket(changeID, wsIDs["stdio"])
 	if err != nil {
-		return nil, fmt.Errorf(`cannot connect to "io" websocket: %v`, err)
+		return nil, fmt.Errorf(`cannot connect to "stdio" websocket: %v`, err)
 	}
 	_ = wsutil.WebsocketSendStream(ioConn, stdin, -1)
 	stdoutDone := wsutil.WebsocketRecvStream(stdout, ioConn)

--- a/client/exec.go
+++ b/client/exec.go
@@ -258,9 +258,13 @@ func (p *ExecProcess) Wait() error {
 	<-p.writesDone
 
 	var exitCode int
-	err = change.Get("exit-code", &exitCode)
+	if len(change.Tasks) == 0 {
+		return fmt.Errorf("expected exec change to have at least one task")
+	}
+	task := change.Tasks[0]
+	err = task.Get("exit-code", &exitCode)
 	if err != nil {
-		return fmt.Errorf("cannot get exit-code: %v", err)
+		return fmt.Errorf("cannot get exit code: %v", err)
 	}
 	if exitCode != 0 {
 		return &ExitError{exitCode: exitCode}

--- a/client/exec.go
+++ b/client/exec.go
@@ -95,11 +95,16 @@ func (client *Client) Exec(opts *ExecOptions, args *ExecAdditionalArgs) (string,
 		return "", errors.New("combined stderr not currently supported in non-terminal mode")
 	}
 
+	var timeoutStr string
+	if opts.Timeout != 0 {
+		timeoutStr = opts.Timeout.String()
+	}
+
 	var payload = struct {
 		Command     []string          `json:"command"`
 		Environment map[string]string `json:"environment"`
 		WorkingDir  string            `json:"working-dir"`
-		Timeout     time.Duration     `json:"timeout"`
+		Timeout     string            `json:"timeout"`
 		UserID      *int              `json:"user-id"`
 		User        string            `json:"user"`
 		GroupID     *int              `json:"group-id"`
@@ -108,7 +113,20 @@ func (client *Client) Exec(opts *ExecOptions, args *ExecAdditionalArgs) (string,
 		Stderr      bool              `json:"stderr"`
 		Width       int               `json:"width"`
 		Height      int               `json:"height"`
-	}(*opts)
+	}{
+		Command:     opts.Command,
+		Environment: opts.Environment,
+		WorkingDir:  opts.WorkingDir,
+		Timeout:     timeoutStr,
+		UserID:      opts.UserID,
+		User:        opts.User,
+		GroupID:     opts.GroupID,
+		Group:       opts.Group,
+		Terminal:    opts.Terminal,
+		Stderr:      opts.Stderr,
+		Width:       opts.Width,
+		Height:      opts.Height,
+	}
 	var body bytes.Buffer
 	err := json.NewEncoder(&body).Encode(&payload)
 	if err != nil {

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -32,14 +32,14 @@ func (s *execSuite) TestForwardSignal(c *C) {
 	buf := &bytes.Buffer{}
 	w := testWebsocketWriter{buf}
 
-	err := client.ExecForwardSignal(w, 1)
+	err := client.ExecSendSignal(w, "SIGHUP")
 	c.Check(err, IsNil)
-	err = client.ExecForwardSignal(w, 42)
+	err = client.ExecSendSignal(w, "SIGUSR1")
 	c.Check(err, IsNil)
 
 	c.Check(buf.String(), Equals, `
-{"command":"signal","signal":1}
-{"command":"signal","signal":42}
+{"command":"signal","signal":{"name":"SIGHUP"}}
+{"command":"signal","signal":{"name":"SIGUSR1"}}
 `[1:])
 }
 
@@ -47,14 +47,14 @@ func (s *execSuite) TestSendTermSize(c *C) {
 	buf := &bytes.Buffer{}
 	w := testWebsocketWriter{buf}
 
-	err := client.ExecSendTermSize(w, 150, 50)
+	err := client.ExecSendResize(w, 150, 50)
 	c.Check(err, IsNil)
-	err = client.ExecSendTermSize(w, 80, 25)
+	err = client.ExecSendResize(w, 80, 25)
 	c.Check(err, IsNil)
 
 	c.Check(buf.String(), Equals, `
-{"command":"window-resize","args":{"height":"50","width":"150"}}
-{"command":"window-resize","args":{"height":"25","width":"80"}}
+{"command":"resize","resize":{"width":150,"height":50}}
+{"command":"resize","resize":{"width":80,"height":25}}
 `[1:])
 }
 

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -68,8 +68,3 @@ func (w testJSONWriter) WriteJSON(v interface{}) error {
 	encoder := json.NewEncoder(w.w)
 	return encoder.Encode(v)
 }
-
-func (s *execSuite) TestExitCodeNoWait(c *C) {
-	process := &ExecProcess{}
-	c.Check(process.ExitCode(), Equals, -1)
-}

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -29,7 +29,7 @@ var _ = Suite(&execSuite{})
 func (s *execSuite) TestSendSignal(c *C) {
 	buf := &bytes.Buffer{}
 	execution := &Execution{
-		controlWebsocket: testJSONWriter{buf},
+		controlConn: testJSONWriter{buf},
 	}
 
 	err := execution.SendSignal("SIGHUP")
@@ -46,7 +46,7 @@ func (s *execSuite) TestSendSignal(c *C) {
 func (s *execSuite) TestSendResize(c *C) {
 	buf := &bytes.Buffer{}
 	execution := &Execution{
-		controlWebsocket: testJSONWriter{buf},
+		controlConn: testJSONWriter{buf},
 	}
 
 	err := execution.SendResize(150, 50)

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -68,3 +68,8 @@ func (w testJSONWriter) WriteJSON(v interface{}) error {
 	encoder := json.NewEncoder(w.w)
 	return encoder.Encode(v)
 }
+
+func (s *execSuite) TestExitCodeNoWait(c *C) {
+	process := &ExecProcess{}
+	c.Check(process.ExitCode(), Equals, -1)
+}

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -30,7 +30,7 @@ var _ = Suite(&execSuite{})
 
 func (s *execSuite) TestForwardSignal(c *C) {
 	buf := &bytes.Buffer{}
-	w := testWebsocketConn{w: buf}
+	w := testWebsocketWriter{buf}
 
 	err := client.ExecForwardSignal(w, 1)
 	c.Check(err, IsNil)
@@ -45,7 +45,7 @@ func (s *execSuite) TestForwardSignal(c *C) {
 
 func (s *execSuite) TestSendTermSize(c *C) {
 	buf := &bytes.Buffer{}
-	w := testWebsocketConn{w: buf}
+	w := testWebsocketWriter{buf}
 
 	err := client.ExecSendTermSize(w, 150, 50)
 	c.Check(err, IsNil)
@@ -58,12 +58,15 @@ func (s *execSuite) TestSendTermSize(c *C) {
 `[1:])
 }
 
-type testWebsocketConn struct {
+type testWebsocketWriter struct {
 	w io.Writer
-	client.WebsocketConn
 }
 
-func (w testWebsocketConn) WriteJSON(v interface{}) error {
+func (w testWebsocketWriter) WriteMessage(messageType int, data []byte) error {
+	panic("not implemented")
+}
+
+func (w testWebsocketWriter) WriteJSON(v interface{}) error {
 	encoder := json.NewEncoder(w.w)
 	return encoder.Encode(v)
 }

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -30,7 +30,7 @@ var _ = Suite(&execSuite{})
 
 func (s *execSuite) TestForwardSignal(c *C) {
 	buf := &bytes.Buffer{}
-	w := testWebsocketWriter{buf}
+	w := testWebsocketConn{w: buf}
 
 	err := client.ExecForwardSignal(w, 1)
 	c.Check(err, IsNil)
@@ -45,7 +45,7 @@ func (s *execSuite) TestForwardSignal(c *C) {
 
 func (s *execSuite) TestSendTermSize(c *C) {
 	buf := &bytes.Buffer{}
-	w := testWebsocketWriter{buf}
+	w := testWebsocketConn{w: buf}
 
 	err := client.ExecSendTermSize(w, 150, 50)
 	c.Check(err, IsNil)
@@ -58,15 +58,12 @@ func (s *execSuite) TestSendTermSize(c *C) {
 `[1:])
 }
 
-type testWebsocketWriter struct {
+type testWebsocketConn struct {
 	w io.Writer
+	client.WebsocketConn
 }
 
-func (w testWebsocketWriter) WriteMessage(messageType int, data []byte) error {
-	panic("not implemented")
-}
-
-func (w testWebsocketWriter) WriteJSON(v interface{}) error {
+func (w testWebsocketConn) WriteJSON(v interface{}) error {
 	encoder := json.NewEncoder(w.w)
 	return encoder.Encode(v)
 }

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -28,13 +28,13 @@ var _ = Suite(&execSuite{})
 
 func (s *execSuite) TestSendSignal(c *C) {
 	buf := &bytes.Buffer{}
-	execution := &Execution{
+	process := &ExecProcess{
 		controlConn: testJSONWriter{buf},
 	}
 
-	err := execution.SendSignal("SIGHUP")
+	err := process.SendSignal("SIGHUP")
 	c.Check(err, IsNil)
-	err = execution.SendSignal("SIGUSR1")
+	err = process.SendSignal("SIGUSR1")
 	c.Check(err, IsNil)
 
 	c.Check(buf.String(), Equals, `
@@ -45,13 +45,13 @@ func (s *execSuite) TestSendSignal(c *C) {
 
 func (s *execSuite) TestSendResize(c *C) {
 	buf := &bytes.Buffer{}
-	execution := &Execution{
+	process := &ExecProcess{
 		controlConn: testJSONWriter{buf},
 	}
 
-	err := execution.SendResize(150, 50)
+	err := process.SendResize(150, 50)
 	c.Check(err, IsNil)
-	err = execution.SendResize(80, 25)
+	err = process.SendResize(80, 25)
 	c.Check(err, IsNil)
 
 	c.Check(buf.String(), Equals, `

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -30,7 +30,7 @@ var _ = Suite(&execSuite{})
 
 func (s *execSuite) TestForwardSignal(c *C) {
 	buf := &bytes.Buffer{}
-	w := testJSONWriter{buf}
+	w := testWebsocketWriter{buf}
 
 	err := client.ExecForwardSignal(w, 1)
 	c.Check(err, IsNil)
@@ -45,7 +45,7 @@ func (s *execSuite) TestForwardSignal(c *C) {
 
 func (s *execSuite) TestSendTermSize(c *C) {
 	buf := &bytes.Buffer{}
-	w := testJSONWriter{buf}
+	w := testWebsocketWriter{buf}
 
 	err := client.ExecSendTermSize(w, 150, 50)
 	c.Check(err, IsNil)
@@ -58,11 +58,15 @@ func (s *execSuite) TestSendTermSize(c *C) {
 `[1:])
 }
 
-type testJSONWriter struct {
+type testWebsocketWriter struct {
 	w io.Writer
 }
 
-func (w testJSONWriter) WriteJSON(v interface{}) error {
+func (w testWebsocketWriter) WriteMessage(messageType int, data []byte) error {
+	panic("not implemented")
+}
+
+func (w testWebsocketWriter) WriteJSON(v interface{}) error {
 	encoder := json.NewEncoder(w.w)
 	return encoder.Encode(v)
 }

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -185,7 +185,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 		return errors.New(change.Err)
 	}
 	var exitCode int
-	err = change.Get("return", &exitCode)
+	err = change.Get("exit-code", &exitCode)
 	if err != nil {
 		return err
 	}

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -161,7 +161,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-		Control: func(conn client.WebsocketConn) {
+		Control: func(conn client.WebsocketWriter) {
 			execControlHandler(conn, terminal)
 		},
 		DataDone: make(chan bool),
@@ -206,7 +206,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 	return nil
 }
 
-func execControlHandler(control client.WebsocketConn, terminal bool) {
+func execControlHandler(control client.WebsocketWriter, terminal bool) {
 	ch := make(chan os.Signal, 10)
 	signal.Notify(ch,
 		unix.SIGWINCH, unix.SIGHUP,

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -190,14 +190,14 @@ func (cmd *cmdExec) Execute(args []string) error {
 	if change.Err != "" {
 		return errors.New(change.Err)
 	}
-	var returnCode int
-	err = change.Get("return", &returnCode)
+	var exitCode int
+	err = change.Get("return", &exitCode)
 	if err != nil {
 		return err
 	}
-	if returnCode != 0 {
-		logger.Debugf("Process exited with return code %d", returnCode)
-		panic(&exitStatus{returnCode})
+	if exitCode != 0 {
+		logger.Debugf("Process exited with return code %d", exitCode)
+		return &exitStatus{exitCode}
 	}
 
 	// Wait for any remaining I/O to be flushed

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -162,7 +162,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 		return nil
 	case *client.ExitError:
 		logger.Debugf("Process exited with return code %d", e.ExitCode())
-		return &exitStatus{e.ExitCode()}
+		panic(&exitStatus{e.ExitCode()})
 	default:
 		return err
 	}

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -224,7 +224,7 @@ func execControlHandler(control client.WebsocketWriter, terminal bool) {
 				break
 			}
 			logger.Debugf("Window size is now: %dx%d", width, height)
-			err = client.ExecSendTermSize(control, width, height)
+			err = client.ExecSendResize(control, width, height)
 			if err != nil {
 				logger.Debugf("Error setting terminal size: %v", err)
 				break
@@ -233,9 +233,9 @@ func execControlHandler(control client.WebsocketWriter, terminal bool) {
 			file, err := os.OpenFile("/dev/tty", os.O_RDONLY|unix.O_NOCTTY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0666)
 			if err == nil {
 				file.Close()
-				err = client.ExecForwardSignal(control, int(unix.SIGHUP))
+				err = client.ExecSendSignal(control, "SIGHUP")
 			} else {
-				err = client.ExecForwardSignal(control, int(unix.SIGTERM))
+				err = client.ExecSendSignal(control, "SIGTERM")
 				sig = unix.SIGTERM
 			}
 			logger.Debugf("Received '%s' signal, forwarding to executing program", sig)
@@ -247,7 +247,7 @@ func execControlHandler(control client.WebsocketWriter, terminal bool) {
 			unix.SIGTSTP, unix.SIGTTIN, unix.SIGTTOU, unix.SIGUSR1,
 			unix.SIGUSR2, unix.SIGSEGV, unix.SIGCONT:
 			logger.Debugf("Received '%s signal', forwarding to executing program", sig)
-			err := client.ExecForwardSignal(control, int(sig.(unix.Signal)))
+			err := client.ExecSendSignal(control, unix.SignalName(sig.(unix.Signal)))
 			if err != nil {
 				logger.Debugf("Failed to forward signal '%s': %v", sig, err)
 				break

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -144,21 +144,22 @@ func (cmd *cmdExec) Execute(args []string) error {
 
 	// Start the command.
 	opts := &client.ExecOptions{
-		Command:       command,
-		Environment:   env,
-		WorkingDir:    cmd.WorkingDir,
-		Timeout:       cmd.Timeout,
-		User:          user,
-		UserID:        userID,
-		Group:         group,
-		GroupID:       groupID,
-		UseTerminal:   useTerminal,
-		CombineStderr: useTerminal,
-		Width:         width,
-		Height:        height,
-		Stdin:         os.Stdin,
-		Stdout:        os.Stdout,
-		Stderr:        os.Stderr,
+		Command:     command,
+		Environment: env,
+		WorkingDir:  cmd.WorkingDir,
+		Timeout:     cmd.Timeout,
+		User:        user,
+		UserID:      userID,
+		Group:       group,
+		GroupID:     groupID,
+		UseTerminal: useTerminal,
+		Width:       width,
+		Height:      height,
+		Stdin:       os.Stdin,
+		Stdout:      os.Stdout,
+	}
+	if !useTerminal {
+		opts.Stderr = os.Stderr
 	}
 	process, err := cmd.client.Exec(opts)
 	if err != nil {

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -173,16 +173,15 @@ func (cmd *cmdExec) Execute(args []string) error {
 
 	// Wait for the command to finish.
 	err = process.Wait()
-	if err != nil {
+	switch e := err.(type) {
+	case nil:
+		return nil
+	case *client.ExitError:
+		logger.Debugf("Process exited with return code %d", e.ExitCode())
+		return &exitStatus{e.ExitCode()}
+	default:
 		return err
 	}
-	exitCode := process.ExitCode()
-	if exitCode != 0 {
-		logger.Debugf("Process exited with return code %d", exitCode)
-		return &exitStatus{exitCode}
-	}
-
-	return nil
 }
 
 func execControlHandler(process *client.ExecProcess, useTerminal bool, done <-chan struct{}) {

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -54,12 +54,12 @@ var execDescs = map[string]string{
 	"T":       "Disable pseudo-terminal allocation",
 }
 
-var shortExecHelp = "Execute a command and wait for it to finish"
+var shortExecHelp = "Execute a remote command and wait for it to finish"
 var longExecHelp = `
-The exec command executes a command via the Pebble API and waits for it to
-finish. Stdin is forwarded, and stdout and stderr are received. By default,
-exec's terminal mode is used if the terminal is a TTY (use -t or -T to
-override).
+The exec command runs a remote command and waits for it to finish. The local
+stdin is sent as the input to the remote process, while the remote stdout and
+stderr are output locally. By default, exec allocates a pseudo-terminal on the
+remote if the local stdin and stdout are terminals (use -t or -T to override).
 
 To avoid confusion, exec options may be separated from the command and its
 arguments using "--", for example:

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -193,13 +193,13 @@ func execControlHandler(process *client.ExecProcess, useTerminal bool, done <-ch
 			logger.Debugf("Received '%s signal', updating window geometry", sig)
 			width, height, err := ptyutil.GetSize(unix.Stdout)
 			if err != nil {
-				logger.Debugf("Error getting terminal size: %v", err)
+				logger.Debugf("Cannot get terminal size: %v", err)
 				break
 			}
 			logger.Debugf("Window size is now: %dx%d", width, height)
 			err = process.SendResize(width, height)
 			if err != nil {
-				logger.Debugf("Error setting terminal size: %v", err)
+				logger.Debugf("Cannot set terminal size: %v", err)
 				break
 			}
 		case unix.SIGHUP:
@@ -213,16 +213,16 @@ func execControlHandler(process *client.ExecProcess, useTerminal bool, done <-ch
 			}
 			logger.Debugf("Received '%s' signal, forwarding to executing program", sig)
 			if err != nil {
-				logger.Debugf("Failed to forward signal '%s': %v", sig, err)
+				logger.Debugf("Cannot forward signal '%s': %v", sig, err)
 				return
 			}
 		case unix.SIGTERM, unix.SIGINT, unix.SIGQUIT, unix.SIGABRT,
 			unix.SIGTSTP, unix.SIGTTIN, unix.SIGTTOU, unix.SIGUSR1,
 			unix.SIGUSR2, unix.SIGSEGV, unix.SIGCONT:
-			logger.Debugf("Received '%s signal', forwarding to executing program", sig)
+			logger.Debugf("Received '%s' signal, forwarding to executing program", sig)
 			err := process.SendSignal(unix.SignalName(sig.(unix.Signal)))
 			if err != nil {
-				logger.Debugf("Failed to forward signal '%s': %v", sig, err)
+				logger.Debugf("Cannot forward signal '%s': %v", sig, err)
 				break
 			}
 		}

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -53,16 +53,15 @@ var execDescs = map[string]string{
 	"gid":     "Group ID to run command as",
 	"group":   "Group name to run command as (group's GID must match gid if both present)",
 	"timeout": "Timeout after which to terminate command",
-	"t":       "Force pseudo-terminal allocation",
-	"T":       "Disable pseudo-terminal allocation",
+	"t":       "Allocate remote pseudo-terminal (default if stdin and stdout are TTYs)",
+	"T":       "Disable remote pseudo-terminal allocation",
 }
 
 var shortExecHelp = "Execute a remote command and wait for it to finish"
 var longExecHelp = `
 The exec command runs a remote command and waits for it to finish. The local
 stdin is sent as the input to the remote process, while the remote stdout and
-stderr are output locally. By default, exec allocates a pseudo-terminal on the
-remote if the local stdin and stdout are terminals (use -t or -T to override).
+stderr are output locally.
 
 To avoid confusion, exec options may be separated from the command and its
 arguments using "--", for example:

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -202,23 +202,9 @@ func execControlHandler(process *client.ExecProcess, useTerminal bool, done <-ch
 				logger.Debugf("Cannot set terminal size: %v", err)
 				break
 			}
-		case unix.SIGHUP:
-			file, err := os.OpenFile("/dev/tty", os.O_RDONLY|unix.O_NOCTTY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0666)
-			if err == nil {
-				file.Close()
-				err = process.SendSignal("SIGHUP")
-			} else {
-				err = process.SendSignal("SIGTERM")
-				sig = unix.SIGTERM
-			}
-			logger.Debugf("Received '%s' signal, forwarding to executing program", sig)
-			if err != nil {
-				logger.Debugf("Cannot forward signal '%s': %v", sig, err)
-				return
-			}
-		case unix.SIGTERM, unix.SIGINT, unix.SIGQUIT, unix.SIGABRT,
-			unix.SIGTSTP, unix.SIGTTIN, unix.SIGTTOU, unix.SIGUSR1,
-			unix.SIGUSR2, unix.SIGSEGV, unix.SIGCONT:
+		case unix.SIGHUP, unix.SIGTERM, unix.SIGINT, unix.SIGQUIT,
+			unix.SIGABRT, unix.SIGTSTP, unix.SIGTTIN, unix.SIGTTOU,
+			unix.SIGUSR1, unix.SIGUSR2, unix.SIGSEGV, unix.SIGCONT:
 			logger.Debugf("Received '%s' signal, forwarding to executing program", sig)
 			err := process.SendSignal(unix.SignalName(sig.(unix.Signal)))
 			if err != nil {

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -161,7 +161,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-		Control: func(conn *websocket.Conn) {
+		Control: func(conn client.WebsocketWriter) {
 			execControlHandler(conn, terminal)
 		},
 		DataDone: make(chan bool),
@@ -206,7 +206,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 	return nil
 }
 
-func execControlHandler(control *websocket.Conn, terminal bool) {
+func execControlHandler(control client.WebsocketWriter, terminal bool) {
 	ch := make(chan os.Signal, 10)
 	signal.Notify(ch,
 		unix.SIGWINCH, unix.SIGHUP,

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -161,7 +161,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-		Control: func(conn client.WebsocketWriter) {
+		Control: func(conn client.WebsocketConn) {
 			execControlHandler(conn, terminal)
 		},
 		DataDone: make(chan bool),
@@ -206,7 +206,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 	return nil
 }
 
-func execControlHandler(control client.WebsocketWriter, terminal bool) {
+func execControlHandler(control client.WebsocketConn, terminal bool) {
 	ch := make(chan os.Signal, 10)
 	signal.Notify(ch,
 		unix.SIGWINCH, unix.SIGHUP,

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -32,34 +32,34 @@ import (
 
 type cmdExec struct {
 	clientMixin
-	WorkingDir string        `long:"cwd"`
+	WorkingDir string        `short:"w"`
 	Env        []string      `long:"env"`
 	User       string        `long:"user"`
 	Group      string        `long:"group"`
 	Timeout    time.Duration `long:"timeout"`
-	Terminal   bool          `short:"t" long:"terminal"`
-	NoTerminal bool          `short:"T" long:"no-terminal"`
+	Terminal   bool          `short:"t"`
+	NoTerminal bool          `short:"T"`
 	Positional struct {
 		Command string `positional-arg-name:"<command>" required:"1"`
 	} `positional-args:"yes"`
 }
 
 var execDescs = map[string]string{
-	"cwd":         "Working directory to run command in",
-	"env":         "Environment variable to set (in 'FOO=bar' format)",
-	"user":        "User name or ID to run command as",
-	"group":       "Group name or ID to run command as",
-	"timeout":     "Timeout after which to terminate command",
-	"terminal":    "Force pseudo-terminal allocation",
-	"no-terminal": "Disable pseudo-terminal allocation",
+	"w":       "Working directory to run command in",
+	"env":     "Environment variable to set (in 'FOO=bar' format)",
+	"user":    "User name or ID to run command as",
+	"group":   "Group name or ID to run command as",
+	"timeout": "Timeout after which to terminate command",
+	"t":       "Force pseudo-terminal allocation",
+	"T":       "Disable pseudo-terminal allocation",
 }
 
 var shortExecHelp = "Execute a command and wait for it to finish"
 var longExecHelp = `
 The exec command executes a command via the Pebble API and waits for it to
 finish. Stdin is forwarded, and stdout and stderr are received. By default,
-exec's terminal mode is used if the terminal is a TTY (use -t/--terminal or
--T/--no-terminal to override).
+exec's terminal mode is used if the terminal is a TTY (use -t or -T to
+override).
 
 To avoid confusion, exec options may be separated from the command and its
 arguments using "--", for example:

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -141,7 +141,8 @@ func (cmd *cmdExec) Execute(args []string) error {
 		Stdin:       os.Stdin,
 		Stdout:      os.Stdout,
 	}
-	if !useTerminal {
+	stderrIsTerminal := ptyutil.IsTerminal(unix.Stderr)
+	if !stdoutIsTerminal || !stderrIsTerminal {
 		opts.Stderr = os.Stderr
 	}
 	process, err := cmd.client.Exec(opts)

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -181,12 +181,6 @@ func (cmd *cmdExec) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	if !change.Ready {
-		// This case shouldn't happen (because the change should either be ready,
-		// or if a timeout was specified it will apply at the Exec level and the
-		// change will be Ready but in an error state), but handle just in case.
-		return errors.New("command unexpectedly not finished after waiting for change")
-	}
 	if change.Err != "" {
 		return errors.New(change.Err)
 	}

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -144,21 +144,21 @@ func (cmd *cmdExec) Execute(args []string) error {
 
 	// Start the command.
 	opts := &client.ExecOptions{
-		Command:        command,
-		Environment:    env,
-		WorkingDir:     cmd.WorkingDir,
-		Timeout:        cmd.Timeout,
-		User:           user,
-		UserID:         userID,
-		Group:          group,
-		GroupID:        groupID,
-		UseTerminal:    useTerminal,
-		SeparateStderr: !useTerminal,
-		Width:          width,
-		Height:         height,
-		Stdin:          os.Stdin,
-		Stdout:         os.Stdout,
-		Stderr:         os.Stderr,
+		Command:       command,
+		Environment:   env,
+		WorkingDir:    cmd.WorkingDir,
+		Timeout:       cmd.Timeout,
+		User:          user,
+		UserID:        userID,
+		Group:         group,
+		GroupID:       groupID,
+		UseTerminal:   useTerminal,
+		CombineStderr: useTerminal,
+		Width:         width,
+		Height:        height,
+		Stdin:         os.Stdin,
+		Stdout:        os.Stdout,
+		Stderr:        os.Stderr,
 	}
 	process, err := cmd.client.Exec(opts)
 	if err != nil {

--- a/cmd/pebble/cmd_exec.go
+++ b/cmd/pebble/cmd_exec.go
@@ -172,10 +172,11 @@ func (cmd *cmdExec) Execute(args []string) error {
 	go execControlHandler(process, useTerminal, done)
 
 	// Wait for the command to finish.
-	exitCode, err := process.Wait()
+	err = process.Wait()
 	if err != nil {
 		return err
 	}
+	exitCode := process.ExitCode()
 	if exitCode != 0 {
 		logger.Debugf("Process exited with return code %d", exitCode)
 		return &exitStatus{exitCode}

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -179,7 +179,7 @@ var helpCategories = []helpCategory{{
 	Commands:    []string{"changes", "tasks"},
 }, {
 	Label:       "Command execution",
-	Description: "execute a command",
+	Description: "run a command remotely",
 	Commands:    []string{"exec"},
 }, {
 	Label:       "Other",

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -168,7 +168,7 @@ type helpCategory struct {
 var helpCategories = []helpCategory{{
 	Label:       "Basics",
 	Description: "basic management",
-	Commands:    []string{"run", "autostart", "start", "stop", "services", "logs"},
+	Commands:    []string{"run", "autostart", "start", "stop", "exec", "services", "logs"},
 }, {
 	Label:       "Configuration",
 	Description: "manage configuration",
@@ -177,10 +177,6 @@ var helpCategories = []helpCategory{{
 	Label:       "Changes",
 	Description: "view changes and tasks",
 	Commands:    []string{"changes", "tasks"},
-}, {
-	Label:       "Command execution",
-	Description: "run a command remotely",
-	Commands:    []string{"exec"},
 }, {
 	Label:       "Other",
 	Description: "other commands",

--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -72,7 +72,8 @@ func (rcmd *cmdRun) Execute(args []string) error {
 			// This exit code must be in system'd SuccessExitStatus.
 			panic(&exitStatus{42})
 		}
-		return fmt.Errorf("cannot run pebble: %v", err)
+		fmt.Fprintf(os.Stderr, "cannot run pebble: %v\n", err)
+		panic(&exitStatus{1})
 	}
 
 	return nil

--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -70,10 +70,10 @@ func (rcmd *cmdRun) Execute(args []string) error {
 			// No "error: " prefix as this isn't an error.
 			fmt.Fprintf(os.Stdout, "%v\n", err)
 			// This exit code must be in system'd SuccessExitStatus.
-			panic(&exitStatus{42})
+			return &exitStatus{42}
 		}
 		fmt.Fprintf(os.Stderr, "cannot run pebble: %v\n", err)
-		panic(&exitStatus{1})
+		return &exitStatus{1}
 	}
 
 	return nil

--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -70,10 +70,9 @@ func (rcmd *cmdRun) Execute(args []string) error {
 			// No "error: " prefix as this isn't an error.
 			fmt.Fprintf(os.Stdout, "%v\n", err)
 			// This exit code must be in system'd SuccessExitStatus.
-			return &exitStatus{42}
+			panic(&exitStatus{42})
 		}
-		fmt.Fprintf(os.Stderr, "cannot run pebble: %v\n", err)
-		return &exitStatus{1}
+		return fmt.Errorf("cannot run pebble: %v", err)
 	}
 
 	return nil

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -321,11 +321,19 @@ func main() {
 	}()
 
 	if err := run(); err != nil {
+		var status *exitStatus
+		if errors.As(err, &status) {
+			os.Exit(status.code)
+		}
 		fmt.Fprintf(Stderr, errorPrefix+"%v\n", err)
 		os.Exit(1)
 	}
 }
 
+// exitStatus can be returned as an error from commands to have Pebble exit
+// with the given exit code. Pebble's main function also recovers from a
+// panic(&exitStatus{code}), for the rare cases when an error return is not
+// possible.
 type exitStatus struct {
 	code int
 }

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -327,7 +327,7 @@ func main() {
 }
 
 // exitStatus can be used in panic(&exitStatus{code}) to cause Pebble's main
-// function to exit with a given status code, for the rare cases when you want
+// function to exit with a given exit code, for the rare cases when you want
 // to return an exit code other than 0 or 1, or when an error return is not
 // possible.
 type exitStatus struct {

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -321,18 +321,14 @@ func main() {
 	}()
 
 	if err := run(); err != nil {
-		var status *exitStatus
-		if errors.As(err, &status) {
-			os.Exit(status.code)
-		}
 		fmt.Fprintf(Stderr, errorPrefix+"%v\n", err)
 		os.Exit(1)
 	}
 }
 
-// exitStatus can be returned as an error from commands to have Pebble exit
-// with the given exit code. Pebble's main function also recovers from a
-// panic(&exitStatus{code}), for the rare cases when an error return is not
+// exitStatus can be used in panic(&exitStatus{code}) to cause Pebble's main
+// function to exit with a given status code, for the rare cases when you want
+// to return an exit code other than 0 or 1, or when an error return is not
 // possible.
 type exitStatus struct {
 	code int

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -46,10 +46,6 @@ var api = []*Command{{
 	UserOK: true,
 	GET:    v1GetChangeWait,
 }, {
-	Path:   "/v1/changes/{id}/websocket",
-	UserOK: true,
-	GET:    v1GetChangeWebsocket,
-}, {
 	Path:   "/v1/services",
 	UserOK: true,
 	GET:    v1GetServices,
@@ -80,6 +76,10 @@ var api = []*Command{{
 	Path:   "/v1/exec",
 	UserOK: true,
 	POST:   v1PostExec,
+}, {
+	Path:   "/v1/tasks/{task-id}/websocket/{websocket-id}",
+	UserOK: true,
+	GET:    v1GetTaskWebsocket,
 }}
 
 var (

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -256,7 +256,7 @@ type websocketResponse struct {
 }
 
 func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	err := wr.connect(wr.change, wr.websocketID, r, w)
+	err := wr.connect(r, w, wr.change, wr.websocketID)
 	if errors.Is(err, os.ErrNotExist) {
 		rsp := statusNotFound("websocket not found")
 		rsp.ServeHTTP(w, r)
@@ -271,7 +271,7 @@ func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// the websocket protocol.
 }
 
-type connectFunc func(change *state.Change, websocketID string, r *http.Request, w http.ResponseWriter) error
+type connectFunc func(r *http.Request, w http.ResponseWriter, change *state.Change, websocketID string) error
 
 // connectFuncs maps change kind to websocket connect function.
 var connectFuncs = map[string]connectFunc{

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -48,6 +48,8 @@ type taskInfo struct {
 
 	SpawnTime time.Time  `json:"spawn-time,omitempty"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
+
+	Data map[string]*json.RawMessage `json:"data,omitempty"`
 }
 
 type taskInfoProgress struct {
@@ -97,16 +99,14 @@ func change2changeInfo(chg *state.Change) *changeInfo {
 		if !readyTime.IsZero() {
 			taskInfo.ReadyTime = &readyTime
 		}
-		taskInfos[j] = taskInfo
-
 		var data map[string]*json.RawMessage
 		if t.Get("api-data", &data) == nil {
-			chgInfo.Data = data
+			taskInfo.Data = data
 		}
+		taskInfos[j] = taskInfo
 	}
 	chgInfo.Tasks = taskInfos
 
-	// If change's "api-data" is set, that overrides any task "api-data".
 	var data map[string]*json.RawMessage
 	if chg.Get("api-data", &data) == nil {
 		chgInfo.Data = data

--- a/internal/daemon/api_changes.go
+++ b/internal/daemon/api_changes.go
@@ -258,12 +258,12 @@ type websocketResponse struct {
 func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := wr.connect(r, w, wr.change, wr.websocketID)
 	if errors.Is(err, os.ErrNotExist) {
-		rsp := statusNotFound("websocket not found")
+		rsp := statusNotFound("cannot find websocket with id %q", wr.websocketID)
 		rsp.ServeHTTP(w, r)
 		return
 	}
 	if err != nil {
-		rsp := statusInternalError("%v", err)
+		rsp := statusInternalError("cannot connect to websocket: %v", err)
 		rsp.ServeHTTP(w, r)
 		return
 	}

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -202,6 +202,8 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 	ids := setupChanges(st)
 	chg := st.Change(ids[0])
 	chg.Set("api-data", map[string]int{"n": 42})
+	task := chg.Tasks()[0]
+	task.Set("api-data", map[string]string{"foo": "bar"})
 	st.Unlock()
 	s.vars = map[string]string{"id": ids[0]}
 
@@ -239,6 +241,9 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
 				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
+				"data": map[string]interface{}{
+					"foo": "bar",
+				},
 			},
 			map[string]interface{}{
 				"id":         ids[3],

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -48,12 +48,6 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	if len(payload.Command) < 1 {
 		return statusBadRequest("must specify command")
 	}
-	if payload.UseTerminal && payload.SeparateStderr {
-		return statusBadRequest("separate stderr not currently supported in terminal mode")
-	}
-	if !payload.UseTerminal && !payload.SeparateStderr {
-		return statusBadRequest("combined stderr not currently supported in non-terminal mode")
-	}
 
 	var timeout time.Duration
 	if payload.Timeout != "" {

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -25,18 +25,18 @@ import (
 )
 
 type execPayload struct {
-	Command       []string          `json:"command"`
-	Environment   map[string]string `json:"environment"`
-	WorkingDir    string            `json:"working-dir"`
-	Timeout       string            `json:"timeout"`
-	UserID        *int              `json:"user-id"`
-	User          string            `json:"user"`
-	GroupID       *int              `json:"group-id"`
-	Group         string            `json:"group"`
-	UseTerminal   bool              `json:"use-terminal"`
-	CombineStderr bool              `json:"combine-stderr"`
-	Width         int               `json:"width"`
-	Height        int               `json:"height"`
+	Command     []string          `json:"command"`
+	Environment map[string]string `json:"environment"`
+	WorkingDir  string            `json:"working-dir"`
+	Timeout     string            `json:"timeout"`
+	UserID      *int              `json:"user-id"`
+	User        string            `json:"user"`
+	GroupID     *int              `json:"group-id"`
+	Group       string            `json:"group"`
+	UseTerminal bool              `json:"use-terminal"`
+	SplitStderr bool              `json:"split-stderr"`
+	Width       int               `json:"width"`
+	Height      int               `json:"height"`
 }
 
 func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
@@ -75,16 +75,16 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	defer st.Unlock()
 
 	args := &cmdstate.ExecArgs{
-		Command:       payload.Command,
-		Environment:   payload.Environment,
-		WorkingDir:    payload.WorkingDir,
-		Timeout:       timeout,
-		UserID:        uid,
-		GroupID:       gid,
-		UseTerminal:   payload.UseTerminal,
-		CombineStderr: payload.CombineStderr,
-		Width:         payload.Width,
-		Height:        payload.Height,
+		Command:     payload.Command,
+		Environment: payload.Environment,
+		WorkingDir:  payload.WorkingDir,
+		Timeout:     timeout,
+		UserID:      uid,
+		GroupID:     gid,
+		UseTerminal: payload.UseTerminal,
+		SplitStderr: payload.SplitStderr,
+		Width:       payload.Width,
+		Height:      payload.Height,
 	}
 	change, metadata, err := cmdstate.Exec(st, args)
 	if err != nil {

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -25,18 +25,18 @@ import (
 )
 
 type execPayload struct {
-	Command        []string          `json:"command"`
-	Environment    map[string]string `json:"environment"`
-	WorkingDir     string            `json:"working-dir"`
-	Timeout        string            `json:"timeout"`
-	UserID         *int              `json:"user-id"`
-	User           string            `json:"user"`
-	GroupID        *int              `json:"group-id"`
-	Group          string            `json:"group"`
-	UseTerminal    bool              `json:"use-terminal"`
-	SeparateStderr bool              `json:"separate-stderr"`
-	Width          int               `json:"width"`
-	Height         int               `json:"height"`
+	Command       []string          `json:"command"`
+	Environment   map[string]string `json:"environment"`
+	WorkingDir    string            `json:"working-dir"`
+	Timeout       string            `json:"timeout"`
+	UserID        *int              `json:"user-id"`
+	User          string            `json:"user"`
+	GroupID       *int              `json:"group-id"`
+	Group         string            `json:"group"`
+	UseTerminal   bool              `json:"use-terminal"`
+	CombineStderr bool              `json:"combine-stderr"`
+	Width         int               `json:"width"`
+	Height        int               `json:"height"`
 }
 
 func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
@@ -75,16 +75,16 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	defer st.Unlock()
 
 	args := &cmdstate.ExecArgs{
-		Command:        payload.Command,
-		Environment:    payload.Environment,
-		WorkingDir:     payload.WorkingDir,
-		Timeout:        timeout,
-		UserID:         uid,
-		GroupID:        gid,
-		UseTerminal:    payload.UseTerminal,
-		SeparateStderr: payload.SeparateStderr,
-		Width:          payload.Width,
-		Height:         payload.Height,
+		Command:       payload.Command,
+		Environment:   payload.Environment,
+		WorkingDir:    payload.WorkingDir,
+		Timeout:       timeout,
+		UserID:        uid,
+		GroupID:       gid,
+		UseTerminal:   payload.UseTerminal,
+		CombineStderr: payload.CombineStderr,
+		Width:         payload.Width,
+		Height:        payload.Height,
 	}
 	change, metadata, err := cmdstate.Exec(st, args)
 	if err != nil {

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -24,21 +24,23 @@ import (
 	"github.com/canonical/pebble/internal/overlord/cmdstate"
 )
 
+type execPayload struct {
+	Command        []string          `json:"command"`
+	Environment    map[string]string `json:"environment"`
+	WorkingDir     string            `json:"working-dir"`
+	Timeout        string            `json:"timeout"`
+	UserID         *int              `json:"user-id"`
+	User           string            `json:"user"`
+	GroupID        *int              `json:"group-id"`
+	Group          string            `json:"group"`
+	UseTerminal    bool              `json:"use-terminal"`
+	SeparateStderr bool              `json:"separate-stderr"`
+	Width          int               `json:"width"`
+	Height         int               `json:"height"`
+}
+
 func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
-	var payload struct {
-		Command        []string          `json:"command"`
-		Environment    map[string]string `json:"environment"`
-		WorkingDir     string            `json:"working-dir"`
-		Timeout        string            `json:"timeout"`
-		UserID         *int              `json:"user-id"`
-		User           string            `json:"user"`
-		GroupID        *int              `json:"group-id"`
-		Group          string            `json:"group"`
-		UseTerminal    bool              `json:"use-terminal"`
-		SeparateStderr bool              `json:"separate-stderr"`
-		Width          int               `json:"width"`
-		Height         int               `json:"height"`
-	}
+	var payload execPayload
 	decoder := json.NewDecoder(req.Body)
 	if err := decoder.Decode(&payload); err != nil {
 		return statusBadRequest("cannot decode request body: %v", err)

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -100,10 +100,9 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	stateEnsureBefore(st, 0) // start it right away
 
 	result := map[string]interface{}{
-		"environment":   metadata.Environment,
-		"task-id":       metadata.TaskID,
-		"websocket-ids": metadata.WebsocketIDs,
-		"working-dir":   metadata.WorkingDir,
+		"environment": metadata.Environment,
+		"task-id":     metadata.TaskID,
+		"working-dir": metadata.WorkingDir,
 	}
 	return AsyncResponse(result, change.ID())
 }

--- a/internal/daemon/api_exec.go
+++ b/internal/daemon/api_exec.go
@@ -26,18 +26,18 @@ import (
 
 func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	var payload struct {
-		Command     []string          `json:"command"`
-		Environment map[string]string `json:"environment"`
-		WorkingDir  string            `json:"working-dir"`
-		Timeout     string            `json:"timeout"`
-		UserID      *int              `json:"user-id"`
-		User        string            `json:"user"`
-		GroupID     *int              `json:"group-id"`
-		Group       string            `json:"group"`
-		Terminal    bool              `json:"terminal"`
-		Stderr      bool              `json:"stderr"`
-		Width       int               `json:"width"`
-		Height      int               `json:"height"`
+		Command        []string          `json:"command"`
+		Environment    map[string]string `json:"environment"`
+		WorkingDir     string            `json:"working-dir"`
+		Timeout        string            `json:"timeout"`
+		UserID         *int              `json:"user-id"`
+		User           string            `json:"user"`
+		GroupID        *int              `json:"group-id"`
+		Group          string            `json:"group"`
+		UseTerminal    bool              `json:"use-terminal"`
+		SeparateStderr bool              `json:"separate-stderr"`
+		Width          int               `json:"width"`
+		Height         int               `json:"height"`
 	}
 	decoder := json.NewDecoder(req.Body)
 	if err := decoder.Decode(&payload); err != nil {
@@ -46,10 +46,10 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	if len(payload.Command) < 1 {
 		return statusBadRequest("must specify command")
 	}
-	if payload.Terminal && payload.Stderr {
+	if payload.UseTerminal && payload.SeparateStderr {
 		return statusBadRequest("separate stderr not currently supported in terminal mode")
 	}
-	if !payload.Terminal && !payload.Stderr {
+	if !payload.UseTerminal && !payload.SeparateStderr {
 		return statusBadRequest("combined stderr not currently supported in non-terminal mode")
 	}
 
@@ -79,16 +79,16 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	defer st.Unlock()
 
 	args := &cmdstate.ExecArgs{
-		Command:     payload.Command,
-		Environment: payload.Environment,
-		WorkingDir:  payload.WorkingDir,
-		Timeout:     timeout,
-		UserID:      uid,
-		GroupID:     gid,
-		Terminal:    payload.Terminal,
-		Stderr:      payload.Stderr,
-		Width:       payload.Width,
-		Height:      payload.Height,
+		Command:        payload.Command,
+		Environment:    payload.Environment,
+		WorkingDir:     payload.WorkingDir,
+		Timeout:        timeout,
+		UserID:         uid,
+		GroupID:        gid,
+		UseTerminal:    payload.UseTerminal,
+		SeparateStderr: payload.SeparateStderr,
+		Width:          payload.Width,
+		Height:         payload.Height,
 	}
 	change, metadata, err := cmdstate.Exec(st, args)
 	if err != nil {

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -167,7 +167,7 @@ func (s *execSuite) TestUserIDGroupID(c *C) {
 func (s *execSuite) exec(c *C, stdin string, opts *client.ExecOptions) (stdout, stderr string, exitCode int, waitErr error) {
 	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
-	opts.Stdin = ioutil.NopCloser(strings.NewReader(stdin))
+	opts.Stdin = strings.NewReader(stdin)
 	opts.Stdout = outBuf
 	opts.Stderr = errBuf
 	execution, err := s.client.Exec(opts)
@@ -183,7 +183,7 @@ func (s *execSuite) TestSignal(c *C) {
 	opts := &client.ExecOptions{
 		Command:        []string{"sleep", "1"},
 		SeparateStderr: true,
-		Stdin:          ioutil.NopCloser(strings.NewReader("")),
+		Stdin:          strings.NewReader(""),
 		Stdout:         ioutil.Discard,
 		Stderr:         ioutil.Discard,
 	}
@@ -205,7 +205,7 @@ func (s *execSuite) TestStreaming(c *C) {
 	opts := &client.ExecOptions{
 		Command:        []string{"cat"},
 		SeparateStderr: true,
-		Stdin:          ioutil.NopCloser(channelReader{stdinCh}),
+		Stdin:          channelReader{stdinCh},
 		Stdout:         channelWriter{stdoutCh},
 		Stderr:         ioutil.Discard,
 	}

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 
@@ -198,7 +199,7 @@ func (s *execSuite) TestSignal(c *C) {
 		Stdin:  ioutil.NopCloser(strings.NewReader("")),
 		Stdout: ioutil.Discard,
 		Stderr: ioutil.Discard,
-		Control: func(conn client.WebsocketConn) {
+		Control: func(conn *websocket.Conn) {
 			signal := <-signalCh
 			err := client.ExecForwardSignal(conn, signal)
 			c.Check(err, IsNil)

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -170,10 +170,10 @@ func (s *execSuite) exec(c *C, stdin string, opts *client.ExecOptions) (stdout, 
 	opts.Stdin = strings.NewReader(stdin)
 	opts.Stdout = outBuf
 	opts.Stderr = errBuf
-	execution, err := s.client.Exec(opts)
+	process, err := s.client.Exec(opts)
 	c.Assert(err, IsNil)
 
-	exitCode, waitErr = execution.Wait()
+	exitCode, waitErr = process.Wait()
 	c.Check(err, IsNil)
 
 	return outBuf.String(), errBuf.String(), exitCode, waitErr
@@ -187,13 +187,13 @@ func (s *execSuite) TestSignal(c *C) {
 		Stdout:         ioutil.Discard,
 		Stderr:         ioutil.Discard,
 	}
-	execution, err := s.client.Exec(opts)
+	process, err := s.client.Exec(opts)
 	c.Assert(err, IsNil)
 
-	err = execution.SendSignal("SIGINT")
+	err = process.SendSignal("SIGINT")
 	c.Assert(err, IsNil)
 
-	exitCode, err := execution.Wait()
+	exitCode, err := process.Wait()
 	c.Check(err, IsNil)
 
 	c.Check(exitCode, Equals, 130)
@@ -209,7 +209,7 @@ func (s *execSuite) TestStreaming(c *C) {
 		Stdout:         channelWriter{stdoutCh},
 		Stderr:         ioutil.Discard,
 	}
-	execution, err := s.client.Exec(opts)
+	process, err := s.client.Exec(opts)
 	c.Assert(err, IsNil)
 
 	for i := 0; i < 20; i++ {
@@ -233,7 +233,7 @@ func (s *execSuite) TestStreaming(c *C) {
 		c.Fatalf("timed out waiting to write to stdin")
 	}
 
-	exitCode, err := execution.Wait()
+	exitCode, err := process.Wait()
 	c.Check(err, IsNil)
 	c.Check(exitCode, Equals, 0)
 }

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -30,6 +30,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/internal/logger"
 )
 
 var _ = Suite(&execSuite{})
@@ -37,6 +38,10 @@ var _ = Suite(&execSuite{})
 type execSuite struct {
 	daemon *Daemon
 	client *client.Client
+}
+
+func (s *execSuite) SetUpSuite(c *C) {
+	logger.SetLogger(logger.New(os.Stderr, "[test] "))
 }
 
 func (s *execSuite) SetUpTest(c *C) {
@@ -59,7 +64,7 @@ func (s *execSuite) TearDownTest(c *C) {
 	c.Check(err, IsNil)
 }
 
-// Some of these tests use the Go client (tested elsewhere) for simplicity.
+// Some of these tests use the Go client for simplicity.
 
 func (s *execSuite) TestStdinStdout(c *C) {
 	stdout, stderr, waitErr := s.exec(c, "foo bar", &client.ExecOptions{

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -394,6 +394,6 @@ func execRequest(c *C, opts *client.ExecOptions) (*http.Response, execResponse) 
 
 func getExitCode(c *C, change *client.Change) int {
 	exitCode := 1
-	_ = change.Get("return", &exitCode)
+	_ = change.Get("exit-code", &exitCode)
 	return exitCode
 }

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 
@@ -199,7 +198,7 @@ func (s *execSuite) TestSignal(c *C) {
 		Stdin:  ioutil.NopCloser(strings.NewReader("")),
 		Stdout: ioutil.Discard,
 		Stderr: ioutil.Discard,
-		Control: func(conn *websocket.Conn) {
+		Control: func(conn client.WebsocketConn) {
 			signal := <-signalCh
 			err := client.ExecForwardSignal(conn, signal)
 			c.Check(err, IsNil)

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -122,9 +122,9 @@ func (s *execSuite) TestWorkingDir(c *C) {
 func (s *execSuite) TestTimeout(c *C) {
 	stdout, stderr, _, waitErr := s.exec(c, "", &client.ExecOptions{
 		Command: []string{"sleep", "1"},
-		Timeout: time.Millisecond,
+		Timeout: 10 * time.Millisecond,
 	})
-	c.Check(waitErr, ErrorMatches, `cannot perform the following tasks:\n.*timed out after 1ms.*`)
+	c.Check(waitErr, ErrorMatches, `cannot perform the following tasks:\n.*timed out after 10ms.*`)
 	c.Check(stdout, Equals, "")
 	c.Check(stderr, Equals, "")
 }

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -352,9 +352,3 @@ func execRequest(c *C, opts *client.ExecOptions) (*http.Response, execResponse) 
 	c.Assert(err, IsNil)
 	return httpResp, execResp
 }
-
-func getExitCode(c *C, change *client.Change) int {
-	exitCode := 1
-	_ = change.Get("exit-code", &exitCode)
-	return exitCode
-}

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 
@@ -199,7 +198,7 @@ func (s *execSuite) TestSignal(c *C) {
 		Stdin:  ioutil.NopCloser(strings.NewReader("")),
 		Stdout: ioutil.Discard,
 		Stderr: ioutil.Discard,
-		Control: func(conn *websocket.Conn) {
+		Control: func(conn client.WebsocketWriter) {
 			signal := <-signalCh
 			err := client.ExecForwardSignal(conn, signal)
 			c.Check(err, IsNil)

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/client"
@@ -187,7 +186,7 @@ func (s *execSuite) exec(c *C, stdin string, opts *client.ExecOptions) (changeEr
 }
 
 func (s *execSuite) TestSignal(c *C) {
-	signalCh := make(chan int, 1)
+	signalCh := make(chan string, 1)
 	opts := &client.ExecOptions{
 		Command:        []string{"sleep", "1"},
 		SeparateStderr: true,
@@ -196,7 +195,7 @@ func (s *execSuite) TestSignal(c *C) {
 		Stderr:         ioutil.Discard,
 		Control: func(conn client.WebsocketWriter) {
 			signal := <-signalCh
-			err := client.ExecForwardSignal(conn, signal)
+			err := client.ExecSendSignal(conn, signal)
 			c.Check(err, IsNil)
 		},
 	}
@@ -204,7 +203,7 @@ func (s *execSuite) TestSignal(c *C) {
 	c.Assert(err, IsNil)
 
 	select {
-	case signalCh <- int(unix.SIGINT):
+	case signalCh <- "SIGINT":
 	case <-time.After(time.Second):
 		c.Fatalf("timed out sending to signal channel")
 	}

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -350,12 +350,16 @@ type execResponse struct {
 
 // execRequest directly calls exec via the ServeHTTP endpoint, rather than
 // going through the Go client.
-func execRequest(c *C, options *client.ExecOptions) (*http.Response, execResponse) {
+func execRequest(c *C, opts *client.ExecOptions) (*http.Response, execResponse) {
+	var timeoutStr string
+	if opts.Timeout != 0 {
+		timeoutStr = opts.Timeout.String()
+	}
 	var payload = struct {
 		Command     []string          `json:"command"`
 		Environment map[string]string `json:"environment"`
 		WorkingDir  string            `json:"working-dir"`
-		Timeout     time.Duration     `json:"timeout"`
+		Timeout     string            `json:"timeout"`
 		UserID      *int              `json:"user-id"`
 		User        string            `json:"user"`
 		GroupID     *int              `json:"group-id"`
@@ -364,7 +368,20 @@ func execRequest(c *C, options *client.ExecOptions) (*http.Response, execRespons
 		Stderr      bool              `json:"stderr"`
 		Width       int               `json:"width"`
 		Height      int               `json:"height"`
-	}(*options)
+	}{
+		Command:     opts.Command,
+		Environment: opts.Environment,
+		WorkingDir:  opts.WorkingDir,
+		Timeout:     timeoutStr,
+		UserID:      opts.UserID,
+		User:        opts.User,
+		GroupID:     opts.GroupID,
+		Group:       opts.Group,
+		Terminal:    opts.Terminal,
+		Stderr:      opts.Stderr,
+		Width:       opts.Width,
+		Height:      opts.Height,
+	}
 	requestBody, err := json.Marshal(payload)
 	c.Assert(err, IsNil)
 

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -343,26 +343,13 @@ type execResponse struct {
 }
 
 // execRequest directly calls exec via the ServeHTTP endpoint, rather than
-// going through the Go client.
+// using the Go client.
 func execRequest(c *C, opts *client.ExecOptions) (*http.Response, execResponse) {
 	var timeoutStr string
 	if opts.Timeout != 0 {
 		timeoutStr = opts.Timeout.String()
 	}
-	var payload = struct {
-		Command        []string          `json:"command"`
-		Environment    map[string]string `json:"environment"`
-		WorkingDir     string            `json:"working-dir"`
-		Timeout        string            `json:"timeout"`
-		UserID         *int              `json:"user-id"`
-		User           string            `json:"user"`
-		GroupID        *int              `json:"group-id"`
-		Group          string            `json:"group"`
-		Terminal       bool              `json:"use-terminal"`
-		SeparateStderr bool              `json:"separate-stderr"`
-		Width          int               `json:"width"`
-		Height         int               `json:"height"`
-	}{
+	payload := execPayload{
 		Command:        opts.Command,
 		Environment:    opts.Environment,
 		WorkingDir:     opts.WorkingDir,
@@ -371,12 +358,12 @@ func execRequest(c *C, opts *client.ExecOptions) (*http.Response, execResponse) 
 		User:           opts.User,
 		GroupID:        opts.GroupID,
 		Group:          opts.Group,
-		Terminal:       opts.UseTerminal,
+		UseTerminal:    opts.UseTerminal,
 		SeparateStderr: opts.SeparateStderr,
 		Width:          opts.Width,
 		Height:         opts.Height,
 	}
-	requestBody, err := json.Marshal(payload)
+	requestBody, err := json.Marshal(&payload)
 	c.Assert(err, IsNil)
 
 	httpResp, body := doRequest(c, v1PostExec, "POST", "/v1/exec", nil, nil, requestBody)

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -89,11 +89,10 @@ func (s *execSuite) TestCombinedStderr(c *C) {
 	}
 	process, err := s.client.Exec(opts)
 	c.Assert(err, IsNil)
-	exitCode, waitErr := process.Wait()
+	err = process.Wait()
 	c.Check(err, IsNil)
-	c.Check(waitErr, IsNil)
 	c.Check(outBuf.String(), Equals, "OUT\nERR!\n")
-	c.Check(exitCode, Equals, 0)
+	c.Check(process.ExitCode(), Equals, 0)
 }
 
 func (s *execSuite) TestEnvironment(c *C) {
@@ -181,10 +180,10 @@ func (s *execSuite) exec(c *C, stdin string, opts *client.ExecOptions) (stdout, 
 	process, err := s.client.Exec(opts)
 	c.Assert(err, IsNil)
 
-	exitCode, waitErr = process.Wait()
+	waitErr = process.Wait()
 	c.Check(err, IsNil)
 
-	return outBuf.String(), errBuf.String(), exitCode, waitErr
+	return outBuf.String(), errBuf.String(), process.ExitCode(), waitErr
 }
 
 func (s *execSuite) TestSignal(c *C) {
@@ -200,10 +199,10 @@ func (s *execSuite) TestSignal(c *C) {
 	err = process.SendSignal("SIGINT")
 	c.Assert(err, IsNil)
 
-	exitCode, err := process.Wait()
+	err = process.Wait()
 	c.Check(err, IsNil)
 
-	c.Check(exitCode, Equals, 130)
+	c.Check(process.ExitCode(), Equals, 130)
 }
 
 func (s *execSuite) TestStreaming(c *C) {
@@ -239,9 +238,9 @@ func (s *execSuite) TestStreaming(c *C) {
 		c.Fatalf("timed out waiting to write to stdin")
 	}
 
-	exitCode, err := process.Wait()
+	err = process.Wait()
 	c.Check(err, IsNil)
-	c.Check(exitCode, Equals, 0)
+	c.Check(process.ExitCode(), Equals, 0)
 }
 
 type channelReader struct {

--- a/internal/daemon/api_exec_test.go
+++ b/internal/daemon/api_exec_test.go
@@ -268,29 +268,6 @@ func (s *execSuite) TestNoCommand(c *C) {
 	c.Check(execResp.Result["message"], Equals, "must specify command")
 }
 
-func (s *execSuite) TestNotSupported(c *C) {
-	// These combinations aren't currently supported (but will be later)
-	httpResp, execResp := execRequest(c, &client.ExecOptions{
-		Command:        []string{"echo", "foo"},
-		UseTerminal:    true,
-		SeparateStderr: true,
-	})
-	c.Check(httpResp.StatusCode, Equals, http.StatusBadRequest)
-	c.Check(execResp.StatusCode, Equals, http.StatusBadRequest)
-	c.Check(execResp.Type, Equals, "error")
-	c.Check(execResp.Result["message"], Matches, ".*not currently supported.*")
-
-	httpResp, execResp = execRequest(c, &client.ExecOptions{
-		Command:        []string{"echo", "foo"},
-		UseTerminal:    false,
-		SeparateStderr: false,
-	})
-	c.Check(httpResp.StatusCode, Equals, http.StatusBadRequest)
-	c.Check(execResp.StatusCode, Equals, http.StatusBadRequest)
-	c.Check(execResp.Type, Equals, "error")
-	c.Check(execResp.Result["message"], Matches, ".*not currently supported.*")
-}
-
 func (s *execSuite) TestCommandNotFound(c *C) {
 	httpResp, execResp := execRequest(c, &client.ExecOptions{
 		Command:        []string{"badcmd"},

--- a/internal/daemon/api_tasks.go
+++ b/internal/daemon/api_tasks.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/canonical/pebble/internal/overlord/state"
+)
+
+func v1GetTaskWebsocket(c *Command, req *http.Request, _ *userState) Response {
+	vars := muxVars(req)
+	taskID := vars["task-id"]
+	websocketID := vars["websocket-id"]
+
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.Task(taskID)
+	if task == nil {
+		return statusNotFound("cannot find task with id %q", taskID)
+	}
+
+	var connect websocketConnectFunc
+	switch task.Kind() {
+	case "exec":
+		commandMgr := c.d.overlord.CommandManager()
+		connect = commandMgr.Connect
+	default:
+		return statusBadRequest("%q tasks do not have websockets", task.Kind())
+	}
+
+	return websocketResponse{
+		task:        task,
+		websocketID: websocketID,
+		connect:     connect,
+	}
+}
+
+type websocketConnectFunc func(r *http.Request, w http.ResponseWriter, task *state.Task, websocketID string) error
+
+type websocketResponse struct {
+	task        *state.Task
+	websocketID string
+	connect     websocketConnectFunc
+}
+
+func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := wr.connect(r, w, wr.task, wr.websocketID)
+	if errors.Is(err, os.ErrNotExist) {
+		rsp := statusNotFound("cannot find websocket with id %q", wr.websocketID)
+		rsp.ServeHTTP(w, r)
+		return
+	}
+	if err != nil {
+		rsp := statusInternalError("cannot connect to websocket %q: %v", wr.websocketID, err)
+		rsp.ServeHTTP(w, r)
+		return
+	}
+	// In the success case, Connect takes over the connection and upgrades to
+	// the websocket protocol.
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -294,6 +294,7 @@ func (w *wrappedWriter) Flush() {
 	}
 }
 
+// Hijack is needed for websockets to take over an HTTP connection.
 func (w *wrappedWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := w.w.(http.Hijacker)
 	if !ok {

--- a/internal/daemon/ucrednet.go
+++ b/internal/daemon/ucrednet.go
@@ -115,6 +115,8 @@ func (wl *ucrednetListener) Accept() (net.Conn, error) {
 		}
 		var ucred *syscall.Ucred
 		var ucredErr error
+		// Call getUcred inside a Control() block to ensure fd is valid for
+		// the duration of the call, avoiding a race condition.
 		err = rawConn.Control(func(fd uintptr) {
 			ucred, ucredErr = getUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
 		})

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -76,7 +76,7 @@ type ExecArgs struct {
 	Height         int
 }
 
-// ExecMetadata is the metadata from an Exec call.
+// ExecMetadata is the metadata returned from an Exec call.
 type ExecMetadata struct {
 	WebsocketIDs map[string]string // keys are "control", "io", and "stderr" if SeparateStderr true
 	Environment  map[string]string

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -428,7 +428,7 @@ func (s *execWs) do(ctx context.Context, change *state.Change) error {
 		}()
 	}
 
-	finisher := func(cmdResult int, cmdErr error) error {
+	finisher := func(exitCode int, cmdErr error) error {
 		for _, tty := range ttys {
 			tty.Close()
 		}
@@ -451,7 +451,7 @@ func (s *execWs) do(ctx context.Context, change *state.Change) error {
 			pty.Close()
 		}
 
-		setApiData(change, cmdResult)
+		setApiData(change, exitCode)
 
 		return cmdErr
 	}
@@ -524,12 +524,12 @@ func (s *execWs) do(ctx context.Context, change *state.Change) error {
 	return finisher(0, nil)
 }
 
-func setApiData(change *state.Change, cmdResult int) {
+func setApiData(change *state.Change, exitCode int) {
 	st := change.State()
 	st.Lock()
 	defer st.Unlock()
 	change.Set("api-data", map[string]interface{}{
-		"return": cmdResult,
+		"exit-code": exitCode,
 	})
 }
 

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -63,21 +63,21 @@ func (m *CommandManager) Ensure() error {
 
 // ExecArgs holds the arguments for a command execution.
 type ExecArgs struct {
-	Command       []string
-	Environment   map[string]string
-	WorkingDir    string
-	Timeout       time.Duration
-	UserID        *int
-	GroupID       *int
-	UseTerminal   bool
-	CombineStderr bool
-	Width         int
-	Height        int
+	Command     []string
+	Environment map[string]string
+	WorkingDir  string
+	Timeout     time.Duration
+	UserID      *int
+	GroupID     *int
+	UseTerminal bool
+	SplitStderr bool
+	Width       int
+	Height      int
 }
 
 // ExecMetadata is the metadata returned from an Exec call.
 type ExecMetadata struct {
-	WebsocketIDs map[string]string // keys are "control", "io", and "stderr" if CombineStderr false
+	WebsocketIDs map[string]string // keys are "control", "io", and "stderr" if SplitStderr true
 	Environment  map[string]string
 	WorkingDir   string
 }
@@ -141,7 +141,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Change, ExecMetadata, error) 
 		ioConnected:      make(chan struct{}),
 		controlConnected: make(chan struct{}),
 		useTerminal:      args.UseTerminal,
-		combineStderr:    args.CombineStderr,
+		splitStderr:      args.SplitStderr,
 		width:            args.Width,
 		height:           args.Height,
 		uid:              args.UserID,
@@ -152,7 +152,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Change, ExecMetadata, error) 
 	// Generate unique identifier for each websocket (used by connect API).
 	e.websockets[wsControl] = nil
 	e.websockets[wsIO] = nil
-	if !args.CombineStderr {
+	if args.SplitStderr {
 		e.websockets[wsStderr] = nil
 	}
 	for key := range e.websockets {
@@ -253,7 +253,7 @@ type execution struct {
 	ioConnected      chan struct{}
 	controlConnected chan struct{}
 	useTerminal      bool
-	combineStderr    bool
+	splitStderr      bool
 	width            int
 	height           int
 	uid              *int
@@ -292,7 +292,7 @@ func (e *execution) connect(r *http.Request, w http.ResponseWriter, id string) e
 	// Signal that we're connected.
 	if key == wsControl {
 		close(e.controlConnected)
-	} else if e.websockets[wsIO] != nil && (e.combineStderr || e.websockets[wsStderr] != nil) {
+	} else if e.websockets[wsIO] != nil && (!e.splitStderr || e.websockets[wsStderr] != nil) {
 		close(e.ioConnected)
 	}
 	return nil
@@ -362,7 +362,7 @@ func (e *execution) do(ctx context.Context, change *state.Change) error {
 
 		stdin = tty
 		stdout = tty
-		stderr = tty // stderr will be overwritten below if combineStderr false
+		stderr = tty // stderr will be overwritten below if splitStderr true
 
 		if e.width > 0 && e.height > 0 {
 			ptyutil.SetSize(int(pty.Fd()), e.width, e.height)
@@ -411,7 +411,7 @@ func (e *execution) do(ctx context.Context, change *state.Change) error {
 		ptys = append(ptys, stdoutReader)
 		ttys = append(ttys, stdoutWriter)
 		stdout = stdoutWriter
-		stderr = stdoutWriter // stderr will be overwritten below if combineStderr false
+		stderr = stdoutWriter // stderr will be overwritten below if splitStderr true
 		wg.Add(1)
 		go func() {
 			<-wsutil.WebsocketSendStream(ioConn, stdoutReader, -1)
@@ -420,7 +420,7 @@ func (e *execution) do(ctx context.Context, change *state.Change) error {
 		}()
 	}
 
-	if !e.combineStderr {
+	if e.splitStderr {
 		// Start goroutine to receive from cmd.Stderr pipe and write to a
 		// separate "stderr" websocket.
 		stderrReader, stderrWriter, err := os.Pipe()

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -105,7 +105,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Change, ExecMetadata, error) 
 		}
 		u, err := user.LookupId(strconv.Itoa(userID))
 		if err != nil {
-			logger.Noticef("Failed to look up user %d: %v", userID, err)
+			logger.Noticef("Cannot look up user %d: %v", userID, err)
 		} else {
 			if env["HOME"] == "" {
 				env["HOME"] = u.HomeDir
@@ -275,7 +275,7 @@ func (e *execution) connect(r *http.Request, w http.ResponseWriter, id string) e
 		}
 	}
 	if id != wsID {
-		return fmt.Errorf("websocket ID %q not found", id)
+		return fmt.Errorf("cannot find websocket ID %q", id)
 	}
 
 	// Upgrade the HTTP connection to a websocket connection.
@@ -590,7 +590,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 		}
 
 		if err != nil {
-			logger.Debugf("Error getting next reader for PID %d: %v", pid, err)
+			logger.Debugf("Cannot get next reader for PID %d: %v", pid, err)
 			er, ok := err.(*websocket.CloseError)
 			if !ok {
 				break
@@ -602,7 +602,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 			// If an abnormal closure occurred, kill the attached process.
 			err := unix.Kill(pid, unix.SIGKILL)
 			if err != nil {
-				logger.Noticef("Failed to send SIGKILL to pid %d", pid)
+				logger.Noticef("Cannot send SIGKILL to pid %d", pid)
 			} else {
 				logger.Noticef("Sent SIGKILL to pid %d", pid)
 			}
@@ -612,7 +612,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 		var command execCommand
 		err = json.NewDecoder(r).Decode(&command)
 		if err != nil {
-			logger.Noticef("Failed to unmarshal control socket command: %s", err)
+			logger.Noticef("Cannot decode control socket command: %s", err)
 			continue
 		}
 
@@ -626,7 +626,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 			logger.Debugf("Received 'resize' command with size %dx%d", w, h)
 			err = ptyutil.SetSize(ptyFd, w, h)
 			if err != nil {
-				logger.Noticef("Failed to set window size to: %dx%d", w, h)
+				logger.Noticef("Cannot set window size to: %dx%d", w, h)
 				continue
 			}
 		case command.Command == "signal":
@@ -643,7 +643,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 			logger.Debugf("Received 'signal' command with signal %s", name)
 			err := unix.Kill(pid, sig)
 			if err != nil {
-				logger.Noticef("Failed forwarding %s to PID %d", name, pid)
+				logger.Noticef("Cannot forward %s to PID %d", name, pid)
 				continue
 			}
 			logger.Noticef("Forwarded signal %s to PID %d", name, pid)

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -219,7 +219,10 @@ func getWsAndCacheKey(change *state.Change) (*execWs, string, error) {
 		return nil, "", err
 	}
 
-	ws := st.Cached("exec-" + cacheKey).(*execWs)
+	ws, ok := st.Cached("exec-" + cacheKey).(*execWs)
+	if !ok {
+		return nil, "", fmt.Errorf("exec for change %q no longer active", change.ID())
+	}
 	return ws, cacheKey, nil
 }
 

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -275,7 +275,7 @@ func (e *execution) connect(r *http.Request, w http.ResponseWriter, id string) e
 		}
 	}
 	if id != wsID {
-		return fmt.Errorf("cannot find websocket ID %q", id)
+		return os.ErrNotExist
 	}
 
 	// Upgrade the HTTP connection to a websocket connection.

--- a/internal/overlord/cmdstate/cmdmgr.go
+++ b/internal/overlord/cmdstate/cmdmgr.go
@@ -602,7 +602,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 			// If an abnormal closure occurred, kill the attached process.
 			err := unix.Kill(pid, unix.SIGKILL)
 			if err != nil {
-				logger.Noticef("Cannot send SIGKILL to pid %d", pid)
+				logger.Noticef("Cannot send SIGKILL to pid %d: %v", pid, err)
 			} else {
 				logger.Noticef("Sent SIGKILL to pid %d", pid)
 			}
@@ -612,7 +612,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 		var command execCommand
 		err = json.NewDecoder(r).Decode(&command)
 		if err != nil {
-			logger.Noticef("Cannot decode control socket command: %s", err)
+			logger.Noticef("Cannot decode control socket command: %v", err)
 			continue
 		}
 
@@ -626,7 +626,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 			logger.Debugf("Received 'resize' command with size %dx%d", w, h)
 			err = ptyutil.SetSize(ptyFd, w, h)
 			if err != nil {
-				logger.Noticef("Cannot set window size to: %dx%d", w, h)
+				logger.Noticef("Cannot set window size to %dx%d: %v", w, h, err)
 				continue
 			}
 		case command.Command == "signal":
@@ -643,7 +643,7 @@ func (e *execution) controlLoop(pidCh <-chan int, exitCh <-chan struct{}, ptyFd 
 			logger.Debugf("Received 'signal' command with signal %s", name)
 			err := unix.Kill(pid, sig)
 			if err != nil {
-				logger.Noticef("Cannot forward %s to PID %d", name, pid)
+				logger.Noticef("Cannot forward %s to PID %d: %v", name, pid, err)
 				continue
 			}
 			logger.Noticef("Forwarded signal %s to PID %d", name, pid)

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -22,8 +22,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/user"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -35,7 +33,6 @@ import (
 	"github.com/canonical/pebble/internal/logger"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/ptyutil"
-	"github.com/canonical/pebble/internal/strutil"
 	"github.com/canonical/pebble/internal/wsutil"
 )
 
@@ -47,146 +44,6 @@ const (
 	wsStdio   = "stdio"
 	wsStderr  = "stderr"
 )
-
-type CommandManager struct{}
-
-// NewManager creates a new CommandManager.
-func NewManager(runner *state.TaskRunner) *CommandManager {
-	runner.AddHandler("exec", doExec, nil)
-	return &CommandManager{}
-}
-
-// Ensure is part of the overlord.StateManager interface.
-func (m *CommandManager) Ensure() error {
-	return nil
-}
-
-// ExecArgs holds the arguments for a command execution.
-type ExecArgs struct {
-	Command     []string
-	Environment map[string]string
-	WorkingDir  string
-	Timeout     time.Duration
-	UserID      *int
-	GroupID     *int
-	UseTerminal bool
-	SplitStderr bool
-	Width       int
-	Height      int
-}
-
-// ExecMetadata is the metadata returned from an Exec call.
-type ExecMetadata struct {
-	WebsocketIDs map[string]string // keys are "control", "stdio", as well as "stderr" if SplitStderr true
-	Environment  map[string]string
-	WorkingDir   string
-}
-
-// Exec creates a change that will execute the command with the given arguments.
-func Exec(st *state.State, args *ExecArgs) (*state.Change, ExecMetadata, error) {
-	env := map[string]string{}
-	for k, v := range args.Environment {
-		env[k] = v
-	}
-
-	// Set a reasonable default for PATH.
-	_, ok := env["PATH"]
-	if !ok {
-		env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	}
-
-	// Set HOME and USER based on the UserID.
-	if env["HOME"] == "" || env["USER"] == "" {
-		var userID int
-		if args.UserID != nil {
-			userID = *args.UserID
-		} else {
-			userID = os.Getuid()
-		}
-		u, err := user.LookupId(strconv.Itoa(userID))
-		if err != nil {
-			logger.Noticef("Cannot look up user %d: %v", userID, err)
-		} else {
-			if env["HOME"] == "" {
-				env["HOME"] = u.HomeDir
-			}
-			if env["USER"] == "" {
-				env["USER"] = u.Username
-			}
-		}
-	}
-
-	// Set default value for LANG.
-	_, ok = env["LANG"]
-	if !ok {
-		env["LANG"] = "C.UTF-8"
-	}
-
-	// Set default working directory to $HOME, or / if $HOME not set.
-	cwd := args.WorkingDir
-	if cwd == "" {
-		cwd = env["HOME"]
-		if cwd == "" {
-			cwd = "/"
-		}
-	}
-
-	// Set up the object that will track the execution.
-	e := &execution{
-		command:          args.Command,
-		env:              env,
-		timeout:          args.Timeout,
-		websockets:       make(map[string]*websocket.Conn),
-		websocketIDs:     make(map[string]string),
-		ioConnected:      make(chan struct{}),
-		controlConnected: make(chan struct{}),
-		useTerminal:      args.UseTerminal,
-		splitStderr:      args.SplitStderr,
-		width:            args.Width,
-		height:           args.Height,
-		uid:              args.UserID,
-		gid:              args.GroupID,
-		workingDir:       cwd,
-	}
-
-	// Generate unique identifier for each websocket (used by connect API).
-	e.websockets[wsControl] = nil
-	e.websockets[wsStdio] = nil
-	if args.SplitStderr {
-		e.websockets[wsStderr] = nil
-	}
-	for key := range e.websockets {
-		var err error
-		e.websocketIDs[key], err = strutil.UUID()
-		if err != nil {
-			return nil, ExecMetadata{}, err
-		}
-	}
-
-	// Make a copy of websocketIDs map for the return value.
-	ids := make(map[string]string, len(e.websocketIDs))
-	for key, id := range e.websocketIDs {
-		ids[key] = id
-	}
-	metadata := ExecMetadata{
-		WebsocketIDs: ids,
-		Environment:  env,
-		WorkingDir:   cwd,
-	}
-
-	// Create change object for this execution and store it in state.
-	cacheKey, err := strutil.UUID()
-	if err != nil {
-		return nil, ExecMetadata{}, err
-	}
-	st.Cache("exec-"+cacheKey, e)
-	change := st.NewChange("exec", fmt.Sprintf("Execute command %q", args.Command[0]))
-	task := st.NewTask("exec", fmt.Sprintf("exec command %q", args.Command[0]))
-	change.AddAll(state.NewTaskSet(task))
-	change.Set("cache-key", cacheKey)
-
-	return change, metadata, nil
-}
 
 func doExec(task *state.Task, tomb *tomb.Tomb) error {
 	st := task.State()

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -67,7 +67,10 @@ type execution struct {
 
 func (m *CommandManager) doExec(task *state.Task, tomb *tomb.Tomb) error {
 	var request executionRequest
+	st := task.State()
+	st.Lock()
 	err := task.Get("execution-request", &request)
+	st.Unlock()
 	if err != nil {
 		return fmt.Errorf("cannot get execution request for task %q: %v", task.ID(), err)
 	}

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -103,6 +103,7 @@ func (m *CommandManager) doExec(task *state.Task, tomb *tomb.Tomb) error {
 	m.executionsMutex.Lock()
 	m.executions[task.ID()] = e
 	m.executionsMutex.Unlock()
+	m.executionsCond.Broadcast() // signal that Connects can start happening
 	defer func() {
 		m.executionsMutex.Lock()
 		delete(m.executions, task.ID())

--- a/internal/overlord/cmdstate/manager.go
+++ b/internal/overlord/cmdstate/manager.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmdstate
+
+import (
+	"github.com/canonical/pebble/internal/overlord/state"
+)
+
+type CommandManager struct{}
+
+// NewManager creates a new CommandManager.
+func NewManager(runner *state.TaskRunner) *CommandManager {
+	runner.AddHandler("exec", doExec, nil)
+	return &CommandManager{}
+}
+
+// Ensure is part of the overlord.StateManager interface.
+func (m *CommandManager) Ensure() error {
+	return nil
+}

--- a/internal/overlord/cmdstate/manager.go
+++ b/internal/overlord/cmdstate/manager.go
@@ -15,6 +15,9 @@
 package cmdstate
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/canonical/pebble/internal/overlord/state"
 )
 
@@ -22,11 +25,21 @@ type CommandManager struct{}
 
 // NewManager creates a new CommandManager.
 func NewManager(runner *state.TaskRunner) *CommandManager {
-	runner.AddHandler("exec", doExec, nil)
-	return &CommandManager{}
+	manager := &CommandManager{}
+	runner.AddHandler("exec", manager.doExec, nil)
+	return manager
 }
 
 // Ensure is part of the overlord.StateManager interface.
 func (m *CommandManager) Ensure() error {
 	return nil
+}
+
+// Connect upgrades the HTTP connection and connects to the given websocket.
+func (m *CommandManager) Connect(r *http.Request, w http.ResponseWriter, task *state.Task, websocketID string) error {
+	e, ok := task.Object().(*execution)
+	if !ok {
+		return fmt.Errorf("task %q has no execution object", task.ID())
+	}
+	return e.connect(r, w, websocketID)
 }

--- a/internal/overlord/cmdstate/request.go
+++ b/internal/overlord/cmdstate/request.go
@@ -46,8 +46,8 @@ type ExecMetadata struct {
 	WorkingDir  string
 }
 
-// executionRequest is stored on a task to specify the args for an execution.
-type executionRequest struct {
+// execSetup is stored on a task to specify the args for an execution.
+type execSetup struct {
 	Command     []string
 	Environment map[string]string
 	Timeout     time.Duration
@@ -60,7 +60,7 @@ type executionRequest struct {
 	WorkingDir  string
 }
 
-// Exec creates a change that will execute the command with the given arguments.
+// Exec creates a task that will execute the command with the given arguments.
 func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 	environment := map[string]string{}
 	for k, v := range args.Environment {
@@ -111,7 +111,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 
 	// Create a task for this execution (though it's not started here).
 	task := st.NewTask("exec", fmt.Sprintf("exec command %q", args.Command[0]))
-	request := executionRequest{
+	setup := execSetup{
 		Command:     args.Command,
 		Environment: environment,
 		Timeout:     args.Timeout,
@@ -123,7 +123,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		GroupID:     args.GroupID,
 		WorkingDir:  workingDir,
 	}
-	task.Set("execution-request", &request)
+	task.Set("exec-setup", &setup)
 
 	metadata := ExecMetadata{
 		TaskID:      task.ID(),

--- a/internal/overlord/cmdstate/request.go
+++ b/internal/overlord/cmdstate/request.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmdstate
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"time"
+
+	"github.com/canonical/pebble/internal/logger"
+	"github.com/canonical/pebble/internal/overlord/state"
+	"github.com/canonical/pebble/internal/strutil"
+	"github.com/gorilla/websocket"
+)
+
+// ExecArgs holds the arguments for a command execution.
+type ExecArgs struct {
+	Command     []string
+	Environment map[string]string
+	WorkingDir  string
+	Timeout     time.Duration
+	UserID      *int
+	GroupID     *int
+	UseTerminal bool
+	SplitStderr bool
+	Width       int
+	Height      int
+}
+
+// ExecMetadata is the metadata returned from an Exec call.
+type ExecMetadata struct {
+	WebsocketIDs map[string]string // keys are "control", "stdio", as well as "stderr" if SplitStderr true
+	Environment  map[string]string
+	WorkingDir   string
+}
+
+// Exec creates a change that will execute the command with the given arguments.
+func Exec(st *state.State, args *ExecArgs) (*state.Change, ExecMetadata, error) {
+	env := map[string]string{}
+	for k, v := range args.Environment {
+		env[k] = v
+	}
+
+	// Set a reasonable default for PATH.
+	_, ok := env["PATH"]
+	if !ok {
+		env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	}
+
+	// Set HOME and USER based on the UserID.
+	if env["HOME"] == "" || env["USER"] == "" {
+		var userID int
+		if args.UserID != nil {
+			userID = *args.UserID
+		} else {
+			userID = os.Getuid()
+		}
+		u, err := user.LookupId(strconv.Itoa(userID))
+		if err != nil {
+			logger.Noticef("Cannot look up user %d: %v", userID, err)
+		} else {
+			if env["HOME"] == "" {
+				env["HOME"] = u.HomeDir
+			}
+			if env["USER"] == "" {
+				env["USER"] = u.Username
+			}
+		}
+	}
+
+	// Set default value for LANG.
+	_, ok = env["LANG"]
+	if !ok {
+		env["LANG"] = "C.UTF-8"
+	}
+
+	// Set default working directory to $HOME, or / if $HOME not set.
+	cwd := args.WorkingDir
+	if cwd == "" {
+		cwd = env["HOME"]
+		if cwd == "" {
+			cwd = "/"
+		}
+	}
+
+	// Set up the object that will track the execution.
+	e := &execution{
+		command:          args.Command,
+		env:              env,
+		timeout:          args.Timeout,
+		websockets:       make(map[string]*websocket.Conn),
+		websocketIDs:     make(map[string]string),
+		ioConnected:      make(chan struct{}),
+		controlConnected: make(chan struct{}),
+		useTerminal:      args.UseTerminal,
+		splitStderr:      args.SplitStderr,
+		width:            args.Width,
+		height:           args.Height,
+		uid:              args.UserID,
+		gid:              args.GroupID,
+		workingDir:       cwd,
+	}
+
+	// Generate unique identifier for each websocket (used by connect API).
+	e.websockets[wsControl] = nil
+	e.websockets[wsStdio] = nil
+	if args.SplitStderr {
+		e.websockets[wsStderr] = nil
+	}
+	for key := range e.websockets {
+		var err error
+		e.websocketIDs[key], err = strutil.UUID()
+		if err != nil {
+			return nil, ExecMetadata{}, err
+		}
+	}
+
+	// Make a copy of websocketIDs map for the return value.
+	ids := make(map[string]string, len(e.websocketIDs))
+	for key, id := range e.websocketIDs {
+		ids[key] = id
+	}
+	metadata := ExecMetadata{
+		WebsocketIDs: ids,
+		Environment:  env,
+		WorkingDir:   cwd,
+	}
+
+	// Create change object for this execution and store it in state.
+	cacheKey, err := strutil.UUID()
+	if err != nil {
+		return nil, ExecMetadata{}, err
+	}
+	st.Cache("exec-"+cacheKey, e)
+	change := st.NewChange("exec", fmt.Sprintf("Execute command %q", args.Command[0]))
+	task := st.NewTask("exec", fmt.Sprintf("exec command %q", args.Command[0]))
+	change.AddAll(state.NewTaskSet(task))
+	change.Set("cache-key", cacheKey)
+
+	return change, metadata, nil
+}

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -82,6 +82,7 @@ type Overlord struct {
 	inited     bool
 	runner     *state.TaskRunner
 	serviceMgr *servstate.ServiceManager
+	commandMgr *cmdstate.CommandManager
 }
 
 // New creates a new Overlord with all its state managers.
@@ -121,14 +122,14 @@ func New(pebbleDir string, restartBehavior RestartBehavior, serviceOutput io.Wri
 	}
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
-	serviceMgr, err := servstate.NewManager(s, o.runner, o.pebbleDir, serviceOutput)
+	o.serviceMgr, err = servstate.NewManager(s, o.runner, o.pebbleDir, serviceOutput)
 	if err != nil {
 		return nil, err
 	}
-	o.addManager(serviceMgr)
+	o.addManager(o.serviceMgr)
 
-	cmdMgr := cmdstate.NewManager(o.runner)
-	o.addManager(cmdMgr)
+	o.commandMgr = cmdstate.NewManager(o.runner)
+	o.addManager(o.commandMgr)
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
@@ -137,11 +138,6 @@ func New(pebbleDir string, restartBehavior RestartBehavior, serviceOutput io.Wri
 }
 
 func (o *Overlord) addManager(mgr StateManager) {
-	// It may be necessary to keep a reference in the overlord itself.
-	switch x := mgr.(type) {
-	case *servstate.ServiceManager:
-		o.serviceMgr = x
-	}
 	o.stateEng.AddManager(mgr)
 }
 
@@ -430,6 +426,12 @@ func (o *Overlord) TaskRunner() *state.TaskRunner {
 // under the overlord.
 func (o *Overlord) ServiceManager() *servstate.ServiceManager {
 	return o.serviceMgr
+}
+
+// CommandManager returns the command manager responsible for executing
+// commands under the overlord.
+func (o *Overlord) CommandManager() *cmdstate.CommandManager {
+	return o.commandMgr
 }
 
 // Fake creates an Overlord without any managers and with a backend

--- a/internal/overlord/state/task.go
+++ b/internal/overlord/state/task.go
@@ -62,6 +62,10 @@ type Task struct {
 	undoingTime time.Duration
 
 	atTime time.Time
+
+	// An arbitrary object attached to this task, for example an execution
+	// instance for "exec" tasks.
+	object interface{}
 }
 
 func newTask(state *State, id, kind, summary string) *Task {
@@ -463,6 +467,17 @@ func (t *Task) At(when time.Time) {
 		}
 		t.state.EnsureBefore(d)
 	}
+}
+
+// Object returns the arbitrary object associated with this task, or nil if
+// not set.
+func (t *Task) Object() interface{} {
+	return t.object
+}
+
+// SetObject sets the arbitrary object associated with this task.
+func (t *Task) SetObject(object interface{}) {
+	t.object = object
 }
 
 // TaskSetEdge designates tasks inside a TaskSet for outside reference.

--- a/internal/overlord/state/task.go
+++ b/internal/overlord/state/task.go
@@ -62,10 +62,6 @@ type Task struct {
 	undoingTime time.Duration
 
 	atTime time.Time
-
-	// An arbitrary object attached to this task, for example an execution
-	// instance for "exec" tasks.
-	object interface{}
 }
 
 func newTask(state *State, id, kind, summary string) *Task {
@@ -467,17 +463,6 @@ func (t *Task) At(when time.Time) {
 		}
 		t.state.EnsureBefore(d)
 	}
-}
-
-// Object returns the arbitrary object associated with this task, or nil if
-// not set.
-func (t *Task) Object() interface{} {
-	return t.object
-}
-
-// SetObject sets the arbitrary object associated with this task.
-func (t *Task) SetObject(object interface{}) {
-	t.object = object
 }
 
 // TaskSetEdge designates tasks inside a TaskSet for outside reference.

--- a/internal/overlord/state/task_test.go
+++ b/internal/overlord/state/task_test.go
@@ -630,3 +630,24 @@ func (cs *taskSuite) TestTaskAddAllWithEdges(c *C) {
 	err = ts2.AddAllWithEdges(tsWithDuplicatedEdge)
 	c.Assert(err, ErrorMatches, `cannot add taskset: duplicated edge "install"`)
 }
+
+func (cs *taskSuite) TestObject(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	t1 := st.NewTask("test1", "this is a test")
+	c.Assert(t1.Object(), IsNil)
+	t1.SetObject(1234)
+	c.Assert(t1.Object(), Equals, 1234)
+	ch := make(chan int)
+	t1.SetObject(ch) // should work even if not JSON serializable
+	c.Assert(t1.Object(), Equals, ch)
+	t1.SetObject(nil)
+	c.Assert(t1.Object(), IsNil)
+
+	t2 := st.NewTask("test2", "this is a test")
+	c.Assert(t2.Object(), IsNil)
+	t2.SetObject("x")
+	c.Assert(t2.Object(), Equals, "x")
+}

--- a/internal/overlord/state/task_test.go
+++ b/internal/overlord/state/task_test.go
@@ -630,24 +630,3 @@ func (cs *taskSuite) TestTaskAddAllWithEdges(c *C) {
 	err = ts2.AddAllWithEdges(tsWithDuplicatedEdge)
 	c.Assert(err, ErrorMatches, `cannot add taskset: duplicated edge "install"`)
 }
-
-func (cs *taskSuite) TestObject(c *C) {
-	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
-
-	t1 := st.NewTask("test1", "this is a test")
-	c.Assert(t1.Object(), IsNil)
-	t1.SetObject(1234)
-	c.Assert(t1.Object(), Equals, 1234)
-	ch := make(chan int)
-	t1.SetObject(ch) // should work even if not JSON serializable
-	c.Assert(t1.Object(), Equals, ch)
-	t1.SetObject(nil)
-	c.Assert(t1.Object(), IsNil)
-
-	t2 := st.NewTask("test2", "this is a test")
-	c.Assert(t2.Object(), IsNil)
-	t2.SetObject("x")
-	c.Assert(t2.Object(), Equals, "x")
-}

--- a/internal/overlord/state/taskrunner.go
+++ b/internal/overlord/state/taskrunner.go
@@ -189,7 +189,7 @@ func (r *TaskRunner) run(t *Task) {
 	r.tombs[t.ID()] = tomb
 	tomb.Go(func() error {
 		// Capture the error result with tomb.Kill so we can
-		// use tomb.Err uniformily to consider both it or a
+		// use tomb.Err uniformly to consider both it or a
 		// overriding previous Kill reason.
 		t0 := time.Now()
 		tomb.Kill(handler(t, tomb))

--- a/internal/wsutil/wsutil.go
+++ b/internal/wsutil/wsutil.go
@@ -329,7 +329,7 @@ func WebsocketSendStream(conn *websocket.Conn, r io.Reader, bufferSize int) chan
 			}
 		}
 		conn.WriteMessage(websocket.TextMessage, []byte{})
-		ch <- true
+		close(ch) // NOTE(benhoyt): this was "ch <- true", but that can block
 	}(conn, r)
 
 	return ch

--- a/internal/wsutil/wsutil.go
+++ b/internal/wsutil/wsutil.go
@@ -27,33 +27,14 @@ import (
 	"github.com/canonical/pebble/internal/logger"
 )
 
-// WebsocketReader represents a readable websocket (and is implemented by
-// *websocket.Conn).
-type WebsocketReader interface {
-	NextReader() (messageType int, r io.Reader, err error)
-}
-
-// WebsocketWriter represents a writeable websocket (and is implemented by
-// *websocket.Conn).
-type WebsocketWriter interface {
-	WriteMessage(messageType int, data []byte) error
-}
-
-// WebsocketConn represents a readable and writeable websocket (and is
-// implemented by *websocket.Conn).
-type WebsocketConn interface {
-	WebsocketReader
-	WebsocketWriter
-}
-
 // WebsocketExecMirror mirrors a websocket connection with a set of Writer/Reader.
-func WebsocketExecMirror(conn WebsocketConn, w io.WriteCloser, r io.ReadCloser, exited chan struct{}, fd int) (chan bool, chan bool) {
+func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited chan struct{}, fd int) (chan bool, chan bool) {
 	readDone := make(chan bool, 1)
 	writeDone := make(chan bool, 1)
 
 	go DefaultWriter(conn, w, writeDone)
 
-	go func(conn WebsocketWriter, r io.ReadCloser) {
+	go func(conn *websocket.Conn, r io.ReadCloser) {
 		in := ExecReaderToChannel(r, -1, exited, fd)
 		for {
 			buf, ok := <-in
@@ -84,7 +65,7 @@ func WebsocketExecMirror(conn WebsocketConn, w io.WriteCloser, r io.ReadCloser, 
 	return readDone, writeDone
 }
 
-func DefaultWriter(conn WebsocketReader, w io.WriteCloser, writeDone chan<- bool) {
+func DefaultWriter(conn *websocket.Conn, w io.WriteCloser, writeDone chan<- bool) {
 	for {
 		mt, r, err := conn.NextReader()
 		if err != nil {
@@ -325,7 +306,7 @@ again:
 	return n, int(pollFds[0].Revents), err
 }
 
-func WebsocketSendStream(conn WebsocketWriter, r io.Reader, bufferSize int) chan bool {
+func WebsocketSendStream(conn *websocket.Conn, r io.Reader, bufferSize int) chan bool {
 	ch := make(chan bool)
 
 	if r == nil {
@@ -333,7 +314,7 @@ func WebsocketSendStream(conn WebsocketWriter, r io.Reader, bufferSize int) chan
 		return ch
 	}
 
-	go func(conn WebsocketWriter, r io.Reader) {
+	go func(conn *websocket.Conn, r io.Reader) {
 		in := ReaderToChannel(r, bufferSize)
 		for {
 			buf, ok := <-in
@@ -354,10 +335,10 @@ func WebsocketSendStream(conn WebsocketWriter, r io.Reader, bufferSize int) chan
 	return ch
 }
 
-func WebsocketRecvStream(w io.Writer, conn WebsocketReader) chan bool {
+func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 	ch := make(chan bool)
 
-	go func(w io.Writer, conn WebsocketReader) {
+	go func(w io.Writer, conn *websocket.Conn) {
 		for {
 			mt, r, err := conn.NextReader()
 			if mt == websocket.CloseMessage {

--- a/internal/wsutil/wsutil.go
+++ b/internal/wsutil/wsutil.go
@@ -217,7 +217,7 @@ func ExecReaderToChannel(r io.Reader, bufferSize int, exited <-chan struct{}, fd
 				// handled and triggers another codepath. (See [2].)"
 				if avoidAtomicLoad || atomic.LoadInt32(&attachedChildIsDead) == 1 {
 					avoidAtomicLoad = true
-					// Handle race between atomic.StorInt32() in the go routine
+					// Handle race between atomic.StoreInt32() in the go routine
 					// explained in [1] and atomic.LoadInt32() in the go routine
 					// here:
 					// We need to check for (POLLHUP | POLLRDHUP) here again since we might


### PR DESCRIPTION
This implements the Pebble/Go side of the [one-shot commands spec](https://docs.google.com/document/d/1npbNQMokDUoGX1UT61CvnMq6lIJ6MnU6CwExkymHEcA/edit) for command execution using websocket communication, including the Go client and `pebble exec` CLI.

**Other notes for the code reviewer:**

* I've added a number of tests for the API with use-terminal=false. They're not exactly "unit" tests as they run real commands and use the Go client for connecting to the websockets, but this makes the code and tests significantly simpler, and they run fast.
* There is currently only one trivial test with use-terminal=true, as it's hard to test terminal-specific features in Go tests. Instead, I suggest we focus on manual testing for testing terminal interactivity (see "Terminal resizing" under manual tests below).
* I may add client tests later when we've figured out what shape the extracted LXD websocket proxying library takes. Ideally it would use a websocket-like interface rather than `*websocket.Conn` (which makes things kinda hard to test right now).
* The `ptyutil` or `wsutil` packages were pulled basically verbatim from LXD, so I'm not going to add tests for those. The LXD team will be extracting those to a shared library, at which point we can `go get` them instead of vendoring.

**Manual tests:**

```
# Build and run the Pebble server with something like this:
$ go build ./cmd/pebble
$ PEBBLE_DEBUG=1 PEBBLE=~/pebble ./pebble run --hold

# Then in another terminal you can run "pebble exec"

# Basic stdout
$ PEBBLE=~/pebble ./pebble exec -- echo foo
foo
$ PEBBLE=~/pebble ./pebble exec -- echo foo >out
$ cat out
foo

# Stdin and stdout
$ PEBBLE=~/pebble ./pebble exec -- cat
asdf
asdf
# press Ctrl-D to exit
$ PEBBLE=~/pebble ./pebble exec -- cat
foo
foo
# also try Ctrl-C to exit (signal handling)

# Executable not found
$ PEBBLE=~/pebble ./pebble exec -- foobar
error: exec: "foobar": executable file not found in $PATH

# Command error
$ PEBBLE=~/pebble ./pebble exec -- ls notfound
ls: cannot access 'notfound': No such file or directory
$ echo $?
2
$ PEBBLE=~/pebble ./pebble exec -T -- ls notfound 2>err
$ echo $?
2
$ cat err
ls: cannot access 'notfound': No such file or directory

# Terminal resizing
$ PEBBLE=~/pebble ./pebble exec -- nano
# Ensure window is correctly sized to the parent terminal
# Drag to change window size and ensure nano updates
```

Fixes #37.