### PR TITLE
Remove a bunch of snapd references

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -52,9 +52,9 @@ type doer interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-// Config allows to customize client behavior.
+// Config allows the user to customize client behavior.
 type Config struct {
-	// BaseURL contains the base URL where snappy daemon is expected to be.
+	// BaseURL contains the base URL where the pebble daemon is expected to be.
 	// It can be empty for a default behavior of talking over a unix socket.
 	BaseURL string
 
@@ -65,11 +65,11 @@ type Config struct {
 	// alive for later reuse
 	DisableKeepAlive bool
 
-	// User-Agent to sent to the snapd daemon
+	// User-Agent to sent to the pebble daemon
 	UserAgent string
 }
 
-// A Client knows how to talk to the snappy daemon.
+// A Client knows how to talk to the pebble daemon.
 type Client struct {
 	baseURL   url.URL
 	doer      doer

--- a/client/warnings.go
+++ b/client/warnings.go
@@ -40,7 +40,7 @@ type jsonWarning struct {
 	RepeatAfter string `json:"repeat-after,omitempty"`
 }
 
-// WarningsOptions contains options for querying snapd for warnings
+// WarningsOptions contains options for querying pebble for warnings
 // supported options:
 // - All: return all warnings, instead of only the un-okayed ones.
 type WarningsOptions struct {
@@ -71,7 +71,7 @@ type warningsAction struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// Okay asks snapd to chill about the warnings that would have been returned by
+// Okay asks pebble to chill about the warnings that would have been returned by
 // Warnings at the given time.
 func (client *Client) Okay(t time.Time) error {
 	var body bytes.Buffer

--- a/cmd/pebble/cmd_changes_test.go
+++ b/cmd/pebble/cmd_changes_test.go
@@ -95,7 +95,7 @@ var fakeChangesJSON = `{"type": "sync", "result": [
   },
   {
     "id":   "one",
-    "kind": "remove-snap",
+    "kind": "remove",
     "summary": "...",
     "status": "Do",
     "ready": false,

--- a/cmd/pebble/cmd_version_test.go
+++ b/cmd/pebble/cmd_version_test.go
@@ -28,9 +28,7 @@ func (s *PebbleSuite) TestVersionCommand(c *C) {
 		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"version":"7.89"}}`)
 	})
 
-	restore := fakeArgs("snap", "version")
-	defer restore()
-	restore = fakeVersion("4.56")
+	restore := fakeVersion("4.56")
 	defer restore()
 
 	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"version"})

--- a/cmd/pebble/export_test.go
+++ b/cmd/pebble/export_test.go
@@ -15,11 +15,6 @@
 package main
 
 import (
-	//"os/user"
-	//"time"
-
-	//"github.com/jessevdk/go-flags"
-
 	"github.com/canonical/pebble/client"
 )
 
@@ -31,172 +26,18 @@ func Client() *client.Client {
 	return client.New(ClientConfig)
 }
 
-const WriteLogBufSize = writeLogBufSize
-
 var (
-	//FirstNonOptionIsRun = firstNonOptionIsRun
-
-	//CreateUserDataDirs = createUserDataDirs
-	//ResolveApp         = resolveApp
-	//SnapdHelperPath    = snapdHelperPath
-	//SortByPath         = sortByPath
-	//AdviseCommand      = adviseCommand
-	//Antialias          = antialias
-	//FormatChannel      = fmtChannel
-	//PrintDescr         = printDescr
-	//WrapFlow           = wrapFlow
-	//TrueishJSON        = trueishJSON
-
 	CanUnicode      = canUnicode
 	ColorTable      = colorTable
 	MonoColorTable  = mono
 	ColorColorTable = color
 	NoEscColorTable = noesc
-	//ColorMixinGetEscapes = (colorMixin).getEscapes
-	//FillerPublisher      = fillerPublisher
-	//LongPublisher        = longPublisher
-	//ShortPublisher       = shortPublisher
-
-	//ReadRpc = readRpc
 
 	WriteWarningTimestamp = writeWarningTimestamp
 	MaybePresentWarnings  = maybePresentWarnings
 
-	//LongSnapDescription     = longSnapDescription
-	//SnapUsage               = snapUsage
-	//SnapHelpCategoriesIntro = snapHelpCategoriesIntro
-	//SnapHelpAllFooter       = snapHelpAllFooter
-	//SnapHelpFooter          = snapHelpFooter
-	//HelpCategories          = helpCategories
-
-	//LintArg  = lintArg
-	//LintDesc = lintDesc
-
-	//FixupArg = fixupArg
-
-	//InterfacesDeprecationNotice = interfacesDeprecationNotice
-
 	GetEnvPaths = getEnvPaths
 )
-
-//func NewInfoWriter(w writeflusher) *infoWriter {
-//	return &infoWriter{
-//		writeflusher: w,
-//		termWidth:    20,
-//		esc:          &escapes{dash: "--", tick: "*"},
-//		fmtTime:      func(t time.Time) string { return t.Format(time.Kitchen) },
-//	}
-//}
-//
-//func SetVerbose(iw *infoWriter, verbose bool) {
-//	iw.verbose = verbose
-//}
-//
-//var (
-//	ClientSnapFromPath          = clientSnapFromPath
-//	SetupDiskSnap               = (*infoWriter).setupDiskSnap
-//	SetupSnap                   = (*infoWriter).setupSnap
-//	MaybePrintServices          = (*infoWriter).maybePrintServices
-//	MaybePrintCommands          = (*infoWriter).maybePrintCommands
-//	MaybePrintType              = (*infoWriter).maybePrintType
-//	PrintSummary                = (*infoWriter).printSummary
-//	MaybePrintPublisher         = (*infoWriter).maybePrintPublisher
-//	MaybePrintNotes             = (*infoWriter).maybePrintNotes
-//	MaybePrintStandaloneVersion = (*infoWriter).maybePrintStandaloneVersion
-//	MaybePrintBuildDate         = (*infoWriter).maybePrintBuildDate
-//	MaybePrintContact           = (*infoWriter).maybePrintContact
-//	MaybePrintBase              = (*infoWriter).maybePrintBase
-//	MaybePrintPath              = (*infoWriter).maybePrintPath
-//	MaybePrintSum               = (*infoWriter).maybePrintSum
-//	MaybePrintCohortKey         = (*infoWriter).maybePrintCohortKey
-//	MaybePrintHealth            = (*infoWriter).maybePrintHealth
-//)
-//
-//func MockPollTime(d time.Duration) (restore func()) {
-//	d0 := pollTime
-//	pollTime = d
-//	return func() {
-//		pollTime = d0
-//	}
-//}
-//
-//func MockMaxGoneTime(d time.Duration) (restore func()) {
-//	d0 := maxGoneTime
-//	maxGoneTime = d
-//	return func() {
-//		maxGoneTime = d0
-//	}
-//}
-//
-//func MockSyscallExec(f func(string, []string, []string) error) (restore func()) {
-//	syscallExecOrig := syscallExec
-//	syscallExec = f
-//	return func() {
-//		syscallExec = syscallExecOrig
-//	}
-//}
-//
-//func MockUserCurrent(f func() (*user.User, error)) (restore func()) {
-//	userCurrentOrig := userCurrent
-//	userCurrent = f
-//	return func() {
-//		userCurrent = userCurrentOrig
-//	}
-//}
-//
-//func MockStoreNew(f func(*store.Config, store.DeviceAndAuthContext) *store.Store) (restore func()) {
-//	storeNewOrig := storeNew
-//	storeNew = f
-//	return func() {
-//		storeNew = storeNewOrig
-//	}
-//}
-//
-//func MockGetEnv(f func(name string) string) (restore func()) {
-//	osGetenvOrig := osGetenv
-//	osGetenv = f
-//	return func() {
-//		osGetenv = osGetenvOrig
-//	}
-//}
-//
-//func MockMountInfoPath(newMountInfoPath string) (restore func()) {
-//	mountInfoPathOrig := mountInfoPath
-//	mountInfoPath = newMountInfoPath
-//	return func() {
-//		mountInfoPath = mountInfoPathOrig
-//	}
-//}
-//
-//func MockOsReadlink(f func(string) (string, error)) (restore func()) {
-//	osReadlinkOrig := osReadlink
-//	osReadlink = f
-//	return func() {
-//		osReadlink = osReadlinkOrig
-//	}
-//}
-//
-//var AutoImportCandidates = autoImportCandidates
-//
-//func AliasInfoLess(snapName1, alias1, cmd1, snapName2, alias2, cmd2 string) bool {
-//	x := aliasInfos{
-//		&aliasInfo{
-//			Snap:    snapName1,
-//			Alias:   alias1,
-//			Command: cmd1,
-//		},
-//		&aliasInfo{
-//			Snap:    snapName2,
-//			Alias:   alias2,
-//			Command: cmd2,
-//		},
-//	}
-//	return x.Less(0, 1)
-//}
-//
-//func AssertTypeNameCompletion(match string) []flags.Completion {
-//	return assertTypeName("").Complete(match)
-//}
 
 func FakeIsStdoutTTY(t bool) (restore func()) {
 	oldIsStdoutTTY := isStdoutTTY
@@ -213,86 +54,3 @@ func FakeIsStdinTTY(t bool) (restore func()) {
 		isStdinTTY = oldIsStdinTTY
 	}
 }
-
-//func MockTimeNow(newTimeNow func() time.Time) (restore func()) {
-//	oldTimeNow := timeNow
-//	timeNow = newTimeNow
-//	return func() {
-//		timeNow = oldTimeNow
-//	}
-//}
-//
-//func MockTimeutilHuman(h func(time.Time) string) (restore func()) {
-//	oldH := timeutilHuman
-//	timeutilHuman = h
-//	return func() {
-//		timeutilHuman = oldH
-//	}
-//}
-//
-//func MockWaitConfTimeout(d time.Duration) (restore func()) {
-//	oldWaitConfTimeout := d
-//	waitConfTimeout = d
-//	return func() {
-//		waitConfTimeout = oldWaitConfTimeout
-//	}
-//}
-//
-//func Wait(cli *client.Client, id string) (*client.Change, error) {
-//	wmx := waitMixin{}
-//	wmx.client = cli
-//	return wmx.wait(id)
-//}
-//
-//func ColorMixin(cmode, umode string) colorMixin {
-//	return colorMixin{
-//		Color:        cmode,
-//		unicodeMixin: unicodeMixin{Unicode: umode},
-//	}
-//}
-//
-//func CmdAdviseSnap() *cmdAdviseSnap {
-//	return &cmdAdviseSnap{}
-//}
-//
-//func MockSELinuxIsEnabled(isEnabled func() (bool, error)) (restore func()) {
-//	old := selinuxIsEnabled
-//	selinuxIsEnabled = isEnabled
-//	return func() {
-//		selinuxIsEnabled = old
-//	}
-//}
-//
-//func MockSELinuxVerifyPathContext(verifypathcon func(string) (bool, error)) (restore func()) {
-//	old := selinuxVerifyPathContext
-//	selinuxVerifyPathContext = verifypathcon
-//	return func() {
-//		selinuxVerifyPathContext = old
-//	}
-//}
-//
-//func MockSELinuxRestoreContext(restorecon func(string, selinux.RestoreMode) error) (restore func()) {
-//	old := selinuxRestoreContext
-//	selinuxRestoreContext = restorecon
-//	return func() {
-//		selinuxRestoreContext = old
-//	}
-//}
-//
-//func MockTermSize(newTermSize func() (int, int)) (restore func()) {
-//	old := termSize
-//	termSize = newTermSize
-//	return func() {
-//		termSize = old
-//	}
-//}
-//
-//func MockImagePrepare(newImagePrepare func(*image.Options) error) (restore func()) {
-//	old := imagePrepare
-//	imagePrepare = newImagePrepare
-//	return func() {
-//		imagePrepare = old
-//	}
-//}
-//
-//type ServiceName = serviceName

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -543,7 +543,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		// those open requests resulted in something that
 		// prevents us from going into socket activation mode.
 		//
-		// If this is the case we do a "normal" snapd restart
+		// If this is the case we do a "normal" pebble restart
 		// to process the new changes.
 		if !d.standbyOpinions.CanStandby() {
 			d.restartSocket = false
@@ -555,7 +555,7 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	if err != nil {
 		// do not stop the shutdown even if the tomb errors
 		// because we already scheduled a slow shutdown and
-		// exiting here will just restart snapd (via systemd)
+		// exiting here will just restart pebble (via systemd)
 		// which will lead to confusing results.
 		if restartSystem {
 			logger.Noticef("WARNING: cannot stop daemon: %v", err)
@@ -589,7 +589,7 @@ func (d *Daemon) rebootDelay() (time.Duration, error) {
 	if err == nil {
 		rebootDelay = rebootAt.Sub(now)
 	} else {
-		ovr := os.Getenv("SNAPD_REBOOT_DELAY") // for tests
+		ovr := os.Getenv("PEBBLE_REBOOT_DELAY") // for tests
 		if ovr != "" {
 			d, err := time.ParseDuration(ovr)
 			if err == nil {
@@ -608,7 +608,7 @@ func (d *Daemon) doReboot(sigCh chan<- os.Signal, waitTimeout time.Duration) err
 		return err
 	}
 	// ask for shutdown and wait for it to happen.
-	// if we exit snapd will be restared by systemd
+	// if we exit, pebble will be restarted by systemd
 	if err := reboot(rebootDelay); err != nil {
 		return err
 	}
@@ -674,12 +674,12 @@ func (d *Daemon) RebootIsMissing(st *state.State) error {
 		// might get rolled back!!
 		st.ClearReboot()
 		clearReboot(st)
-		logger.Noticef("snapd was restarted while a system restart was expected, snapd retried to schedule and waited again for a system restart %d times and is giving up", rebootMaxTentatives)
+		logger.Noticef("pebble was restarted while a system restart was expected, pebble retried to schedule and waited again for a system restart %d times and is giving up", rebootMaxTentatives)
 		return nil
 	}
 	st.Set("daemon-system-restart-tentative", nTentative)
 	d.state = st
-	logger.Noticef("snapd was restarted while a system restart was expected, snapd will try to schedule and wait for a system restart again (tenative %d/%d)", nTentative, rebootMaxTentatives)
+	logger.Noticef("pebble was restarted while a system restart was expected, pebble will try to schedule and wait for a system restart again (tenative %d/%d)", nTentative, rebootMaxTentatives)
 	return state.ErrExpectedReboot
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -109,7 +109,7 @@ func (s *daemonSuite) TestExplicitPaths(c *C) {
 }
 
 func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
-	fakeUserAgent := "some-agent-talking-to-snapd/1.0"
+	fakeUserAgent := "some-agent-talking-to-pebble/1.0"
 
 	cmd := &Command{d: s.newDaemon(c)}
 	handler := &fakeHandler{cmd: cmd}
@@ -316,8 +316,8 @@ func (s *daemonSuite) TestUserAccess(c *check.C) {
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessOK)
 	c.Check(cmd.canAccess(put, nil), check.Equals, accessUnauthorized)
 
-	// Since this request has a RemoteAddr, it must be coming from the snapd
-	// socket instead of the snap one. In that case, UntrustedOK should have no
+	// Since this request has a RemoteAddr, it must be coming from the pebble server
+	// socket instead of the pebble one. In that case, UntrustedOK should have no
 	// bearing on the default behavior, which is to deny access.
 	cmd = &Command{d: d, UntrustedOK: true}
 	c.Check(cmd.canAccess(get, nil), check.Equals, accessUnauthorized)
@@ -780,7 +780,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
 }
 
 // This test tests that when there is a shutdown we close the sigterm
-// handler so that systemd can kill snapd.
+// handler so that systemd can kill pebble.
 func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	oldRebootNoticeWait := rebootNoticeWait
 	oldRebootWaitTimeout := rebootWaitTimeout

--- a/internal/daemon/response.go
+++ b/internal/daemon/response.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"time"
 
 	"github.com/canonical/pebble/internal/logger"
-	"time"
 )
 
 type ResponseType string

--- a/internal/daemon/ucrednet_test.go
+++ b/internal/daemon/ucrednet_test.go
@@ -180,15 +180,15 @@ func (s *ucrednetSuite) TestGetNothing(c *check.C) {
 }
 
 func (s *ucrednetSuite) TestGet(c *check.C) {
-	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;")
+	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/.pebble.socket;")
 	c.Check(err, check.IsNil)
 	c.Check(pid, check.Equals, int32(100))
 	c.Check(uid, check.Equals, uint32(42))
-	c.Check(socket, check.Equals, "/run/snap.socket")
+	c.Check(socket, check.Equals, "/run/.pebble.socket")
 }
 
 func (s *ucrednetSuite) TestGetSneak(c *check.C) {
-	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/snap.socket;pid=0;uid=0;socket=/tmp/my.socket")
+	pid, uid, socket, err := ucrednetGet("pid=100;uid=42;socket=/run/.pebble.socket;pid=0;uid=0;socket=/tmp/my.socket")
 	c.Check(err, check.Equals, errNoID)
 	c.Check(pid, check.Equals, ucrednetNoProcess)
 	c.Check(uid, check.Equals, ucrednetNobody)
@@ -196,9 +196,9 @@ func (s *ucrednetSuite) TestGetSneak(c *check.C) {
 }
 
 func (s *ucrednetSuite) TestGetWithZeroPid(c *check.C) {
-	pid, uid, socket, err := ucrednetGet("pid=0;uid=42;socket=/run/snap.socket;")
+	pid, uid, socket, err := ucrednetGet("pid=0;uid=42;socket=/run/.pebble.socket;")
 	c.Check(err, check.IsNil)
 	c.Check(pid, check.Equals, int32(0))
 	c.Check(uid, check.Equals, uint32(42))
-	c.Check(socket, check.Equals, "/run/snap.socket")
+	c.Check(socket, check.Equals, "/run/.pebble.socket")
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -55,7 +55,7 @@ func (s *LogSuite) TestDebugf(c *C) {
 
 func (s *LogSuite) TestDebugfEnv(c *C) {
 	os.Setenv("PEBBLE_DEBUG", "1")
-	defer os.Unsetenv("SNAPD_DEBUG")
+	defer os.Unsetenv("PEBBLE_DEBUG")
 
 	logger.Debugf("xyzzy")
 	c.Check(s.logbuf.String(), Matches, `.* PREFIX: DEBUG xyzzy.*\n`)

--- a/internal/osutil/mkdirallchown.go
+++ b/internal/osutil/mkdirallchown.go
@@ -24,8 +24,6 @@ import (
 )
 
 // XXX: we need to come back and fix this; this is a hack to unblock us.
-//      As part of the fixing we should unify with the similar code in
-//      cmd/snap-update-ns/utils.(*Secure).MkdirAll
 var mu sync.Mutex
 
 // MkdirAllChown is like os.MkdirAll but it calls os.Chown on any

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -161,8 +161,7 @@ func loadState(statePath string, restartBehavior RestartBehavior, backend state.
 	}
 
 	if !osutil.CanStat(statePath) {
-		// fail fast, mostly interesting for tests, this dir is setup
-		// by the snapd package
+		// fail fast, mostly interesting for tests, this dir is set up by pebble
 		stateDir := filepath.Dir(statePath)
 		if !osutil.IsDir(stateDir) {
 			return nil, fmt.Errorf("fatal: directory %q must be present", stateDir)

--- a/internal/overlord/standby/standby.go
+++ b/internal/overlord/standby/standby.go
@@ -29,7 +29,7 @@ type Opinionator interface {
 	CanStandby() bool
 }
 
-// StandbyOpinions tracks if snapd can go into socket activation mode
+// StandbyOpinions tracks if pebble can go into socket activation mode
 type StandbyOpinions struct {
 	state     *state.State
 	startTime time.Time

--- a/internal/overlord/state/state.go
+++ b/internal/overlord/state/state.go
@@ -291,7 +291,7 @@ func (s *State) Restarting() (bool, RestartType) {
 
 var ErrExpectedReboot = errors.New("expected reboot did not happen")
 
-// VerifyReboot checks if the state rembers that a system restart was
+// VerifyReboot checks if the state remembers that a system restart was
 // requested and whether it succeeded based on the provided current
 // boot id.  It returns ErrExpectedReboot if the expected reboot did
 // not happen yet.  It must be called early in the usage of state and

--- a/internal/overlord/state/state_test.go
+++ b/internal/overlord/state/state_test.go
@@ -426,7 +426,7 @@ func (ss *stateSuite) TestNewTaskAndCheckpoint(c *C) {
 	t1ID := t1.ID()
 	t1.Set("a", 1)
 	t1.SetStatus(state.DoneStatus)
-	t1.SetProgress("snap", 5, 10)
+	t1.SetProgress("foo", 5, 10)
 	t1.JoinLane(42)
 	t1.JoinLane(43)
 

--- a/internal/overlord/state/task.go
+++ b/internal/overlord/state/task.go
@@ -468,7 +468,7 @@ func (t *Task) At(when time.Time) {
 // TaskSetEdge designates tasks inside a TaskSet for outside reference.
 //
 // This is useful to give tasks inside TaskSets a special meaning. It
-// is used to mark e.g. the last task used for downloading a snap.
+// is used to mark e.g. the last task in a task set.
 type TaskSetEdge string
 
 // A TaskSet holds a set of tasks.

--- a/internal/overlord/state/task_test.go
+++ b/internal/overlord/state/task_test.go
@@ -174,9 +174,9 @@ func (ts *taskSuite) TestProgressAndSetProgress(c *C) {
 
 	t := st.NewTask("download", "1...")
 
-	t.SetProgress("snap", 2, 99)
+	t.SetProgress("foo", 2, 99)
 	label, cur, tot := t.Progress()
-	c.Check(label, Equals, "snap")
+	c.Check(label, Equals, "foo")
 	c.Check(cur, Equals, 2)
 	c.Check(tot, Equals, 99)
 

--- a/internal/strutil/strutil.go
+++ b/internal/strutil/strutil.go
@@ -57,7 +57,7 @@ func SizeToStr(size int64) string {
 }
 
 // Quoted formats a slice of strings to a quoted list of
-// comma-separated strings, e.g. `"snap1", "snap2"`
+// comma-separated strings, e.g. `"foo", "bar"`
 func Quoted(names []string) string {
 	quoted := make([]string, len(names))
 	for i, name := range names {

--- a/internal/testutil/base.go
+++ b/internal/testutil/base.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-// BaseTest is a structure used as a base test suite for all the snappy
+// BaseTest is a structure used as a base test suite for many of the pebble
 // tests.
 type BaseTest struct {
 	cleanupHandlers []func()


### PR DESCRIPTION
Because of the history of pebble code being copied from snapd, there are still a bunch of snap/snapd references scattered throughout the code. This removes the most obvious ones in comments and the like. It also deletes a bunch of commented-out code in `cmd/pebble/export_test.go` (that's what version control is for :-).

I would also like to remove the systemd/standby stuff that I believe is specific to snapd, but that's a heavier change so I'd like to discuss that first.