### PR TITLE
Make Pebble a child subreaper and reap zombie children

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -719,7 +719,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *check.C) {
 }
 
 func (s *daemonSuite) TestRebootHelper(c *check.C) {
-	cmd := testutil.FakeCommand(c, "shutdown", "")
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
 	defer cmd.Restore()
 
 	tests := []struct {
@@ -769,7 +769,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *check.C) {
 	}()
 	rebootNoticeWait = 150 * time.Millisecond
 
-	cmd := testutil.FakeCommand(c, "shutdown", "")
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -801,7 +801,7 @@ func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	rebootWaitTimeout = 100 * time.Millisecond
 	rebootNoticeWait = 150 * time.Millisecond
 
-	cmd := testutil.FakeCommand(c, "shutdown", "")
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -840,7 +840,7 @@ func (s *daemonSuite) TestRestartExpectedRebootIsMissing(c *check.C) {
 	rebootRetryWaitTimeout = 100 * time.Millisecond
 	rebootNoticeWait = 150 * time.Millisecond
 
-	cmd := testutil.FakeCommand(c, "shutdown", "")
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -879,7 +879,7 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *check.C) {
 	err := ioutil.WriteFile(s.statePath, fakeState, 0600)
 	c.Assert(err, check.IsNil)
 
-	cmd := testutil.FakeCommand(c, "shutdown", "")
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -903,7 +903,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *check.C) {
 	err = ioutil.WriteFile(s.statePath, fakeState, 0600)
 	c.Assert(err, check.IsNil)
 
-	cmd := testutil.FakeCommand(c, "shutdown", "")
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)

--- a/internal/overlord/checkstate/checkers.go
+++ b/internal/overlord/checkstate/checkers.go
@@ -151,7 +151,7 @@ func (c *execChecker) check(ctx context.Context) error {
 	defer ringBuffer.Close()
 	cmd.Stdout = ringBuffer
 	cmd.Stderr = ringBuffer
-	err = cmd.Start()
+	err = reaper.StartCommand(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/overlord/checkstate/checkers.go
+++ b/internal/overlord/checkstate/checkers.go
@@ -16,6 +16,7 @@ package checkstate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/canonical/pebble/internal/logger"
 	"github.com/canonical/pebble/internal/osutil"
+	"github.com/canonical/pebble/internal/reaper"
 	"github.com/canonical/pebble/internal/servicelog"
 	"github.com/canonical/pebble/internal/strutil/shlex"
 )
@@ -120,8 +122,6 @@ type execChecker struct {
 }
 
 func (c *execChecker) check(ctx context.Context) error {
-	logger.Debugf("Check %q (exec): running %q", c.name, c.command)
-
 	args, err := shlex.Split(c.command)
 	if err != nil {
 		return fmt.Errorf("cannot parse check command: %v", err)
@@ -155,11 +155,16 @@ func (c *execChecker) check(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = cmd.Wait()
+	logger.Debugf("Check %q (exec): running %q (PID %d)", c.name, c.command, cmd.Process.Pid)
+
+	exitCode, err := reaper.WaitCommand(cmd)
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("exec check timed out")
+	}
+	if err == nil && exitCode > 0 {
+		err = fmt.Errorf("exit status %d", exitCode)
+	}
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			err = fmt.Errorf("exec check timed out")
-		}
 		// Include the last few lines of output in the error details
 		var details string
 		details, linesErr := servicelog.LastLines(ringBuffer, maxErrorLines, "", false)

--- a/internal/overlord/checkstate/checkers_test.go
+++ b/internal/overlord/checkstate/checkers_test.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/reaper"
 )
 
 type CheckersSuite struct{}
@@ -145,9 +147,13 @@ func (s *CheckersSuite) TestTCP(c *C) {
 }
 
 func (s *CheckersSuite) TestExec(c *C) {
+	err := reaper.Start()
+	c.Assert(err, IsNil)
+	defer reaper.Stop()
+
 	// Valid command succeeds
 	chk := &execChecker{command: "echo foo"}
-	err := chk.check(context.Background())
+	err = chk.check(context.Background())
 	c.Assert(err, IsNil)
 
 	// Un-parseable command fails

--- a/internal/overlord/checkstate/manager_test.go
+++ b/internal/overlord/checkstate/manager_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/canonical/pebble/internal/logger"
 	"github.com/canonical/pebble/internal/plan"
+	"github.com/canonical/pebble/internal/reaper"
 )
 
 func Test(t *testing.T) {
@@ -44,6 +45,14 @@ func (s *ManagerSuite) SetUpSuite(c *C) {
 	setLoggerOnce.Do(func() {
 		logger.SetLogger(logger.New(os.Stderr, "[test] "))
 	})
+
+	err := reaper.Start()
+	c.Assert(err, IsNil)
+}
+
+func (s *ManagerSuite) TearDownSuite(c *C) {
+	err := reaper.Stop()
+	c.Assert(err, IsNil)
 }
 
 func (s *ManagerSuite) TestChecks(c *C) {

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -361,7 +361,7 @@ func (e *execution) do(ctx context.Context, task *state.Task) error {
 	}
 
 	// Start the command!
-	err = cmd.Start()
+	err = reaper.StartCommand(cmd)
 	exitCode := -1
 	if err == nil {
 		// Send its PID to the control loop.

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -34,6 +34,7 @@ import (
 	"github.com/canonical/pebble/internal/logger"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/ptyutil"
+	"github.com/canonical/pebble/internal/reaper"
 	"github.com/canonical/pebble/internal/wsutil"
 )
 
@@ -361,12 +362,13 @@ func (e *execution) do(ctx context.Context, task *state.Task) error {
 
 	// Start the command!
 	err = cmd.Start()
+	exitCode := -1
 	if err == nil {
 		// Send its PID to the control loop.
 		pidCh <- cmd.Process.Pid
 
 		// Wait for it to finish.
-		err = cmd.Wait()
+		exitCode, err = reaper.WaitCommand(cmd)
 	}
 
 	// Close open files and channels.
@@ -388,30 +390,15 @@ func (e *execution) do(ctx context.Context, task *state.Task) error {
 		_ = closer.Close()
 	}
 
-	// Handle errors: timeout, non-zero exit code, or other error.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		setExitCode(task, -1)
 		return fmt.Errorf("timed out after %v: %w", e.timeout, ctx.Err())
-	} else if exitErr, ok := err.(*exec.ExitError); ok {
-		status, ok := exitErr.Sys().(syscall.WaitStatus)
-		if ok {
-			if status.Signaled() {
-				// 128 + n == Fatal error signal "n"
-				setExitCode(task, 128+int(status.Signal()))
-				return nil
-			}
-			setExitCode(task, status.ExitStatus())
-			return nil
-		}
-		setExitCode(task, -1)
-		return err
-	} else if err != nil {
+	}
+	if err != nil {
 		setExitCode(task, -1)
 		return err
 	}
-
-	// Successful exit (exit code 0).
-	setExitCode(task, 0)
+	setExitCode(task, exitCode)
 	return nil
 }
 

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -62,6 +62,9 @@ const (
 )
 
 // serviceState represents the state a service's state machine is in.
+//
+// See state-diagram.dot (and the generated state-diagram.svg image) for a
+// diagram of the states and transitions. Please try to keep these up to date!
 type serviceState string
 
 const (
@@ -513,6 +516,10 @@ func (m *ServiceManager) getJitter(duration time.Duration) time.Duration {
 // exitCode returns the exit code of the given command, or 128+signal if it
 // exited via a signal.
 func exitCode(cmd *exec.Cmd) int {
+	if cmd.ProcessState == nil {
+		logger.Debugf("############################## TODO cmd.ProcessState nil ###########################")
+		return -1
+	}
 	status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
 	if ok {
 		if status.Signaled() {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -370,7 +370,7 @@ func (s *serviceData) startInternal() error {
 	go func() {
 		exitCode, waitErr := reaper.WaitCommand(cmd)
 		if waitErr != nil {
-			logger.Debugf("Service %q unexpected error: %v", serviceName, waitErr)
+			logger.Noticef("Cannot wait for service %q: %v", serviceName, waitErr)
 		} else {
 			logger.Debugf("Service %q exited with code %d.", serviceName, exitCode)
 		}

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -63,9 +63,6 @@ const (
 )
 
 // serviceState represents the state a service's state machine is in.
-//
-// See state-diagram.dot (and the generated state-diagram.svg image) for a
-// diagram of the states and transitions. Please try to keep these up to date!
 type serviceState string
 
 const (

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -359,6 +359,7 @@ func (s *serviceData) startInternal() error {
 		_ = s.logs.Close()
 		return fmt.Errorf("cannot start service: %w", err)
 	}
+	logger.Debugf("Service %q started with PID %d", s.config.Name, s.cmd.Process.Pid)
 	s.resetTimer = time.AfterFunc(s.config.BackoffLimit.Value, func() { logError(s.backoffResetElapsed()) })
 
 	// Start a goroutine to wait for the process to finish.

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/pebble/internal/overlord/restart"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/plan"
+	"github.com/canonical/pebble/internal/reaper"
 	"github.com/canonical/pebble/internal/servicelog"
 	"github.com/canonical/pebble/internal/strutil/shlex"
 )
@@ -370,7 +371,7 @@ func (s *serviceData) startInternal() error {
 	done := make(chan struct{})
 	cmd := s.cmd
 	go func() {
-		exitCode, waitErr := WaitCommand(cmd)
+		exitCode, waitErr := reaper.WaitCommand(cmd)
 		if waitErr != nil {
 			logger.Debugf("Service %q unexpected error: %v", serviceName, waitErr)
 		} else {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -353,7 +353,7 @@ func (s *serviceData) startInternal() error {
 
 	// Start the process!
 	logger.Noticef("Service %q starting: %s", serviceName, s.config.Command)
-	err = s.cmd.Start()
+	err = reaper.StartCommand(s.cmd)
 	if err != nil {
 		if outputIterator != nil {
 			_ = outputIterator.Close()

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -84,7 +84,9 @@ func NewManager(s *state.State, runner *state.TaskRunner, pebbleDir string, serv
 
 // Stop implements overlord.StateStopper and stops background functions.
 func (m *ServiceManager) Stop() {
-	close(m.stopReaper)
+	if m.stopReaper != nil {
+		close(m.stopReaper)
+	}
 }
 
 // NotifyPlanChanged adds f to the list of functions that are called whenever

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -1468,7 +1468,6 @@ services:
 	var zombied bool
 	for i := 0; i < 10; i++ {
 		stat, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/stat", childPid))
-		logger.Noticef("TODO stat of PID %d: %s", childPid, stat)
 		c.Assert(err, IsNil)
 		statFields := strings.Fields(string(stat))
 		c.Assert(len(statFields) >= 3, Equals, true)

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -142,6 +142,7 @@ func (s *S) SetUpTest(c *C) {
 	s.stopDaemon = make(chan struct{})
 	manager, err := servstate.NewManager(s.st, s.runner, s.dir, logOutput, testRestarter{s.stopDaemon})
 	c.Assert(err, IsNil)
+	defer manager.Stop()
 	s.manager = manager
 
 	restore := servstate.FakeOkayWait(shortOkayWait)
@@ -539,6 +540,7 @@ func (s *S) TestAppendLayer(c *C) {
 	runner := state.NewTaskRunner(s.st)
 	manager, err := servstate.NewManager(s.st, runner, dir, nil, nil)
 	c.Assert(err, IsNil)
+	defer manager.Stop()
 
 	// Append a layer when there are no layers.
 	layer := parseLayer(c, 0, "label1", `
@@ -621,6 +623,7 @@ func (s *S) TestCombineLayer(c *C) {
 	runner := state.NewTaskRunner(s.st)
 	manager, err := servstate.NewManager(s.st, runner, dir, nil, nil)
 	c.Assert(err, IsNil)
+	defer manager.Stop()
 
 	// "Combine" layer with no layers should just append.
 	layer := parseLayer(c, 0, "label1", `

--- a/internal/overlord/servstate/reaper.go
+++ b/internal/overlord/servstate/reaper.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package servstate
+
+import (
+	"os"
+	"os/signal"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/pebble/internal/logger"
+)
+
+// setChildSubreaper sets the current process as a "child subreaper" so we
+// become the parent of dead child processes rather than PID 1. This allows us
+// to wait for processes that are started by a Pebble service but then die, to
+// "reap" them (see https://unix.stackexchange.com/a/250156/73491).
+//
+// The function returns true if sub-reaping is available (Linux 3.4+) along
+// with an error if it's available but can't be set.
+func setChildSubreaper() (bool, error) {
+	err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+	if err == unix.EINVAL {
+		return false, nil
+	}
+	return true, err
+}
+
+// reapChildren "reaps" (waits for) child processes whose parents didn't
+// wait() for them. It stops when the stop channel is closed.
+func reapChildren(stop <-chan struct{}) {
+	sigChld := make(chan os.Signal, 1)
+	signal.Notify(sigChld, unix.SIGCHLD)
+	for {
+		logger.Debugf("Reaper waiting for SIGCHLD")
+		select {
+		case <-sigChld:
+			logger.Debugf("Reaper received SIGCHLD")
+			reapOnce()
+		case <-stop:
+			logger.Debugf("Reaper stopped")
+			signal.Reset(unix.SIGCHLD)
+			return
+		}
+	}
+}
+
+// reapOnce waits for zombie child processes until there are no more.
+func reapOnce() {
+	for {
+		var status unix.WaitStatus
+		pid, err := unix.Wait4(-1, &status, unix.WNOHANG, nil)
+		switch err {
+		case nil:
+			if pid <= 0 {
+				logger.Debugf("Reaper found no children have changed state")
+				return
+			}
+			logger.Noticef("Reaped child PID %d", pid)
+
+		case unix.ECHILD:
+			logger.Debugf("Reaper has no more children to wait for")
+			return
+
+		default:
+			logger.Noticef("Cannot wait for children: %v", err)
+			return
+		}
+	}
+}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -86,10 +86,10 @@ func setChildSubreaper() (bool, error) {
 // reapChildren "reaps" (waits for) child processes whose parents didn't
 // wait() for them. It stops when the stop channel is closed.
 func reapChildren(stop <-chan struct{}) {
+	logger.Debugf("Reaper started, waiting for SIGCHLD.")
 	sigChld := make(chan os.Signal, 1)
 	signal.Notify(sigChld, unix.SIGCHLD)
 	for {
-		logger.Debugf("Reaper waiting for SIGCHLD.")
 		select {
 		case <-sigChld:
 			logger.Debugf("Reaper received SIGCHLD.")
@@ -110,7 +110,6 @@ func reapOnce() {
 		switch err {
 		case nil:
 			if pid <= 0 {
-				logger.Debugf("Reaper found no children have changed state.")
 				return
 			}
 
@@ -130,11 +129,10 @@ func reapOnce() {
 			}
 
 		case unix.ECHILD:
-			logger.Debugf("Reaper has no more children to wait for.")
 			return
 
 		default:
-			logger.Noticef("Cannot wait for children: %v", err)
+			logger.Noticef("Reaper cannot wait for children: %v", err)
 			return
 		}
 	}
@@ -164,7 +162,7 @@ func WaitCommand(cmd *exec.Cmd) (int, error) {
 	err := cmd.Wait()
 	switch err := err.(type) {
 	case nil:
-		logger.Debugf("Expected cmd.Wait error, got nil (exit code %d)", exitCode)
+		logger.Debugf("WaitCommand expected error, got nil (exit code %d)", exitCode)
 		return exitCode, nil
 	case *os.SyscallError:
 		if err.Syscall == "wait" || err.Syscall == "waitid" {

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -37,7 +37,7 @@ var (
 // Start starts the child process reaper.
 func Start() error {
 	if stop != nil {
-		return fmt.Errorf("reaper already started")
+		return nil // already started
 	}
 
 	isSubreaper, err := setChildSubreaper()
@@ -60,7 +60,7 @@ func Start() error {
 // Stop stops the child process reaper.
 func Stop() error {
 	if stop == nil {
-		return fmt.Errorf("reaper not started")
+		return nil // already stopped
 	}
 	close(stop)
 	<-stopped // wait till reapChildren actually finishes
@@ -167,7 +167,7 @@ func WaitCommand(cmd *exec.Cmd) (int, error) {
 		logger.Debugf("Expected cmd.Wait error, got nil (exit code %d)", exitCode)
 		return exitCode, nil
 	case *os.SyscallError:
-		if err.Syscall == "wait" {
+		if err.Syscall == "wait" || err.Syscall == "waitid" {
 			return exitCode, nil
 		}
 		return -1, err

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -574,12 +574,12 @@ func (s *SystemdTestSuite) TestFuseInContainer(c *C) {
 	systemdCmd := testutil.FakeCommand(c, "systemd-detect-virt", `
 echo lxc
 exit 0
-	`)
+	`, false)
 	defer systemdCmd.Restore()
 
 	fuseCmd := testutil.FakeCommand(c, "squashfuse", `
 exit 0
-	`)
+	`, false)
 	defer fuseCmd.Restore()
 
 	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
@@ -612,12 +612,12 @@ func (s *SystemdTestSuite) TestFuseOutsideContainer(c *C) {
 	systemdCmd := testutil.FakeCommand(c, "systemd-detect-virt", `
 echo none
 exit 0
-	`)
+	`, false)
 	defer systemdCmd.Restore()
 
 	fuseCmd := testutil.FakeCommand(c, "squashfuse", `
 exit 0
-	`)
+	`, false)
 	defer fuseCmd.Restore()
 
 	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")

--- a/internal/testutil/exec_test.go
+++ b/internal/testutil/exec_test.go
@@ -28,7 +28,7 @@ type fakeCommandSuite struct{}
 var _ = check.Suite(&fakeCommandSuite{})
 
 func (s *fakeCommandSuite) TestFakeCommand(c *check.C) {
-	fake := FakeCommand(c, "cmd", "true")
+	fake := FakeCommand(c, "cmd", "true", false)
 	defer fake.Restore()
 	err := exec.Command("cmd", "first-run", "--arg1", "arg2", "a space").Run()
 	c.Assert(err, check.IsNil)
@@ -41,7 +41,7 @@ func (s *fakeCommandSuite) TestFakeCommand(c *check.C) {
 }
 
 func (s *fakeCommandSuite) TestFakeCommandAlso(c *check.C) {
-	fake := FakeCommand(c, "fst", "")
+	fake := FakeCommand(c, "fst", "", false)
 	also := fake.Also("snd", "")
 	defer fake.Restore()
 
@@ -52,7 +52,7 @@ func (s *fakeCommandSuite) TestFakeCommandAlso(c *check.C) {
 }
 
 func (s *fakeCommandSuite) TestFakeCommandConflictEcho(c *check.C) {
-	fake := FakeCommand(c, "do-not-swallow-echo-args", "")
+	fake := FakeCommand(c, "do-not-swallow-echo-args", "", false)
 	defer fake.Restore()
 
 	c.Assert(exec.Command("do-not-swallow-echo-args", "-E", "-n", "-e").Run(), check.IsNil)
@@ -63,13 +63,13 @@ func (s *fakeCommandSuite) TestFakeCommandConflictEcho(c *check.C) {
 
 func (s *fakeCommandSuite) TestFakeShellchecksWhenAvailable(c *check.C) {
 	tmpDir := c.MkDir()
-	fakeShellcheck := FakeCommand(c, "shellcheck", fmt.Sprintf(`cat > %s/input`, tmpDir))
+	fakeShellcheck := FakeCommand(c, "shellcheck", fmt.Sprintf(`cat > %s/input`, tmpDir), false)
 	defer fakeShellcheck.Restore()
 
 	restore := FakeShellcheckPath(fakeShellcheck.Exe())
 	defer restore()
 
-	fake := FakeCommand(c, "some-command", "echo some-command")
+	fake := FakeCommand(c, "some-command", "echo some-command", false)
 
 	c.Assert(exec.Command("some-command").Run(), check.IsNil)
 
@@ -90,7 +90,7 @@ func (s *fakeCommandSuite) TestFakeShellchecksWhenAvailable(c *check.C) {
 }
 
 func (s *fakeCommandSuite) TestFakeNoShellchecksWhenNotAvailable(c *check.C) {
-	fakeShellcheck := FakeCommand(c, "shellcheck", `echo "i am not called"; exit 1`)
+	fakeShellcheck := FakeCommand(c, "shellcheck", `echo "i am not called"; exit 1`, false)
 	defer fakeShellcheck.Restore()
 
 	restore := FakeShellcheckPath("")
@@ -98,7 +98,7 @@ func (s *fakeCommandSuite) TestFakeNoShellchecksWhenNotAvailable(c *check.C) {
 
 	// This would fail with proper shellcheck due to SC2086: Double quote to
 	// prevent globbing and word splitting.
-	fake := FakeCommand(c, "some-command", "echo $1")
+	fake := FakeCommand(c, "some-command", "echo $1", false)
 
 	c.Assert(exec.Command("some-command").Run(), check.IsNil)
 


### PR DESCRIPTION
This PR sets Pebble as a Linux "child subreaper", meaning if it's not running as PID 1, it'll get zombie (non-waited-on) children re-parented to Pebble rather than whatever *is* running as PID 1, so that we can reap them.

It also adds a "reaper" background task whose main purpose is to ensure that zombie / non-waited-on child processes are reaped (i.e., waited on and removed from the process table).

The reaper works by waiting for `SIGCHLD`, and on receipt of that signal, reaps as many waiting children as are available. For PIDs that Pebble has started directly using `os/exec`, instead of calling `cmd.Wait` we now call `reaper.WaitCommand()` -- this registers the PID with the reaper so it can notify the caller when it exited.

This is a bit klunky, but it avoids a race condition between `Wait4(-1, ...)` waiting for all PIDs, and `cmd.Wait()` waiting for a single PID -- they all go to the `Wait4(-1, ...)` now. `reaper.WaitCommand` still needs to call `cmd.Wait()` internally after the reaper has reaped the PID, so that `os/exec` cleans up goroutines and file descriptors after itself (it expects `cmd.Wait` to return a "no child processes" error).

This should fix issues like https://github.com/canonical/pebble/issues/71.