### PR TITLE
Simplify client.Logs "N" parameter and avoid pointer

### DIFF
--- a/client/logs.go
+++ b/client/logs.go
@@ -27,22 +27,21 @@ import (
 )
 
 const (
-	AllLogs = -1
-
 	logReaderSize = 4 * 1024
 )
 
 // LogsOptions holds the options for a call to Logs or FollowLogs.
 type LogsOptions struct {
-	// Function called to write a single log to the output (required).
+	// WriteLog is called to write a single log to the output (required).
 	WriteLog func(entry LogEntry) error
 
-	// The list of service names to fetch logs for (nil or empty slice means
-	// all services).
+	// Services is the list of service names to fetch logs for (nil or empty
+	// slice means all services).
 	Services []string
 
-	// Number of logs to fetch (before following if calling FollowLogs). To
-	// fetch all buffered logs, set N to AllLogs.
+	// N defines the number of log lines to return from the buffer. In follow
+	// mode, the default is zero, in non-follow mode it's server-defined
+	// (currently 30). Set to -1 to return the entire buffer.
 	N int
 }
 
@@ -69,7 +68,9 @@ func (client *Client) logs(ctx context.Context, opts *LogsOptions, follow bool) 
 	for _, service := range opts.Services {
 		query.Add("services", service)
 	}
-	query.Set("n", strconv.Itoa(opts.N))
+	if opts.N != 0 {
+		query.Set("n", strconv.Itoa(opts.N))
+	}
 	if follow {
 		query.Set("follow", "true")
 	}

--- a/client/logs.go
+++ b/client/logs.go
@@ -27,9 +27,12 @@ import (
 )
 
 const (
+	AllLogs = -1
+
 	logReaderSize = 4 * 1024
 )
 
+// LogsOptions holds the options for a call to Logs or FollowLogs.
 type LogsOptions struct {
 	// Function called to write a single log to the output (required).
 	WriteLog func(entry LogEntry) error
@@ -38,10 +41,9 @@ type LogsOptions struct {
 	// all services).
 	Services []string
 
-	// Total number of logs to fetch (before following if calling FollowLogs).
-	// If nil, use Pebble's default (10). If negative, fetch all buffered logs.
-	// If set to zero when calling FollowLogs, write no logs before following.
-	N *int
+	// Number of logs to fetch (before following if calling FollowLogs). To
+	// fetch all buffered logs, set N to AllLogs.
+	N int
 }
 
 // LogEntry is the struct passed to the WriteLog function.
@@ -67,9 +69,7 @@ func (client *Client) logs(ctx context.Context, opts *LogsOptions, follow bool) 
 	for _, service := range opts.Services {
 		query.Add("services", service)
 	}
-	if opts.N != nil {
-		query.Set("n", strconv.Itoa(*opts.N))
-	}
+	query.Set("n", strconv.Itoa(opts.N))
 	if follow {
 		query.Set("follow", "true")
 	}

--- a/client/logs_test.go
+++ b/client/logs_test.go
@@ -67,6 +67,28 @@ func (cs *clientSuite) TestLogsServices(c *check.C) {
 `[1:])
 }
 
+func (cs *clientSuite) TestLogsN(c *check.C) {
+	cs.rsp = `
+{"time":"2021-05-03T03:55:49.360994155Z","service":"thing","message":"log 1\n"}
+{"time":"2021-05-03T03:55:49.654334232Z","service":"snappass","message":"log two\n"}
+`[1:]
+	out, writeLog := makeLogWriter()
+	err := cs.cli.Logs(&client.LogsOptions{
+		WriteLog: writeLog,
+		N:        2,
+	})
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/logs")
+	c.Check(cs.req.URL.Query(), check.DeepEquals, url.Values{
+		"n": []string{"2"},
+	})
+	c.Check(out.String(), check.Equals, `
+2021-05-03T03:55:49.360Z [thing] log 1
+2021-05-03T03:55:49.654Z [snappass] log two
+`[1:])
+}
+
 func (cs *clientSuite) TestLogsAll(c *check.C) {
 	cs.rsp = `
 {"time":"2021-05-03T03:55:49.360994155Z","service":"thing","message":"log 1\n"}

--- a/client/logs_test.go
+++ b/client/logs_test.go
@@ -39,7 +39,7 @@ func (cs *clientSuite) TestLogsNoOptions(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/logs")
-	c.Check(cs.req.URL.Query(), check.DeepEquals, url.Values{"n": []string{"0"}})
+	c.Check(cs.req.URL.Query(), check.HasLen, 0)
 	c.Check(out.String(), check.Equals, `
 2021-05-03T03:55:49.360Z [thing] log 1
 2021-05-03T03:55:49.654Z [snappass] log two
@@ -55,14 +55,12 @@ func (cs *clientSuite) TestLogsServices(c *check.C) {
 	err := cs.cli.Logs(&client.LogsOptions{
 		WriteLog: writeLog,
 		Services: []string{"snappass"},
-		N:        10,
 	})
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "GET")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/logs")
 	c.Check(cs.req.URL.Query(), check.DeepEquals, url.Values{
 		"services": []string{"snappass"},
-		"n":        []string{"10"},
 	})
 	c.Check(out.String(), check.Equals, `
 2021-05-03T03:55:49.654Z [snappass] log two
@@ -77,7 +75,7 @@ func (cs *clientSuite) TestLogsAll(c *check.C) {
 	out, writeLog := makeLogWriter()
 	err := cs.cli.Logs(&client.LogsOptions{
 		WriteLog: writeLog,
-		N:        client.AllLogs,
+		N:        -1,
 	})
 	c.Assert(err, check.IsNil)
 	c.Check(cs.req.Method, check.Equals, "GET")
@@ -100,7 +98,6 @@ func (cs *clientSuite) TestFollowLogs(c *check.C) {
 		c.Check(req.URL.Path, check.Equals, "/v1/logs")
 		c.Check(req.URL.Query(), check.DeepEquals, url.Values{
 			"follow": []string{"true"},
-			"n":      []string{"0"},
 		})
 		rsp := &http.Response{
 			Body:       &followReader{readsChan},

--- a/cmd/pebble/cmd_logs.go
+++ b/cmd/pebble/cmd_logs.go
@@ -59,7 +59,7 @@ func (cmd *cmdLogs) Execute(args []string) error {
 	case "":
 		n = 10
 	case "all":
-		n = -1
+		n = client.AllLogs
 	default:
 		var err error
 		n, err = strconv.Atoi(cmd.N)
@@ -91,7 +91,7 @@ func (cmd *cmdLogs) Execute(args []string) error {
 	opts := client.LogsOptions{
 		WriteLog: writeLog,
 		Services: cmd.Positional.Services,
-		N:        &n,
+		N:        n,
 	}
 	var err error
 	if cmd.Follow {

--- a/cmd/pebble/cmd_logs.go
+++ b/cmd/pebble/cmd_logs.go
@@ -44,7 +44,7 @@ type cmdLogs struct {
 var logsDescs = map[string]string{
 	"follow": "Follow (tail) logs for given services until Ctrl-C pressed.",
 	"format": "Output format: \"text\" (default) or \"json\" (JSON lines).",
-	"n":      "Number of logs to show (before following); defaults to 10.\nIf 'all', show all buffered logs.",
+	"n":      "Number of logs to show (before following); defaults to 30.\nIf 'all', show all buffered logs.",
 }
 
 var shortLogsHelp = "Fetch service logs"
@@ -57,9 +57,9 @@ func (cmd *cmdLogs) Execute(args []string) error {
 	var n int
 	switch cmd.N {
 	case "":
-		n = 10
+		n = 30
 	case "all":
-		n = client.AllLogs
+		n = -1
 	default:
 		var err error
 		n, err = strconv.Atoi(cmd.N)

--- a/cmd/pebble/cmd_logs_test.go
+++ b/cmd/pebble/cmd_logs_test.go
@@ -29,7 +29,7 @@ func (s *PebbleSuite) TestLogsText(c *C) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/v1/logs")
 		c.Check(r.URL.Query(), DeepEquals, url.Values{
-			"n": []string{"10"},
+			"n": []string{"30"},
 		})
 		fmt.Fprintf(w, `
 {"time":"2021-05-03T03:55:49.360994155Z","service":"thing","message":"log 1"}
@@ -53,7 +53,7 @@ func (s *PebbleSuite) TestLogsJSON(c *C) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/v1/logs")
 		c.Check(r.URL.Query(), DeepEquals, url.Values{
-			"n": []string{"10"},
+			"n": []string{"30"},
 		})
 		fmt.Fprintf(w, `
 {"time":"2021-05-03T03:55:49.360Z","service":"thing","message":"log 1"}
@@ -123,7 +123,7 @@ func (s *PebbleSuite) TestLogsFollow(c *C) {
 		c.Check(r.Method, Equals, "GET")
 		c.Check(r.URL.Path, Equals, "/v1/logs")
 		c.Check(r.URL.Query(), DeepEquals, url.Values{
-			"n":      []string{"10"},
+			"n":      []string{"30"},
 			"follow": []string{"true"},
 		})
 		fmt.Fprintf(w, `

--- a/internal/daemon/api_logs.go
+++ b/internal/daemon/api_logs.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	defaultNumLogs = 10
+	defaultNumLogs = 30
 	logReaderSize  = 4 * 1024
 )
 
@@ -65,16 +65,20 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	follow := followStr == "true"
 
-	numLogs := defaultNumLogs
+	var numLogs int
 	nStr := query.Get("n")
 	if nStr != "" {
 		n, err := strconv.Atoi(nStr)
-		if err != nil {
-			response := statusBadRequest("n must be a valid integer")
+		if err != nil || n < -1 {
+			response := statusBadRequest("n must be -1, 0, or a positive integer")
 			response.ServeHTTP(w, req)
 			return
 		}
 		numLogs = n
+	} else if follow {
+		numLogs = 0
+	} else {
+		numLogs = defaultNumLogs
 	}
 
 	// If "services" parameter not specified, fetch logs for all services.


### PR DESCRIPTION
For rationale for this change, see discussion at https://github.com/canonical/pebble/issues/83#issuecomment-973980643.

This removes the pointer on the `N *int` (number of logs) parameter to be just a plain `int`. When calling `Logs` (non-follow), the default is the server-specified default (currently 30). When calling `FollowLogs`, the default is 0 (don't show any buffered logs).

This PR also changes the server API to have the same semantics (except that the default is "unset n" rather than "zero N"). This shouldn't affect any real users -- the `pebble logs` CLI command already sends through an explicit "n" value anyway. Any negative "n" values other than -1 are now an error (but this won't affect any clients).

I've also changed the default number of logs from 10 to 30 (see discussion on this PR).

Note: this is a breaking change in the Go client. However, it's a trivial fix, and at this point we probably have exactly one internal user of the Go client (the Pebble CLI itself), so I think it's reasonable.