### PR TITLE
Document that "pebble logs -f" only follows currently-running services

### DIFF
--- a/cmd/pebble/cmd_logs.go
+++ b/cmd/pebble/cmd_logs.go
@@ -42,7 +42,7 @@ type cmdLogs struct {
 }
 
 var logsDescs = map[string]string{
-	"follow": "Follow (tail) logs for given services until Ctrl-C pressed.",
+	"follow": "Follow (tail) logs for given services until Ctrl-C is\npressed. If no services are specified, show logs from\nall services running when the command starts.",
 	"format": "Output format: \"text\" (default) or \"json\" (JSON lines).",
 	"n":      "Number of logs to show (before following); defaults to 30.\nIf 'all', show all buffered logs.",
 }


### PR DESCRIPTION
It would be quite a significant refactoring to have "pebble logs -f"
subscribe to new services being started and wire that through, so for
now at least, just document the current behaviour. It seems unlikely to
affect people in practice, as the service(s) you're debugging will
likely be running.

See https://github.com/canonical/pebble/issues/56