### PR TITLE
Add option for explicit chmod with atomic file write.

### DIFF
--- a/internal/daemon/api_files.go
+++ b/internal/daemon/api_files.go
@@ -491,7 +491,8 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 	if uid != nil && gid != nil {
 		sysUid, sysGid = sys.UserID(*uid), sys.GroupID(*gid)
 	}
-	return atomicWriteChown(item.Path, source, perm, 0, sysUid, sysGid)
+
+	return atomicWriteChown(item.Path, source, perm, osutil.AtomicWriteChmod, sysUid, sysGid)
 }
 
 func parsePermissions(permissions string, defaultMode os.FileMode) (os.FileMode, error) {

--- a/internal/osutil/io.go
+++ b/internal/osutil/io.go
@@ -99,7 +99,7 @@ func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, ui
 	}
 
 	if flags&AtomicWriteChmod != 0 {
-		fd.Chmod(perm)
+		err := fd.Chmod(perm)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/osutil/io_test.go
+++ b/internal/osutil/io_test.go
@@ -107,14 +107,14 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAbsoluteSymlinks(c *C) {
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileChmod(c *C) {
 	tmpdir := c.MkDir()
-	oldmask := syscall.Umask(222)
+	oldmask := syscall.Umask(0222)
 	defer syscall.Umask(oldmask)
 
-	p := filepath.Join(tmpdir, "foo")
-	err := osutil.AtomicWriteFile(p, []byte(""), 0777, osutil.AtomicWriteChmod)
+	path := filepath.Join(tmpdir, "foo")
+	err := osutil.AtomicWriteFile(path, []byte{}, 0777, osutil.AtomicWriteChmod)
 	c.Assert(err, IsNil)
 
-	st, err := os.Stat(p)
+	st, err := os.Stat(path)
 	c.Assert(err, IsNil)
 	c.Assert(st.Mode()&os.ModePerm, Equals, os.FileMode(0777))
 }

--- a/internal/osutil/io_test.go
+++ b/internal/osutil/io_test.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/canonical/pebble/internal/osutil"
 	"github.com/canonical/pebble/internal/osutil/sys"
@@ -102,6 +103,20 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAbsoluteSymlinks(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(p, testutil.FileEquals, "hi")
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileChmod(c *C) {
+	tmpdir := c.MkDir()
+	oldmask := syscall.Umask(222)
+	defer syscall.Umask(oldmask)
+
+	p := filepath.Join(tmpdir, "foo")
+	err := osutil.AtomicWriteFile(p, []byte(""), 0777, osutil.AtomicWriteChmod)
+	c.Assert(err, IsNil)
+
+	st, err := os.Stat(p)
+	c.Assert(err, IsNil)
+	c.Assert(st.Mode()&os.ModePerm, Equals, os.FileMode(0777))
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteAbsoluteSymlink(c *C) {


### PR DESCRIPTION
And use this explicit chmod flag for file writes coming from the files api.

Fixes #80