### PR TITLE
Add signals API to send a signal to one or more services

### DIFF
--- a/client/signals.go
+++ b/client/signals.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 )
 
-// SendSignalOptions holds the options for SendSignal.
 type SendSignalOptions struct {
 	Signal   string
 	Services []string

--- a/client/signals.go
+++ b/client/signals.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// SignalsOptions describe the options for SendSignal.
+type SignalsOptions struct {
+	Signal   string
+	Services []string
+}
+
+// SendSignal sends a signal to each of the specified services.
+func (client *Client) SendSignal(opts *SignalsOptions) error {
+	var body bytes.Buffer
+	payload := signalsPayload{
+		Signal:   opts.Signal,
+		Services: opts.Services,
+	}
+	err := json.NewEncoder(&body).Encode(&payload)
+	if err != nil {
+		return fmt.Errorf("cannot encode JSON payload: %v", err)
+	}
+	_, err = client.doSync("POST", "/v1/signals", nil, nil, &body, nil)
+	return err
+}
+
+type signalsPayload struct {
+	Signal   string   `json:"signal"`
+	Services []string `json:"services"`
+}

--- a/client/signals.go
+++ b/client/signals.go
@@ -20,14 +20,14 @@ import (
 	"fmt"
 )
 
-// SignalsOptions describe the options for SendSignal.
-type SignalsOptions struct {
+// SendSignalOptions holds the options for SendSignal.
+type SendSignalOptions struct {
 	Signal   string
 	Services []string
 }
 
 // SendSignal sends a signal to each of the specified services.
-func (client *Client) SendSignal(opts *SignalsOptions) error {
+func (client *Client) SendSignal(opts *SendSignalOptions) error {
 	var body bytes.Buffer
 	payload := signalsPayload{
 		Signal:   opts.Signal,

--- a/client/signals_test.go
+++ b/client/signals_test.go
@@ -29,7 +29,7 @@ func (cs *clientSuite) TestSignals(c *C) {
 		"status-code": 200,
 		"type": "sync"
 	}`
-	err := cs.cli.SendSignal(&client.SignalsOptions{
+	err := cs.cli.SendSignal(&client.SendSignalOptions{
 		Signal:   "SIGHUP",
 		Services: []string{"s1", "s2"},
 	})

--- a/client/signals_test.go
+++ b/client/signals_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client_test
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/client"
+)
+
+func (cs *clientSuite) TestSignals(c *C) {
+	cs.rsp = `{
+		"result": true,
+		"status": "OK",
+		"status-code": 200,
+		"type": "sync"
+	}`
+	err := cs.cli.SendSignal(&client.SignalsOptions{
+		Signal:   "SIGHUP",
+		Services: []string{"s1", "s2"},
+	})
+	c.Assert(err, IsNil)
+	c.Check(cs.req.Method, Equals, "POST")
+	c.Check(cs.req.URL.Path, Equals, "/v1/signals")
+
+	var body map[string]interface{}
+	err = json.NewDecoder(cs.req.Body).Decode(&body)
+	c.Assert(err, IsNil)
+	c.Assert(body, DeepEquals, map[string]interface{}{
+		"signal":   "SIGHUP",
+		"services": []interface{}{"s1", "s2"},
+	})
+}

--- a/cmd/pebble/cmd_autostart.go
+++ b/cmd/pebble/cmd_autostart.go
@@ -15,8 +15,9 @@
 package main
 
 import (
-	"github.com/canonical/pebble/client"
 	"github.com/jessevdk/go-flags"
+
+	"github.com/canonical/pebble/client"
 )
 
 var shortAutoStartHelp = "Start services set to start by default"

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -168,11 +168,15 @@ type helpCategory struct {
 var helpCategories = []helpCategory{{
 	Label:       "Basics",
 	Description: "basic management",
-	Commands:    []string{"run", "autostart", "start", "stop", "exec", "services", "logs", "signal"},
+	Commands:    []string{"run", "exec"},
+}, {
+	Label:       "Services",
+	Description: "service management",
+	Commands:    []string{"autostart", "start", "stop", "restart", "services", "logs", "signal"},
 }, {
 	Label:       "Configuration",
 	Description: "manage configuration",
-	Commands:    []string{"add", "plan"},
+	Commands:    []string{"add", "plan", "replan"},
 }, {
 	Label:       "Changes",
 	Description: "view changes and tasks",

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -178,9 +178,9 @@ var helpCategories = []helpCategory{{
 	Description: "manage services",
 	Commands:    []string{"services", "logs", "start", "restart", "signal", "stop", "replan"},
 }, {
-	Label:       "Operations",
-	Description: "other operations",
-	Commands:    []string{"exec"}, // TODO: "checks" would go here
+	Label:       "Files",
+	Description: "work with files and execute commands",
+	Commands:    []string{"exec"},
 }, {
 	Label:       "Changes",
 	Description: "manage changes and their tasks",

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -168,7 +168,7 @@ type helpCategory struct {
 var helpCategories = []helpCategory{{
 	Label:       "Basics",
 	Description: "basic management",
-	Commands:    []string{"run", "autostart", "start", "stop", "exec", "services", "logs"},
+	Commands:    []string{"run", "autostart", "start", "stop", "exec", "services", "logs", "signal"},
 }, {
 	Label:       "Configuration",
 	Description: "manage configuration",

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -166,25 +166,29 @@ type helpCategory struct {
 
 // helpCategories helps us by grouping commands
 var helpCategories = []helpCategory{{
-	Label:       "Basics",
-	Description: "basic management",
-	Commands:    []string{"run", "exec"},
+	Label:       "Run",
+	Description: "run pebble",
+	Commands:    []string{"run", "help", "version"},
+}, {
+	Label:       "Plan",
+	Description: "view and change configuration",
+	Commands:    []string{"add", "plan"},
 }, {
 	Label:       "Services",
-	Description: "service management",
-	Commands:    []string{"autostart", "start", "stop", "restart", "services", "logs", "signal"},
+	Description: "manage services",
+	Commands:    []string{"services", "logs", "start", "restart", "signal", "stop", "replan"},
 }, {
-	Label:       "Configuration",
-	Description: "manage configuration",
-	Commands:    []string{"add", "plan", "replan"},
+	Label:       "Operations",
+	Description: "other operations",
+	Commands:    []string{"exec"}, // TODO: "checks" would go here
 }, {
 	Label:       "Changes",
-	Description: "view changes and tasks",
+	Description: "manage changes and their tasks",
 	Commands:    []string{"changes", "tasks"},
 }, {
-	Label:       "Other",
-	Description: "other commands",
-	Commands:    []string{"warnings", "okay", "help", "version"},
+	Label:       "Warnings",
+	Description: "manage warnings",
+	Commands:    []string{"warnings", "okay"},
 }}
 
 var (

--- a/cmd/pebble/cmd_replan.go
+++ b/cmd/pebble/cmd_replan.go
@@ -22,7 +22,8 @@ import (
 var shortReplanHelp = "Ensure running services match the current plan"
 var longReplanHelp = `
 The replan command starts, stops, or restarts services that have changed,
-so that running services match exactly the desired configuration in the current plan.
+so that running services exactly match the desired configuration in the
+current plan.
 `
 
 type cmdReplan struct {

--- a/cmd/pebble/cmd_signal.go
+++ b/cmd/pebble/cmd_signal.go
@@ -47,7 +47,7 @@ func (cmd *cmdSignal) Execute(args []string) error {
 	if !strings.HasPrefix(cmd.Positional.Signal, "SIG") {
 		cmd.Positional.Signal = "SIG" + cmd.Positional.Signal
 	}
-	opts := client.SignalsOptions{
+	opts := client.SendSignalOptions{
 		Signal:   cmd.Positional.Signal,
 		Services: cmd.Positional.Services,
 	}

--- a/cmd/pebble/cmd_signal.go
+++ b/cmd/pebble/cmd_signal.go
@@ -26,7 +26,7 @@ import (
 type cmdSignal struct {
 	clientMixin
 	Positional struct {
-		Signal   string   `positional-arg-name:"<SIGNAME>"`
+		Signal   string   `positional-arg-name:"<SIGNAL>"`
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes" required:"yes"`
 }
@@ -34,10 +34,9 @@ type cmdSignal struct {
 var shortSignalHelp = "Send a signal to one or more running services"
 var longSignalHelp = `
 The signal command sends a signal to one or more running services. The signal
-name must be uppercase to distinguish it from the service names, for example:
+name must be uppercase, for example:
 
 pebble signal HUP mysql nginx
-pebble signal SIGHUP mysql nginx    # full signal name is fine too
 `
 
 func (cmd *cmdSignal) Execute(args []string) error {

--- a/cmd/pebble/cmd_signal.go
+++ b/cmd/pebble/cmd_signal.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/canonical/pebble/client"
+)
+
+type cmdSignal struct {
+	clientMixin
+	Positional struct {
+		Signal   string   `positional-arg-name:"<SIGNAME>"`
+		Services []string `positional-arg-name:"<service>"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+var shortSignalHelp = "Send a signal to one or more running services"
+var longSignalHelp = `
+The signal command sends a signal to one or more running services. The signal
+name must be uppercase to distinguish it from the service names, for example:
+
+pebble signal HUP mysql nginx
+pebble signal SIGHUP mysql nginx    # full signal name is fine too
+`
+
+func (cmd *cmdSignal) Execute(args []string) error {
+	if strings.ToUpper(cmd.Positional.Signal) != cmd.Positional.Signal {
+		return fmt.Errorf("signal name must be uppercase, for example HUP")
+	}
+	if !strings.HasPrefix(cmd.Positional.Signal, "SIG") {
+		cmd.Positional.Signal = "SIG" + cmd.Positional.Signal
+	}
+	opts := client.SignalsOptions{
+		Signal:   cmd.Positional.Signal,
+		Services: cmd.Positional.Services,
+	}
+	err := cmd.client.SendSignal(&opts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	addCommand("signal", shortSignalHelp, longSignalHelp, func() flags.Commander { return &cmdSignal{} }, nil, nil)
+}

--- a/cmd/pebble/cmd_signal_test.go
+++ b/cmd/pebble/cmd_signal_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/check.v1"
+
+	pebble "github.com/canonical/pebble/cmd/pebble"
+)
+
+func (s *PebbleSuite) TestSignalShortName(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v1/signals")
+		assertBodyEquals(c, r.Body, map[string]interface{}{
+			"signal":   "SIGHUP",
+			"services": []interface{}{"s1"},
+		})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": true
+}`)
+	})
+
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"signal", "HUP", "s1"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+}
+
+func (s *PebbleSuite) TestSignalFullName(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v1/signals")
+		assertBodyEquals(c, r.Body, map[string]interface{}{
+			"signal":   "SIGHUP",
+			"services": []interface{}{"s2"},
+		})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": true
+}`)
+	})
+
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"signal", "SIGHUP", "s2"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+}
+
+func (s *PebbleSuite) TestSignalMultipleServices(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v1/signals")
+		assertBodyEquals(c, r.Body, map[string]interface{}{
+			"signal":   "SIGHUP",
+			"services": []interface{}{"s1", "s2"},
+		})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": true
+}`)
+	})
+
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"signal", "SIGHUP", "s1", "s2"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+}
+
+func (s *PebbleSuite) TestSignalErrorLowercase(c *check.C) {
+	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"signal", "hup", "s1"})
+	c.Assert(err, check.ErrorMatches, "signal name must be uppercase, for example HUP")
+}
+
+func (s *PebbleSuite) TestSignalServerError(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "POST")
+		c.Check(r.URL.Path, check.Equals, "/v1/signals")
+		assertBodyEquals(c, r.Body, map[string]interface{}{
+			"signal":   "SIGHUP",
+			"services": []interface{}{"s1"},
+		})
+		fmt.Fprint(w, `{
+			"type": "error",
+			"status-code": 400,
+			"status": "Bad Request",
+			"result": {"message":"invalid signal name \"SIGFOO\""}
+		}`)
+	})
+
+	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"signal", "HUP", "s1"})
+	c.Assert(err, check.ErrorMatches, `invalid signal name "SIGFOO"`)
+}

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -81,6 +81,10 @@ var api = []*Command{{
 	Path:   "/v1/tasks/{task-id}/websocket/{websocket-id}",
 	UserOK: true,
 	GET:    v1GetTaskWebsocket,
+}, {
+	Path:   "/v1/signals",
+	UserOK: true,
+	POST:   v1PostSignals,
 }}
 
 var (

--- a/internal/daemon/api_services_test.go
+++ b/internal/daemon/api_services_test.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/canonical/pebble/internal/overlord/servstate"
 	"github.com/canonical/pebble/internal/overlord/state"
 
 	. "gopkg.in/check.v1"
@@ -320,16 +319,4 @@ func (s *apiSuite) TestServicesReplan(c *C) {
 	c.Check(tasks, HasLen, 2)
 	c.Check(tasks[0].Summary(), Equals, `Start service "test1"`)
 	c.Check(tasks[1].Summary(), Equals, `Start service "test2"`)
-}
-
-type wrappedServiceManager struct {
-	servstate.ServiceManager
-	replan func() ([]string, []string, error)
-}
-
-func (w *wrappedServiceManager) Replan() ([]string, []string, error) {
-	if w.replan != nil {
-		return w.replan()
-	}
-	return w.ServiceManager.Replan()
 }

--- a/internal/daemon/api_signals.go
+++ b/internal/daemon/api_signals.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type signalsPayload struct {
+	Signal   string   `json:"signal"`
+	Services []string `json:"services"`
+}
+
+func v1PostSignals(c *Command, req *http.Request, _ *userState) Response {
+	var payload signalsPayload
+	decoder := json.NewDecoder(req.Body)
+	if err := decoder.Decode(&payload); err != nil {
+		return statusBadRequest("cannot decode request body: %v", err)
+	}
+	if len(payload.Services) <= 0 {
+		return statusBadRequest("must specify one or more services")
+	}
+
+	serviceMgr := c.d.overlord.ServiceManager()
+	err := serviceMgr.SendSignal(payload.Services, payload.Signal)
+	if err != nil {
+		return statusInternalError("%s", err)
+	}
+	return SyncResponse(true)
+}

--- a/internal/daemon/api_signals.go
+++ b/internal/daemon/api_signals.go
@@ -30,7 +30,7 @@ func v1PostSignals(c *Command, req *http.Request, _ *userState) Response {
 	if err := decoder.Decode(&payload); err != nil {
 		return statusBadRequest("cannot decode request body: %v", err)
 	}
-	if len(payload.Services) <= 0 {
+	if len(payload.Services) == 0 {
 		return statusBadRequest("must specify one or more services")
 	}
 

--- a/internal/daemon/api_signals_test.go
+++ b/internal/daemon/api_signals_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/overlord/servstate"
+)
+
+func (s *apiSuite) TestSignalsSend(c *C) {
+	writeTestLayer(s.pebbleDir, `
+services:
+    test1:
+        override: replace
+        command: sleep 10
+`)
+	d := s.daemon(c)
+	d.overlord.Loop()
+
+	// Start test service
+	payload := bytes.NewBufferString(`{"action": "start", "services": ["test1"]}`)
+	req, err := http.NewRequest("POST", "/v1/services", payload)
+	c.Assert(err, IsNil)
+	rsp := v1PostServices(apiCmd("/v1/services"), req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Check(rec.Result().StatusCode, Equals, 202)
+
+	// Wait for it to be running
+	serviceMgr := d.overlord.ServiceManager()
+	for i := 0; ; i++ {
+		if i > 50 {
+			c.Fatalf("timed out waiting for service to start")
+		}
+		services, err := serviceMgr.Services([]string{"test1"})
+		c.Assert(err, IsNil)
+		if len(services) == 1 && services[0].Current == servstate.StatusActive {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// First ensure a bad signal name returns an error
+	payload = bytes.NewBufferString(`{"signal": "FOOBAR", "services": ["test1"]}`)
+	req, err = http.NewRequest("POST", "/v1/signals", payload)
+	c.Assert(err, IsNil)
+	rsp = v1PostSignals(apiCmd("/v1/signals"), req, nil).(*resp)
+	rec = httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Check(rec.Result().StatusCode, Equals, 500)
+	errResult, ok := rsp.Result.(*errorResult)
+	c.Assert(ok, Equals, true)
+	c.Assert(errResult.Message, Matches, `cannot send signal to "test1": invalid signal name "FOOBAR"`)
+
+	// Send SIGTERM to service via API
+	payload = bytes.NewBufferString(`{"signal": "SIGTERM", "services": ["test1"]}`)
+	req, err = http.NewRequest("POST", "/v1/signals", payload)
+	c.Assert(err, IsNil)
+	rsp = v1PostSignals(apiCmd("/v1/signals"), req, nil).(*resp)
+	rec = httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Check(rec.Result().StatusCode, Equals, 200)
+	c.Check(rsp.Result, DeepEquals, true)
+
+	// Ensure it goes into inactive state due to the signal
+	for i := 0; ; i++ {
+		if i > 50 {
+			c.Fatalf("timed out waiting for service to go into backoff")
+		}
+		services, err := serviceMgr.Services([]string{"test1"})
+		c.Assert(err, IsNil)
+		if len(services) == 1 && services[0].Current == servstate.StatusInactive {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (s *apiSuite) TestSignalsBadBody(c *C) {
+	payload := bytes.NewBufferString("@")
+	req, err := http.NewRequest("POST", "/v1/signals", payload)
+	c.Assert(err, IsNil)
+	rsp := v1PostSignals(apiCmd("/v1/signals"), req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Check(rec.Result().StatusCode, Equals, 400)
+	errResult, ok := rsp.Result.(*errorResult)
+	c.Assert(ok, Equals, true)
+	c.Assert(errResult.Message, Matches, "cannot decode request body: .*")
+}
+
+func (s *apiSuite) TestSignalsNoServices(c *C) {
+	payload := bytes.NewBufferString(`{"signal": "SIGTERM"}`)
+	req, err := http.NewRequest("POST", "/v1/signals", payload)
+	c.Assert(err, IsNil)
+	rsp := v1PostSignals(apiCmd("/v1/signals"), req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Check(rec.Result().StatusCode, Equals, 400)
+	errResult, ok := rsp.Result.(*errorResult)
+	c.Assert(ok, Equals, true)
+	c.Assert(errResult.Message, Equals, "must specify one or more services")
+}
+
+func (s *apiSuite) TestSignalsServiceNotRunning(c *C) {
+	s.daemon(c)
+	payload := bytes.NewBufferString(`{"signal": "SIGTERM", "services": ["test1"]}`)
+	req, err := http.NewRequest("POST", "/v1/signals", payload)
+	c.Assert(err, IsNil)
+	rsp := v1PostSignals(apiCmd("/v1/signals"), req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Check(rec.Result().StatusCode, Equals, 500)
+	errResult, ok := rsp.Result.(*errorResult)
+	c.Assert(ok, Equals, true)
+	c.Assert(errResult.Message, Matches, `cannot send signal to "test1": service is not running`)
+}

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -504,7 +504,7 @@ func (s *serviceData) sendSignal(signal string) error {
 			return fmt.Errorf("invalid signal name %q", signal)
 		}
 		logger.Noticef("Sending %s to service %q", signal, s.config.Name)
-		err := syscall.Kill(-s.cmd.Process.Pid, sig)
+		err := syscall.Kill(s.cmd.Process.Pid, sig)
 		if err != nil {
 			return err
 		}
@@ -513,7 +513,7 @@ func (s *serviceData) sendSignal(signal string) error {
 		return fmt.Errorf("service is not running")
 
 	default:
-		return fmt.Errorf("sending signal invalid in state %q", s.state)
+		return fmt.Errorf("invalid in state %q", s.state)
 	}
 	return nil
 }

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -410,11 +410,13 @@ func (m *ServiceManager) SendSignal(services []string, signal string) error {
 	for _, name := range services {
 		s := m.services[name]
 		if s == nil {
+			errors = append(errors, fmt.Sprintf("cannot send signal to %q: service is not running", name))
 			continue
 		}
 		err := s.sendSignal(signal)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("cannot send signal to %q: %v", name, err))
+			continue
 		}
 	}
 	if len(errors) > 0 {

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -757,6 +757,7 @@ func (s *S) TestRestart(c *C) {
 services:
     test2:
         override: merge
+        command: /bin/sh -c "echo test2; exec sleep 300"
         backoff-delay: 50ms
         backoff-limit: 150ms
 `)


### PR DESCRIPTION
This implements spec [JU029 Pebble: sending signals to services](https://docs.google.com/document/d/1R9gdQU7q1CdH3raqLeB9d86pICbOSpm0P04P_CNF2g0/edit#). Specifically:

* An API to send a signal to one or more running services:
  - `POST /v1/signals {"signal": "SIGHUP", "services": ["s1", "s2"]}`
* A Go client to send a signal:
  - `c.SendSignal(&client.SendSignalOptions{Signal: "SIGHUP", Services: []string{"s1, "s2"})`
* A CLI command to send a signal:
  - `pebble signal HUP s1 s2 ...`

One question I had was whether the API should return an error if the service being signaled is not running. After discussion with Harry we decided to mimic the behavior of the Unix `kill` command, which gives an error if the pid is not active. But that's open for debate -- it will mean if you call `send_signal()` in a charm it'll raise an exception if the service hasn't been started yet (maybe that's a good thing).