### PR TITLE
Crossport restart package from snapd.

### DIFF
--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/pebble/internal/overlord"
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/state"
 )
 
@@ -111,7 +112,7 @@ func v1SystemInfo(c *Command, r *http.Request, _ *userState) Response {
 	defer state.Unlock()
 	result := map[string]interface{}{
 		"version": c.d.Version,
-		"boot-id": state.BootID(),
+		"boot-id": restart.BootID(state),
 	}
 	return SyncResponse(result)
 }

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -19,8 +19,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/canonical/pebble/internal/overlord/restart"
 	"gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/overlord/restart"
 )
 
 var _ = check.Suite(&apiSuite{})

--- a/internal/daemon/api_test.go
+++ b/internal/daemon/api_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"gopkg.in/check.v1"
 )
 
@@ -82,7 +83,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	d.Version = "42b1"
 	state := d.overlord.State()
 	state.Lock()
-	state.VerifyReboot("ffffffff-ffff-ffff-ffff-ffffffffffff")
+	restart.Init(state, "ffffffff-ffff-ffff-ffff-ffffffffffff", nil)
 	state.Unlock()
 
 	sysInfoCmd.GET(sysInfoCmd, nil, nil).ServeHTTP(rec, nil)

--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -26,10 +26,10 @@ import (
 
 	"gopkg.in/tomb.v2"
 
-	"github.com/canonical/pebble/internal/logger"
 	"github.com/canonical/pebble/internal/osutil"
 	"github.com/canonical/pebble/internal/overlord/cmdstate"
 	"github.com/canonical/pebble/internal/overlord/patch"
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/servstate"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/strutil"
@@ -47,20 +47,6 @@ var (
 	defaultCachedDownloads = 5
 )
 
-// RestartBehavior controls how to handle and carry forward restart requests
-// via the state.
-type RestartBehavior interface {
-	HandleRestart(t state.RestartType)
-
-	// RebootIsFine is called early when either a reboot was
-	// requested and happened or no reboot was expected at all.
-	RebootIsFine(st *state.State) error
-
-	// RebootIsMissing is called early instead when a reboot was
-	// requested but did not happen.
-	RebootIsMissing(st *state.State) error
-}
-
 // Overlord is the central manager of the system, keeping track
 // of all available state managers and related helpers.
 type Overlord struct {
@@ -75,9 +61,6 @@ type Overlord struct {
 	ensureRun   int32
 	pruneTicker *time.Ticker
 
-	// restarts
-	restartBehavior RestartBehavior
-
 	// managers
 	inited     bool
 	runner     *state.TaskRunner
@@ -86,13 +69,12 @@ type Overlord struct {
 }
 
 // New creates a new Overlord with all its state managers.
-// It can be provided with an optional RestartBehavior.
-func New(pebbleDir string, restartBehavior RestartBehavior, serviceOutput io.Writer) (*Overlord, error) {
+// It can be provided with an optional restart.Handler.
+func New(pebbleDir string, restartHandler restart.Handler, serviceOutput io.Writer) (*Overlord, error) {
 	o := &Overlord{
-		pebbleDir:       pebbleDir,
-		loopTomb:        new(tomb.Tomb),
-		inited:          true,
-		restartBehavior: restartBehavior,
+		pebbleDir: pebbleDir,
+		loopTomb:  new(tomb.Tomb),
+		inited:    true,
 	}
 
 	if !filepath.IsAbs(pebbleDir) {
@@ -104,11 +86,10 @@ func New(pebbleDir string, restartBehavior RestartBehavior, serviceOutput io.Wri
 	statePath := filepath.Join(pebbleDir, ".pebble.state")
 
 	backend := &overlordStateBackend{
-		path:           statePath,
-		ensureBefore:   o.ensureBefore,
-		requestRestart: o.requestRestart,
+		path:         statePath,
+		ensureBefore: o.ensureBefore,
 	}
-	s, err := loadState(statePath, restartBehavior, backend)
+	s, err := loadState(statePath, restartHandler, backend)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +103,7 @@ func New(pebbleDir string, restartBehavior RestartBehavior, serviceOutput io.Wri
 	}
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
-	o.serviceMgr, err = servstate.NewManager(s, o.runner, o.pebbleDir, serviceOutput, restartBehavior)
+	o.serviceMgr, err = servstate.NewManager(s, o.runner, o.pebbleDir, serviceOutput, restartHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +122,7 @@ func (o *Overlord) addManager(mgr StateManager) {
 	o.stateEng.AddManager(mgr)
 }
 
-func loadState(statePath string, restartBehavior RestartBehavior, backend state.Backend) (*state.State, error) {
+func loadState(statePath string, restartHandler restart.Handler, backend state.Backend) (*state.State, error) {
 	timings := timing.Start("", "", map[string]string{"startup": "load-state"})
 
 	curBootID, err := osutil.BootID()
@@ -167,9 +148,7 @@ func loadState(statePath string, restartBehavior RestartBehavior, backend state.
 			return nil, fmt.Errorf("fatal: directory %q must be present", stateDir)
 		}
 		s := state.New(backend)
-		s.Lock()
-		s.VerifyReboot(curBootID)
-		s.Unlock()
+		initRestart(s, curBootID, restartHandler)
 		patch.Init(s)
 		return s, nil
 	}
@@ -194,7 +173,7 @@ func loadState(statePath string, restartBehavior RestartBehavior, backend state.
 	//perfTimings.Save(s)
 	//s.Unlock()
 
-	err = verifyReboot(s, curBootID, restartBehavior)
+	err = initRestart(s, curBootID, restartHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -207,24 +186,10 @@ func loadState(statePath string, restartBehavior RestartBehavior, backend state.
 	return s, nil
 }
 
-func verifyReboot(s *state.State, curBootID string, restartBehavior RestartBehavior) error {
+func initRestart(s *state.State, curBootID string, restartHandler restart.Handler) error {
 	s.Lock()
 	defer s.Unlock()
-	err := s.VerifyReboot(curBootID)
-	if err != nil && err != state.ErrExpectedReboot {
-		return err
-	}
-	rebootMissing := err == state.ErrExpectedReboot
-	if restartBehavior != nil {
-		if rebootMissing {
-			return restartBehavior.RebootIsMissing(s)
-		}
-		return restartBehavior.RebootIsFine(s)
-	}
-	if rebootMissing {
-		logger.Noticef("expected system reboot but it did not happen")
-	}
-	return nil
+	return restart.Init(s, curBootID, restartHandler)
 }
 
 func (o *Overlord) ensureTimerSetup() {
@@ -266,14 +231,6 @@ func (o *Overlord) ensureBefore(d time.Duration) {
 		}
 		o.ensureTimer.Reset(0)
 		o.ensureNext = now
-	}
-}
-
-func (o *Overlord) requestRestart(t state.RestartType) {
-	if o.restartBehavior == nil {
-		logger.Noticef("restart requested but no behavior set")
-	} else {
-		o.restartBehavior.HandleRestart(t)
 	}
 }
 
@@ -437,18 +394,16 @@ func (o *Overlord) CommandManager() *cmdstate.CommandManager {
 // Fake creates an Overlord without any managers and with a backend
 // not using disk. Managers can be added with AddManager. For testing.
 func Fake() *Overlord {
-	return FakeWithRestartHandler(nil)
+	return FakeWithState(nil)
 }
 
-// FakeWithRestartHandler creates an Overlord without any managers and
-// with a backend not using disk. It will use the given handler on
-// restart requests. Managers can be added with AddManager. For
+// FakeWithState creates an Overlord without any managers and
+// with a backend not using disk. Managers can be added with AddManager. For
 // testing.
-func FakeWithRestartHandler(handleRestart func(state.RestartType)) *Overlord {
+func FakeWithState(handleRestart func(restart.RestartType)) *Overlord {
 	o := &Overlord{
-		loopTomb:        new(tomb.Tomb),
-		inited:          false,
-		restartBehavior: fakeRestartBehavior(handleRestart),
+		loopTomb: new(tomb.Tomb),
+		inited:   false,
 	}
 	s := state.New(fakeBackend{o: o})
 	o.stateEng = NewStateEngine(s)
@@ -463,23 +418,6 @@ func (o *Overlord) AddManager(mgr StateManager) {
 		panic("internal error: cannot add managers to a fully initialized Overlord")
 	}
 	o.addManager(mgr)
-}
-
-type fakeRestartBehavior func(state.RestartType)
-
-func (rb fakeRestartBehavior) HandleRestart(t state.RestartType) {
-	if rb == nil {
-		return
-	}
-	rb(t)
-}
-
-func (rb fakeRestartBehavior) RebootIsFine(*state.State) error {
-	panic("internal error: overlord.Fake should not invoke RebootIsFine")
-}
-
-func (rb fakeRestartBehavior) RebootIsMissing(*state.State) error {
-	panic("internal error: overlord.Fake should not invoke RebootIsMissing")
 }
 
 type fakeBackend struct {
@@ -501,6 +439,6 @@ func (mb fakeBackend) EnsureBefore(d time.Duration) {
 	mb.o.ensureBefore(d)
 }
 
-func (mb fakeBackend) RequestRestart(t state.RestartType) {
-	mb.o.requestRestart(t)
+func (mb fakeBackend) RequestRestart(t restart.RestartType) {
+	panic("SHOULD NOT BE REACHED")
 }

--- a/internal/overlord/restart/restart.go
+++ b/internal/overlord/restart/restart.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2014-2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package restart implements requesting restarts from any part of the code that has access to state.
+package restart
+
+import (
+	"github.com/canonical/pebble/internal/overlord/state"
+)
+
+type RestartType int
+
+const (
+	RestartUnset RestartType = iota
+	RestartDaemon
+	RestartSystem
+	// RestartSystemNow is like RestartSystem but action is immediate
+	RestartSystemNow
+	// RestartSocket will restart the daemon so that it goes into
+	// socket activation mode.
+	RestartSocket
+	// Stop just stops the daemon (used with image pre-seeding)
+	StopDaemon
+	// RestartSystemHaltNow will shutdown --halt the system asap
+	RestartSystemHaltNow
+	// RestartSystemPoweroffNow will shutdown --poweroff the system asap
+	RestartSystemPoweroffNow
+)
+
+// Handler can handle restart requests and whether expected reboots happen.
+type Handler interface {
+	HandleRestart(t RestartType)
+	// RebootIsFine is called early when either a reboot was
+	// requested by snapd and happened or no reboot was expected at all.
+	RebootIsFine(st *state.State) error
+	// RebootIsMissing is called early instead when a reboot was
+	// requested by snapd but did not happen.
+	RebootIsMissing(st *state.State) error
+}
+
+// Init initializes the support for restarts requests.
+// It takes the current boot id to track and verify reboots and a
+// Handler that handles the actual requests and reacts to reboot
+// happening.
+// It must be called with the state lock held.
+func Init(st *state.State, curBootID string, h Handler) error {
+	rs := &restartState{
+		h:      h,
+		bootID: curBootID,
+	}
+	var fromBootID string
+	err := st.Get("system-restart-from-boot-id", &fromBootID)
+	if err != nil && err != state.ErrNoState {
+		return err
+	}
+	st.Cache(restartStateKey{}, rs)
+	if fromBootID == "" {
+		return rs.rebootAsExpected(st)
+	}
+	if fromBootID == curBootID {
+		return rs.rebootDidNotHappen(st)
+	}
+	// we rebooted alright
+	ClearReboot(st)
+	return rs.rebootAsExpected(st)
+}
+
+// ClearReboot clears state information about tracking requested reboots.
+func ClearReboot(st *state.State) {
+	st.Set("system-restart-from-boot-id", nil)
+}
+
+type restartStateKey struct{}
+
+type restartState struct {
+	restarting RestartType
+	h          Handler
+	bootID     string
+}
+
+func (rs *restartState) handleRestart(t RestartType) {
+	if rs.h != nil {
+		rs.h.HandleRestart(t)
+	}
+}
+
+func (rs *restartState) rebootAsExpected(st *state.State) error {
+	if rs.h != nil {
+		return rs.h.RebootIsFine(st)
+	}
+	return nil
+}
+
+func (rs *restartState) rebootDidNotHappen(st *state.State) error {
+	if rs.h != nil {
+		return rs.h.RebootIsMissing(st)
+	}
+	return nil
+}
+
+// Request asks for a restart of the managing process.
+// The state needs to be locked to request a restart.
+func Request(st *state.State, t RestartType) {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot request a restart before restart.Init")
+	}
+	rs := cached.(*restartState)
+	switch t {
+	case RestartSystem, RestartSystemNow, RestartSystemHaltNow, RestartSystemPoweroffNow:
+		st.Set("system-restart-from-boot-id", rs.bootID)
+	}
+	rs.restarting = t
+	rs.handleRestart(t)
+}
+
+// Pending returns whether a restart was requested with Request and of which type.
+func Pending(st *state.State) (bool, RestartType) {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		return false, RestartUnset
+	}
+	rs := cached.(*restartState)
+	return rs.restarting != RestartUnset, rs.restarting
+}
+
+func FakePending(st *state.State, restarting RestartType) RestartType {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot fake a restart request before restart.Init")
+	}
+	rs := cached.(*restartState)
+	old := rs.restarting
+	rs.restarting = restarting
+	return old
+}
+
+func ReplaceBootID(st *state.State, bootID string) {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot fake a restart request before restart.Init")
+	}
+	rs := cached.(*restartState)
+	rs.bootID = bootID
+}
+
+func BootID(st *state.State) string {
+	cached := st.Cached(restartStateKey{})
+	if cached == nil {
+		panic("internal error: cannot fake a restart request before restart.Init")
+	}
+	rs := cached.(*restartState)
+	return rs.bootID
+}

--- a/internal/overlord/restart/restart_test.go
+++ b/internal/overlord/restart/restart_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2014-2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package restart_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/overlord/restart"
+	"github.com/canonical/pebble/internal/overlord/state"
+)
+
+func TestRestart(t *testing.T) { TestingT(t) }
+
+type restartSuite struct{}
+
+var _ = Suite(&restartSuite{})
+
+type testHandler struct {
+	restartRequested   bool
+	rebootAsExpected   bool
+	rebootDidNotHappen bool
+}
+
+func (h *testHandler) HandleRestart(t restart.RestartType) {
+	h.restartRequested = true
+}
+
+func (h *testHandler) RebootIsFine(*state.State) error {
+	h.rebootAsExpected = true
+	return nil
+}
+
+func (h *testHandler) RebootIsMissing(*state.State) error {
+	h.rebootDidNotHappen = true
+	return nil
+}
+
+func (s *restartSuite) TestRequestRestartDaemon(c *C) {
+	st := state.New(nil)
+
+	st.Lock()
+	defer st.Unlock()
+
+	// uninitialized
+	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+
+	h := &testHandler{}
+
+	err := restart.Init(st, "boot-id-1", h)
+	c.Assert(err, IsNil)
+	c.Check(h.rebootAsExpected, Equals, true)
+
+	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+
+	restart.Request(st, restart.RestartDaemon)
+
+	c.Check(h.restartRequested, Equals, true)
+
+	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartDaemon)
+}
+
+func (s *restartSuite) TestRequestRestartDaemonNoHandler(c *C) {
+	st := state.New(nil)
+
+	st.Lock()
+	defer st.Unlock()
+
+	err := restart.Init(st, "boot-id-1", nil)
+	c.Assert(err, IsNil)
+
+	restart.Request(st, restart.RestartDaemon)
+
+	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartDaemon)
+}
+
+func (s *restartSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	h := &testHandler{}
+	err := restart.Init(st, "boot-id-1", h)
+	c.Assert(err, IsNil)
+	c.Check(h.rebootAsExpected, Equals, true)
+
+	ok, t := restart.Pending(st)
+	c.Check(ok, Equals, false)
+	c.Check(t, Equals, restart.RestartUnset)
+
+	restart.Request(st, restart.RestartSystem)
+
+	c.Check(h.restartRequested, Equals, true)
+
+	ok, t = restart.Pending(st)
+	c.Check(ok, Equals, true)
+	c.Check(t, Equals, restart.RestartSystem)
+
+	var fromBootID string
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
+	c.Check(fromBootID, Equals, "boot-id-1")
+
+	h1 := &testHandler{}
+	err = restart.Init(st, "boot-id-1", h1)
+	c.Assert(err, IsNil)
+	c.Check(h1.rebootAsExpected, Equals, false)
+	c.Check(h1.rebootDidNotHappen, Equals, true)
+	fromBootID = ""
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), IsNil)
+	c.Check(fromBootID, Equals, "boot-id-1")
+
+	h2 := &testHandler{}
+	err = restart.Init(st, "boot-id-2", h2)
+	c.Assert(err, IsNil)
+	c.Check(h2.rebootAsExpected, Equals, true)
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), Equals, state.ErrNoState)
+}

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/canonical/pebble/internal/logger"
 	"github.com/canonical/pebble/internal/osutil"
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/plan"
 	"github.com/canonical/pebble/internal/servicelog"
@@ -410,7 +411,7 @@ func (s *serviceData) exited(waitErr error) error {
 
 		case plan.ActionHalt:
 			logger.Noticef("Service %q %s action is %q, triggering server exit", s.config.Name, onType, action)
-			s.manager.restarter.HandleRestart(state.RestartDaemon)
+			s.manager.restarter.HandleRestart(restart.RestartDaemon)
 			s.transition(stateStopped)
 
 		case plan.ActionRestart:

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/plan"
 	"github.com/canonical/pebble/internal/servicelog"
@@ -33,7 +34,7 @@ type ServiceManager struct {
 }
 
 type Restarter interface {
-	HandleRestart(t state.RestartType)
+	HandleRestart(t restart.RestartType)
 }
 
 // LabelExists is the error returned by AppendLayer when a layer with that

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -33,6 +33,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/pebble/internal/logger"
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/servstate"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/plan"
@@ -155,7 +156,7 @@ type testRestarter struct {
 	ch chan struct{}
 }
 
-func (r testRestarter) HandleRestart(t state.RestartType) {
+func (r testRestarter) HandleRestart(t restart.RestartType) {
 	close(r.ch)
 }
 

--- a/internal/overlord/standby/export_test.go
+++ b/internal/overlord/standby/export_test.go
@@ -16,18 +16,8 @@ package standby
 
 import (
 	"time"
-
-	"github.com/canonical/pebble/internal/overlord/state"
 )
 
 func (m *StandbyOpinions) SetStartTime(t time.Time) {
 	m.startTime = t
-}
-
-func FakeStateRequestRestart(newStateRequestRestart func(*state.State, state.RestartType)) (restore func()) {
-	oldStateRequestRestart := stateRequestRestart
-	stateRequestRestart = newStateRequestRestart
-	return func() {
-		stateRequestRestart = oldStateRequestRestart
-	}
 }

--- a/internal/overlord/state/taskrunner_test.go
+++ b/internal/overlord/state/taskrunner_test.go
@@ -31,6 +31,7 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
+	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/state"
 )
 
@@ -57,7 +58,7 @@ func (b *stateBackend) EnsureBefore(d time.Duration) {
 	}
 }
 
-func (b *stateBackend) RequestRestart(t state.RestartType) {}
+func (b *stateBackend) RequestRestart(t restart.RestartType) {}
 
 func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change) {
 	for i := 0; i < 20; i++ {


### PR DESCRIPTION
This PR crossports the restart package and related changes from snapd.

It brings pebble inline with the snapd upstream to simplify state by removing the restart concerns into its own package with good separation.

Relevant commits pulled across https://github.com/snapcore/snapd/commits/master/overlord/restart