### PR TITLE
Add a comment to serviceState about the state diagram

### DIFF
--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -62,6 +62,9 @@ const (
 )
 
 // serviceState represents the state a service's state machine is in.
+//
+// See state-diagram.dot (and the generated state-diagram.svg image) for a
+// diagram of the states and transitions. Please try to keep these up to date!
 type serviceState string
 
 const (


### PR DESCRIPTION
Was included as a drive-by update in https://github.com/canonical/pebble/pull/101, but making it a separate PR to avoid noise in that one.