### PR TITLE
Reduce server shutdown timeout from 25s to 1s

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -539,7 +539,7 @@ var (
 	rebootMaxTentatives    = 3
 )
 
-var shutdownTimeout = 25 * time.Second
+var shutdownTimeout = 3 * time.Second
 
 // Stop shuts down the Daemon.
 func (d *Daemon) Stop(sigCh chan<- os.Signal) error {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -539,7 +539,7 @@ var (
 	rebootMaxTentatives    = 3
 )
 
-var shutdownTimeout = 3 * time.Second
+var shutdownTimeout = time.Second
 
 // Stop shuts down the Daemon.
 func (d *Daemon) Stop(sigCh chan<- os.Signal) error {


### PR DESCRIPTION
This is primarily so that when you're debugging locally and press
Ctrl-C to terminate the Pebble server, an open "pebble logs -f" stream
doesn't block shutdown for 25 seconds. There's no need for this timeout
to be so long, so reduce it.

Note that this is only the time it takes to shut down the API server
(perhaps it should be called something more specific like
`serverShutdownTimeout`).

After the shutdown timeout is elapsed, the server terminates the
connection and the client gets an "EOF" error.

Fixes #55