### PR TITLE
Make Pebble "go vet" clean

### DIFF
--- a/cmd/pebble/cmd_logs.go
+++ b/cmd/pebble/cmd_logs.go
@@ -107,7 +107,7 @@ func (cmd *cmdLogs) Execute(args []string) error {
 // Needed because signal.NotifyContext is Go 1.16+
 func notifyContext(parent context.Context, signals ...os.Signal) context.Context {
 	ctx, cancel := context.WithCancel(parent)
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 10)
 	signal.Notify(ch, signals...)
 	go func() {
 		// Wait for signal, then cancel the context.

--- a/cmd/pebble/cmd_logs.go
+++ b/cmd/pebble/cmd_logs.go
@@ -107,7 +107,10 @@ func (cmd *cmdLogs) Execute(args []string) error {
 // Needed because signal.NotifyContext is Go 1.16+
 func notifyContext(parent context.Context, signals ...os.Signal) context.Context {
 	ctx, cancel := context.WithCancel(parent)
-	ch := make(chan os.Signal, 10)
+	// This channel doesn't really need to be buffered here, but it shuts up
+	// "go vet" (and other places in Pebble use a buffer size of 2, so be
+	// consistent).
+	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, signals...)
 	go func() {
 		// Wait for signal, then cancel the context.

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -164,7 +164,7 @@ func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 		}
 		return fmt.Errorf("cannot start service: exited quickly with code %d", cmd.ProcessState.ExitCode())
 	}
-	panic("unreachable")
+	// unreachable
 }
 
 func (m *ServiceManager) doStop(task *state.Task, tomb *tomb.Tomb) error {
@@ -214,7 +214,7 @@ func (m *ServiceManager) doStop(task *state.Task, tomb *tomb.Tomb) error {
 			return nil
 		}
 	}
-	panic("unreachable")
+	// unreachable
 }
 
 var setCmdCredential = func(cmd *exec.Cmd, credential *syscall.Credential) {


### PR DESCRIPTION
Fix a couple of minor issues that `go vet` raises, just to make Pebble "go vet clean" so that we can see real vet issues easily. We could also add `go vet ./...` to the GitHub Actions to ensure this stays up to date, but I decided not to for now.

Before:

```
$ go vet ./...
# github.com/canonical/pebble/internal/overlord/servstate
internal/overlord/servstate/handlers.go:167:2: unreachable code
internal/overlord/servstate/handlers.go:217:2: unreachable code
# github.com/canonical/pebble/cmd/pebble
cmd/pebble/cmd_logs.go:111:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
$
```

After:

```
$ go vet ./...
$
```