### PR TITLE
Add finalizer support to block shutdown for a remote finalizer

### DIFF
--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -45,6 +45,7 @@ type cmdRun struct {
 
 	CreateDirs bool `long:"create-dirs"`
 	Hold       bool `long:"hold"`
+	Finalizer  bool `long:"finalizer"`
 	Verbose    bool `short:"v" long:"verbose"`
 }
 
@@ -54,6 +55,7 @@ func init() {
 			"create-dirs": "Create pebble directory on startup if it doesn't exist",
 			"hold":        "Do not start default services automatically",
 			"verbose":     "Log all output from services to stdout",
+			"finalizer":   "Block shutdown until a remote finalizer has completed",
 		}, nil)
 }
 
@@ -128,6 +130,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal) error {
 	dopts := daemon.Options{
 		Dir:        pebbleDir,
 		SocketPath: socketPath,
+		Finalizer:  rcmd.Finalizer,
 	}
 	if rcmd.Verbose {
 		dopts.ServiceOutput = os.Stdout

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -29,6 +29,10 @@ var api = []*Command{{
 	GuestOK: true,
 	GET:     v1SystemInfo,
 }, {
+	Path:   "/v1/finalize",
+	UserOK: true,
+	POST:   v1Finalize,
+}, {
 	Path:   "/v1/warnings",
 	UserOK: true,
 	GET:    v1GetWarnings,
@@ -114,4 +118,9 @@ func v1SystemInfo(c *Command, r *http.Request, _ *userState) Response {
 		"boot-id": state.BootID(),
 	}
 	return SyncResponse(result)
+}
+
+func v1Finalize(c *Command, r *http.Request, _ *userState) Response {
+	c.d.finalize()
+	return SyncResponse(map[string]interface{}{})
 }

--- a/internal/daemon/api_changes_test.go
+++ b/internal/daemon/api_changes_test.go
@@ -50,7 +50,7 @@ func (s *apiSuite) TestStateChangesDefaultToInProgress(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	setupChanges(st)
@@ -79,7 +79,7 @@ func (s *apiSuite) TestStateChangesInProgress(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	setupChanges(st)
@@ -108,7 +108,7 @@ func (s *apiSuite) TestStateChangesAll(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	setupChanges(st)
@@ -137,7 +137,7 @@ func (s *apiSuite) TestStateChangesReady(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	setupChanges(st)
@@ -165,7 +165,7 @@ func (s *apiSuite) TestStateChangesForServiceName(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	setupChanges(st)
@@ -196,7 +196,7 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	ids := setupChanges(st)
@@ -271,7 +271,7 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	ids := setupChanges(st)
@@ -338,7 +338,7 @@ func (s *apiSuite) TestStateChangeAbortIsReady(c *check.C) {
 	defer restore()
 
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	ids := setupChanges(st)
@@ -372,7 +372,7 @@ func (s *apiSuite) TestStateChangeAbortIsReady(c *check.C) {
 }
 
 func (s *apiSuite) TestWaitChangeNotFound(c *check.C) {
-	s.daemon(c)
+	s.daemon(c, nil)
 	req, err := http.NewRequest("GET", "/v1/changes/x/wait", nil)
 	c.Assert(err, check.IsNil)
 	rsp := v1GetChangeWait(apiCmd("/v1/changes/{id}/wait"), req, nil).(*resp)
@@ -446,7 +446,7 @@ func (s *apiSuite) TestWaitChangeTimeoutCancel(c *check.C) {
 
 func (s *apiSuite) testWaitChange(ctx context.Context, c *check.C, query string, markReady func(st *state.State, change *state.Change)) (*httptest.ResponseRecorder, *resp, string) {
 	// Setup
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 	st.Lock()
 	change := st.NewChange("exec", "Exec")

--- a/internal/daemon/api_plan_test.go
+++ b/internal/daemon/api_plan_test.go
@@ -42,7 +42,7 @@ func (s *apiSuite) TestGetPlanErrors(c *C) {
 		{"/v1/layers?format=foo", 400, `invalid format "foo"`},
 	}
 
-	_ = s.daemon(c)
+	_ = s.daemon(c, nil)
 	planCmd := apiCmd("/v1/plan")
 
 	for _, test := range tests {
@@ -60,7 +60,7 @@ func (s *apiSuite) TestGetPlanErrors(c *C) {
 
 func (s *apiSuite) TestGetPlan(c *C) {
 	writeTestLayer(s.pebbleDir, planLayer)
-	_ = s.daemon(c)
+	_ = s.daemon(c, nil)
 	planCmd := apiCmd("/v1/plan")
 
 	req, err := http.NewRequest("GET", "/v1/plan?format=yaml", nil)
@@ -111,7 +111,7 @@ func (s *apiSuite) TestLayersErrors(c *C) {
 		{`{"action": "add", "label": "x", "format": "yaml", "layer": "@"}`, 400, `cannot parse layer YAML: .*`},
 	}
 
-	_ = s.daemon(c)
+	_ = s.daemon(c, nil)
 	layersCmd := apiCmd("/v1/layers")
 
 	for _, test := range tests {
@@ -129,7 +129,7 @@ func (s *apiSuite) TestLayersErrors(c *C) {
 
 func (s *apiSuite) TestLayersAddAppend(c *C) {
 	writeTestLayer(s.pebbleDir, planLayer)
-	_ = s.daemon(c)
+	_ = s.daemon(c, nil)
 	layersCmd := apiCmd("/v1/layers")
 
 	payload := `{"action": "add", "label": "foo", "format": "yaml", "layer": "services:\n dynamic:\n  override: replace\n  command: echo dynamic\n"}`
@@ -156,7 +156,7 @@ services:
 
 func (s *apiSuite) TestLayersAddCombine(c *C) {
 	writeTestLayer(s.pebbleDir, planLayer)
-	_ = s.daemon(c)
+	_ = s.daemon(c, nil)
 	layersCmd := apiCmd("/v1/layers")
 
 	payload := `{"action": "add", "combine": true, "label": "base", "format": "yaml", "layer": "services:\n dynamic:\n  override: replace\n  command: echo dynamic\n"}`
@@ -183,7 +183,7 @@ services:
 
 func (s *apiSuite) TestLayersCombineFormatError(c *C) {
 	writeTestLayer(s.pebbleDir, planLayer)
-	_ = s.daemon(c)
+	_ = s.daemon(c, nil)
 	layersCmd := apiCmd("/v1/layers")
 
 	payload := `{"action": "add", "combine": true, "label": "base", "format": "yaml", "layer": "services:\n dynamic:\n  command: echo dynamic\n"}`

--- a/internal/daemon/api_services_test.go
+++ b/internal/daemon/api_services_test.go
@@ -69,7 +69,7 @@ func writeTestLayer(pebbleDir, layerYAML string) {
 func (s *apiSuite) TestServicesStart(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 
 	soon := 0
@@ -116,7 +116,7 @@ func (s *apiSuite) TestServicesStart(c *C) {
 func (s *apiSuite) TestServicesStop(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 
 	soon := 0
@@ -163,7 +163,7 @@ func (s *apiSuite) TestServicesStop(c *C) {
 func (s *apiSuite) TestServicesAutoStart(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 
 	soon := 0
@@ -206,7 +206,7 @@ func (s *apiSuite) TestServicesAutoStart(c *C) {
 func (s *apiSuite) TestServicesGet(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
-	s.daemon(c)
+	s.daemon(c, nil)
 
 	// Execute
 	req, err := http.NewRequest("GET", "/v1/services", nil)
@@ -234,7 +234,7 @@ func (s *apiSuite) TestServicesGet(c *C) {
 func (s *apiSuite) TestServicesRestart(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 
 	soon := 0
@@ -283,7 +283,7 @@ func (s *apiSuite) TestServicesRestart(c *C) {
 func (s *apiSuite) TestServicesReplan(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
-	d := s.daemon(c)
+	d := s.daemon(c, nil)
 	st := d.overlord.State()
 
 	soon := 0

--- a/internal/daemon/api_warnings_test.go
+++ b/internal/daemon/api_warnings_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *apiSuite) testWarnings(c *check.C, all bool, body io.Reader) (calls string, result interface{}) {
-	s.daemon(c)
+	s.daemon(c, nil)
 
 	oldOK := stateOkayWarnings
 	oldAll := stateAllWarnings


### PR DESCRIPTION
When juju is using pebble in Kubernetes pods, each pebble instance is running
in its own container. When Kubernetes kills a pod, a juju charm might need to
first run some commands, change the file system etc before pebble disappears.

This change gives juju charms time to run the required steps by blocking shutdown
and then allows juju to notify pebble that it has performed all finalization operations
using the /v1/finalize api.

It is noted that there is a limited time period for both the finalizer to run and pebble
shutdown (including service process termination). In future these timings will be
tuneable from the run cli and also from juju/charm side so that in the case of
Kubernetes the termination grace period can be extending for charms/services that
need more time.