### PR TITLE
Fix panic when replan is called and there are no services to stop/start

### DIFF
--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -107,17 +107,6 @@ var (
 	muxVars = mux.Vars
 )
 
-func newChange(st *state.State, kind, summary string, taskSets []*state.TaskSet, serviceNames []string) *state.Change {
-	chg := st.NewChange(kind, summary)
-	for _, taskSet := range taskSets {
-		chg.AddAll(taskSet)
-	}
-	if serviceNames != nil {
-		chg.Set("service-names", serviceNames)
-	}
-	return chg
-}
-
 func v1SystemInfo(c *Command, r *http.Request, _ *userState) Response {
 	state := c.d.overlord.State()
 	state.Lock()

--- a/internal/daemon/api_services.go
+++ b/internal/daemon/api_services.go
@@ -180,12 +180,26 @@ func v1PostServices(c *Command, r *http.Request, _ *userState) Response {
 	// Use the original requested service name for the summary, not the
 	// resolved one. But do use the resolved set for the count.
 	var summary string
-	if len(services) == 1 {
+	switch len(services) {
+	case 0:
+		// Can happen with a replan that has no services to stop/start. A
+		// change with no tasks needs to be marked Done manually (normally a
+		// change is marked Done when its last task is finished).
+		summary = fmt.Sprintf("%s - no services", strings.Title(payload.Action))
+		change := st.NewChange(payload.Action, summary)
+		change.SetStatus(state.DoneStatus)
+		return AsyncResponse(nil, change.ID())
+	case 1:
 		summary = fmt.Sprintf("%s service %q", strings.Title(payload.Action), payload.Services[0])
-	} else {
+	default:
 		summary = fmt.Sprintf("%s service %q and %d more", strings.Title(payload.Action), payload.Services[0], len(services)-1)
 	}
-	change := newChange(st, payload.Action, summary, []*state.TaskSet{taskSet}, payload.Services)
+
+	change := st.NewChange(payload.Action, summary)
+	change.AddAll(taskSet)
+	if len(payload.Services) > 0 {
+		change.Set("service-names", payload.Services)
+	}
 
 	stateEnsureBefore(st, 0)
 

--- a/internal/daemon/api_services.go
+++ b/internal/daemon/api_services.go
@@ -180,8 +180,8 @@ func v1PostServices(c *Command, r *http.Request, _ *userState) Response {
 	// Use the original requested service name for the summary, not the
 	// resolved one. But do use the resolved set for the count.
 	var summary string
-	switch len(services) {
-	case 0:
+	switch {
+	case len(taskSet.Tasks()) == 0:
 		// Can happen with a replan that has no services to stop/start. A
 		// change with no tasks needs to be marked Done manually (normally a
 		// change is marked Done when its last task is finished).
@@ -189,7 +189,7 @@ func v1PostServices(c *Command, r *http.Request, _ *userState) Response {
 		change := st.NewChange(payload.Action, summary)
 		change.SetStatus(state.DoneStatus)
 		return AsyncResponse(nil, change.ID())
-	case 1:
+	case len(services) == 1:
 		summary = fmt.Sprintf("%s service %q", strings.Title(payload.Action), payload.Services[0])
 	default:
 		summary = fmt.Sprintf("%s service %q and %d more", strings.Title(payload.Action), payload.Services[0], len(services)-1)


### PR DESCRIPTION
When a replan was executed and there were no services to stop/start
(for example, when there are no startup: enabled services), the
POST /v1/services endpoint would panic due to the unhandled case.
Handle this case, which is a change with no tasks -- it needs to be a
real change because the endpoint returns a change ID (the client is
expecting a change ID or an error). It shouldn't be an error because
the replan is actually successful, there's just nothing to do.

Also add a test for this case.

This also removes newChange, which was only used in one place, and
less clear than just including it inline.

Fixes #94