### PR TITLE
feat(#93): Wait for child processes

### DIFF
--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -588,6 +588,12 @@ func (s *serviceData) stop() error {
 			logger.Noticef("Cannot send SIGTERM to process: %v", err)
 		}
 		s.transition(stateTerminating)
+		for {
+			var wstatus syscall.WaitStatus
+			if _, err := syscall.Wait4(-s.cmd.Process.Pid, &wstatus, syscall.WNOHANG, nil); err != syscall.EINTR && err != nil {
+				break
+			}
+		}
 		time.AfterFunc(killWait, func() { logError(s.terminateTimeElapsed()) })
 
 	case stateBackoff:

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -926,7 +926,7 @@ func (s *S) TestStopWaitChildren(c *C) {
 services:
     test2:
         override: merge
-        command: bash -c "trap \"sleep 0.15; echo Hello Child\" SIGTERM; echo Test Child; sleep 0.1"
+        command: bash -c 'bash -c "{ trap \"echo child 1\" SIGTERM; sleep 0.4; } & { trap \"echo child 2\" SIGTERM; sleep 0.3; } & sleep 0.2"; sleep 0.1'
 `)
 	err := s.manager.AppendLayer(layer)
 	c.Assert(err, IsNil)
@@ -947,7 +947,7 @@ services:
 	})
 
 	outputs := map[string]string{
-		"test2": `2.* \[test2\] Test Child\n2.* \[test2\] Terminated\n2.* \[test2\] Hello Child\n`,
+		"test2": `2.* \[test2\] Terminated\n2.* \[test2\] child.*\n2.* \[test2\] Terminated\n2.* \[test2\] child.*\n`,
 	}
 
 	iterators, err := s.manager.ServiceLogs([]string{"test2"}, -1)

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -947,7 +947,8 @@ services:
 	})
 
 	outputs := map[string]string{
-		"test2": `2.* \[test2\] Terminated\n2.* \[test2\] child.*\n2.* \[test2\] Terminated\n2.* \[test2\] child.*\n`,
+		// Signals are not sent in guaranteed order, so we need to expect either on every line.
+		"test2": `2.* \[test2\] Terminated|child 1|child 2\n2.* \[test2\] Terminated|child 1|child 2\n2.* \[test2\] Terminated|child 1|child 2\n2.* \[test2\] Terminated|child 1|child 2\n`,
 	}
 
 	iterators, err := s.manager.ServiceLogs([]string{"test2"}, -1)


### PR DESCRIPTION
This feature implements waiting for child processes when stopping a
service via SIGTERM as described in #93. This is done via waiting for all child processes
that are part of the process group of the main (service) process, i.e.
the leader process. The syscall used is Wait4 with a waitpid behaviour.
Note that waiting for grandchildren is not supported with this approach.

Wait4 system call is used as wait and waitpid are not supported in Golang
(see https://github.com/golang/go/issues/9176). It loops over until there are
no more children to wait on (returns syscall.ECHILD as err, though this is not
checked here explicitly), ignoring hung processes (syscall.WNOHANG) and
retrying on a interrupted system call or library function call (syscall.EINTR,
see https://man7.org/linux/man-pages/man7/signal.7.html).

The test simulates a child process doing clean up work that takes longer than the timer
set to invoke the SIGKILL. Before the implementation, it fails (as expected), inserting
the wait4 functionality makes the test pass.