### PR TITLE
Fix bug with replan/start/restart not updating internal config

### DIFF
--- a/internal/overlord/servstate/export_test.go
+++ b/internal/overlord/servstate/export_test.go
@@ -18,6 +18,8 @@ import (
 	"os/exec"
 	"syscall"
 	"time"
+
+	"github.com/canonical/pebble/internal/plan"
 )
 
 var CalculateNextBackoff = calculateNextBackoff
@@ -45,6 +47,17 @@ func (m *ServiceManager) BackoffNum(serviceName string) int {
 		return -1
 	}
 	return s.backoffNum
+}
+
+func (m *ServiceManager) Config(serviceName string) *plan.Service {
+	m.servicesLock.Lock()
+	defer m.servicesLock.Unlock()
+
+	s := m.services[serviceName]
+	if s == nil {
+		return nil
+	}
+	return s.config
 }
 
 func (m *ServiceManager) GetJitter(duration time.Duration) time.Duration {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -163,7 +163,7 @@ func (m *ServiceManager) serviceForStart(task *state.Task, config *plan.Service)
 		return service
 	}
 
-	// Ensure config is up-to-date from the plan
+	// Ensure config is up-to-date from the plan whenever the user starts a service
 	service.config = config.Copy()
 
 	switch service.state {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -163,7 +163,7 @@ func (m *ServiceManager) serviceForStart(task *state.Task, config *plan.Service)
 		return service
 	}
 
-	// Ensure config is up-to-date from the plan whenever the user starts a service
+	// Ensure config is up-to-date from the plan whenever the user starts a service.
 	service.config = config.Copy()
 
 	switch service.state {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -163,6 +163,9 @@ func (m *ServiceManager) serviceForStart(task *state.Task, config *plan.Service)
 		return service
 	}
 
+	// Ensure config is up-to-date from the plan
+	service.config = config.Copy()
+
 	switch service.state {
 	case stateInitial, stateStarting, stateRunning:
 		taskLogf(task, "Service %q already started.", config.Name)

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -406,7 +406,7 @@ func (s *serviceData) exited(waitErr error) error {
 		action, onType := getAction(s.config, waitErr == nil)
 		switch action {
 		case plan.ActionIgnore:
-			logger.Debugf("Service %q %s action is %q, transitioning to stopped state", s.config.Name, onType, action)
+			logger.Noticef("Service %q %s action is %q, transitioning to stopped state", s.config.Name, onType, action)
 			s.transition(stateStopped)
 
 		case plan.ActionHalt:

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -368,7 +368,7 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 	needsRestart := make(map[string]bool)
 	var stop []string
 	for name, s := range m.services {
-		if config, ok := m.plan.Services[name]; ok && config.Equal(s.config) {
+		if config, ok := m.plan.Services[name]; ok {
 			if config.Equal(s.config) {
 				continue
 			}

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -320,14 +320,14 @@ func (s *S) TestReplanUpdatesConfig(c *C) {
 	s.startTestServices(c)
 	defer s.stopTestServices(c)
 
-	// Ensure the ServiceManager's config reflects the plan config
+	// Ensure the ServiceManager's config reflects the plan config.
 	config := s.manager.Config("test2")
 	c.Assert(config, NotNil)
 	c.Assert(config.OnSuccess, Equals, plan.ActionUnset)
 	c.Assert(config.Summary, Equals, "")
 	command := config.Command
 
-	// Add a layer and override a couple of values
+	// Add a layer and override a couple of values.
 	layer := parseLayer(c, 0, "layer", `
 services:
     test2:
@@ -352,7 +352,7 @@ func (s *S) TestStopStartUpdatesConfig(c *C) {
 	s.startTestServices(c)
 	defer s.stopTestServices(c)
 
-	// Add a layer and override a couple of values
+	// Add a layer and override a couple of values.
 	layer := parseLayer(c, 0, "layer", `
 services:
     test2:

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -316,6 +316,38 @@ func (s *S) TestReplanServices(c *C) {
 	s.stopTestServices(c)
 }
 
+func (s *S) TestReplanUpdatesServiceConfig(c *C) {
+	s.startTestServices(c)
+	defer s.stopTestServices(c)
+
+	// Ensure the ServiceManager's config reflects the plan config
+	config := s.manager.Config("test2")
+	c.Assert(config, NotNil)
+	c.Assert(config.OnSuccess, Equals, plan.ActionUnset)
+	c.Assert(config.Summary, Equals, "")
+	command := config.Command
+
+	// Add a layer and override a couple of values
+	layer := parseLayer(c, 0, "layer", `
+services:
+    test2:
+        override: merge
+        summary: A summary!
+        on-success: ignore
+`)
+	err := s.manager.AppendLayer(layer)
+	c.Assert(err, IsNil)
+
+	// Call Replan and ensure the ServiceManager's config has updated.
+	_, _, err = s.manager.Replan()
+	c.Assert(err, IsNil)
+	config = s.manager.Config("test2")
+	c.Assert(config, NotNil)
+	c.Assert(config.OnSuccess, Equals, plan.ActionIgnore)
+	c.Assert(config.Summary, Equals, "A summary!")
+	c.Assert(config.Command, Equals, command)
+}
+
 func (s *S) TestServiceLogs(c *C) {
 	outputs := map[string]string{
 		"test1": `2.* \[test1\] test1\n`,


### PR DESCRIPTION
This fixes a bug in Replan not updating the stored `service.config` value due to bad logic I introduced in https://github.com/canonical/pebble/pull/79/files#diff-c2607d6e10ee84455ecce459b40a302a3a9f44197dc7a2205c52c0cc76c8bfaaR370. I've also added a test for this case.

It also fixes a similar bug where a manual stop/start (or restart) sequence didn't update the stored service config -- I introduced this bug in the same commit.