### PR TITLE
Avoid use of multipart.Part.FileName() to fix files API on Go 1.17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,23 @@ jobs:
 
     - name: Test and build
       run: |
-        go fmt ./...
-        git diff --exit-code  # Ensure no formatting changes
         go test -race ./...
         go build ./cmd/pebble
+
+  format:
+    runs-on: ubuntu-latest
+
+    name: Format check
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: Ensure no formatting changes
+      run: |
+        go fmt ./...
+        git diff --exit-code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.16', '1.15', '1.14']
+        go: ['1.17', '1.16', '1.15', '1.14']
 
     name: Go ${{ matrix.go }}
 

--- a/internal/osutil/sys/sysnum_16_linux.go
+++ b/internal/osutil/sys/sysnum_16_linux.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build arm || 386
 // +build arm 386
 
 /*

--- a/internal/osutil/sys/sysnum_32_linux.go
+++ b/internal/osutil/sys/sysnum_32_linux.go
@@ -1,4 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build arm64 || amd64 || ppc64le || s390x || ppc
 // +build arm64 amd64 ppc64le s390x ppc
 
 /*


### PR DESCRIPTION
In Go 1.17 they changed `part.FileName()` to pass the result through `filepath.Base()` before returning, stripping off the directory component which is important for Pebble's files API. See https://golang.org/doc/go1.17#mime/multipart and https://github.com/golang/go/commit/784ef4c53135644d70f3476a4bd90010b9acff66.

Note that `ReadForm()` used in the tests also calls `part.FileName()` so we have to roll that ourselves too.

Incidentally, we'd had some discussion about this in the original PR: https://github.com/canonical/pebble/pull/25#discussion_r611891810

> I had thought about using the filename field earlier, but originally decided against it because I know some clients strip off the path part of it (per the "SHOULD NOT" warning in RFC section 2.3 that you've quoted). However, Go does not, and we'll have a lot of control over the Python client (there's no multipart parser in the stdlib) so I think it's okay. I've updated the code to use "filename" -- it is simpler and cleaner.

Oh well, it's a fairly easy fix. :-)

This commit also runs Go 1.17's version of "go fmt", which adds some `//go:build` lines.