### PR TITLE
automatic timestamp trimming for service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,13 @@ services:
         # half a minute ("30s").
         backoff-limit: <duration>
 
-        # (Optional) Regular expression for trimming prefixes from log
-        # messages.  This is used to discard matching prefixes from the
-        # service's log output before pebble attaches its own
-        # timestamp/prefix.  This can be useful for e.g. avoiding redundant
-        # timestamping.
-        log-trim: <regular-expression>
+        # (Optional) Time layout expression for trimming timestamps from log
+        # messages.  It must be specified using the reference-time syntax
+        # of the Go time package. This is used to discard redundant timestamp
+        # prefixes from the service's log output before pebble attaches its own
+        # timestamp/prefix. If omitted, Pebble will attempt to auto-detect and
+        # trim timestamps from the service's logs.
+        time-trim: <timestamp-layout>
 
 
 # (Optional) A list of health checks managed by this configuration layer.
@@ -387,7 +388,7 @@ Here are some of the things coming soon:
   - [x] Consider showing unified log as output of `pebble run` (use `-v`)
   - [x] Automatically restart services that fail
   - [x] Support for custom health checks (HTTP, TCP, command)
-  - [x] Support trimming prefixes (e.g. redundant timestamps) from logs
+  - [x] Automatically remove (double) timestamps from logs
   - [ ] Improve signal handling, e.g., sending SIGHUP to a service
   - [ ] Terminate all services before exiting run command
   - [ ] More tests for existing CLI commands

--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ services:
         # half a minute ("30s").
         backoff-limit: <duration>
 
+        # (Optional) Regular expression for trimming prefixes from log
+        # messages.  This is used to discard matching prefixes from the
+        # service's log output before pebble attaches its own
+        # timestamp/prefix.  This can be useful for e.g. avoiding redundant
+        # timestamping.
+        log-trim: <regular-expression>
+
 
 # (Optional) A list of health checks managed by this configuration layer.
 checks:
@@ -380,7 +387,7 @@ Here are some of the things coming soon:
   - [x] Consider showing unified log as output of `pebble run` (use `-v`)
   - [x] Automatically restart services that fail
   - [x] Support for custom health checks (HTTP, TCP, command)
-  - [ ] Automatically remove (double) timestamps from logs
+  - [x] Support trimming prefixes (e.g. redundant timestamps) from logs
   - [ ] Improve signal handling, e.g., sending SIGHUP to a service
   - [ ] Terminate all services before exiting run command
   - [ ] More tests for existing CLI commands

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -103,8 +103,8 @@ services:
 
     trim-test:
         override: replace
-        command: /bin/sh -c "echo prefix-to-trim  trim-test prefix-to-trim | tee -a %s; sleep 300"
-        log-trim: prefix-to-trim *
+        command: /bin/sh -c "echo 3/3/3333 trim-test | tee -a %s; sleep 300"
+        time-trim: 1/2/2006
 `
 
 var planLayer2 = `
@@ -400,8 +400,8 @@ services:
 	c.Check(config.Summary, Equals, "A summary!")
 }
 
-func (s *S) TestServiceLogTrim(c *C) {
-	outputs := map[string]string{"trim-test": `2.* \[trim-test\] trim-test prefix-to-trim\n`}
+func (s *S) TestServiceTimeTrim(c *C) {
+	outputs := map[string]string{"trim-test": `2.* \[trim-test\] trim-test\n`}
 	s.testServiceLogs(c, outputs)
 
 	// Run test again, but ensure the logs from the previous run are still in the ring buffer.
@@ -560,8 +560,8 @@ services:
         group: nogroup
     trim-test:
         override: replace
-        command: /bin/sh -c "echo prefix-to-trim  trim-test prefix-to-trim | tee -a %s; sleep 300"
-        log-trim: prefix-to-trim *
+        command: /bin/sh -c "echo 3/3/3333 trim-test | tee -a %s; sleep 300"
+        time-trim: 1/2/2006
 `[1:], s.log, s.log, s.log)
 	c.Assert(planYAML(c, s.manager), Equals, expected)
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -65,6 +65,7 @@ type Service struct {
 	Startup     ServiceStartup `yaml:"startup,omitempty"`
 	Override    Override       `yaml:"override,omitempty"`
 	Command     string         `yaml:"command,omitempty"`
+	LogTrim     string         `yaml:"log-trim,omitempty"`
 
 	// Service dependencies
 	After    []string `yaml:"after,omitempty"`
@@ -129,6 +130,9 @@ func (s *Service) Merge(other *Service) {
 	}
 	if other.Command != "" {
 		s.Command = other.Command
+	}
+	if other.LogTrim != "" {
+		s.LogTrim = other.LogTrim
 	}
 	if other.UserID != nil {
 		userID := *other.UserID
@@ -469,6 +473,11 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		if service.Command == "" {
 			return nil, &FormatError{
 				Message: fmt.Sprintf(`plan must define "command" for service %q`, name),
+			}
+		}
+		if _, err := regexp.Compile(service.LogTrim); err != nil {
+			return nil, &FormatError{
+				Message: fmt.Sprintf("plan service %q log-trim expression invalid: %v", name, err),
 			}
 		}
 		_, err := shlex.Split(service.Command)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -65,7 +65,7 @@ type Service struct {
 	Startup     ServiceStartup `yaml:"startup,omitempty"`
 	Override    Override       `yaml:"override,omitempty"`
 	Command     string         `yaml:"command,omitempty"`
-	LogTrim     string         `yaml:"log-trim,omitempty"`
+	TimeTrim    string         `yaml:"time-trim,omitempty"`
 
 	// Service dependencies
 	After    []string `yaml:"after,omitempty"`
@@ -131,8 +131,8 @@ func (s *Service) Merge(other *Service) {
 	if other.Command != "" {
 		s.Command = other.Command
 	}
-	if other.LogTrim != "" {
-		s.LogTrim = other.LogTrim
+	if other.TimeTrim != "" {
+		s.TimeTrim = other.TimeTrim
 	}
 	if other.UserID != nil {
 		userID := *other.UserID
@@ -475,9 +475,10 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 				Message: fmt.Sprintf(`plan must define "command" for service %q`, name),
 			}
 		}
-		if _, err := regexp.Compile(service.LogTrim); err != nil {
+		// Replace time layout underscores with spaces to convert the layout into a date for layout validation
+		if _, err := time.Parse(service.TimeTrim, strings.Replace(service.TimeTrim, "_", " ", -1)); err != nil {
 			return nil, &FormatError{
-				Message: fmt.Sprintf("plan service %q log-trim expression invalid: %v", name, err),
+				Message: fmt.Sprintf("plan service %q time-trim expression invalid: %v", name, err),
 			}
 		}
 		_, err := shlex.Split(service.Command)

--- a/internal/servicelog/formatter.go
+++ b/internal/servicelog/formatter.go
@@ -17,13 +17,13 @@ package servicelog
 import (
 	"bytes"
 	"io"
-	"regexp"
+	"strings"
 	"sync"
 	"time"
 )
 
 type formatter struct {
-	mut             sync.Mutex
+	mu              sync.Mutex
 	serviceName     string
 	dest            io.Writer
 	writeTimestamp  bool
@@ -55,8 +55,8 @@ func NewFormatWriter(dest io.Writer, serviceName string) *formatter {
 }
 
 func (f *formatter) Write(p []byte) (int, error) {
-	f.mut.Lock()
-	defer f.mut.Unlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	written := 0
 	for len(p) > 0 {
 		if f.writeTimestamp {
@@ -98,24 +98,46 @@ func (f *formatter) Write(p []byte) (int, error) {
 	return written, nil
 }
 
+// DefaultLayouts provides a list of default timestamp layouts that the
+// TrimWriter tries to auto-detect for on logged/written line prefixes.  This
+// auto detection only occurs if no explicit layout string is provided to the
+// TrimWriter.
+var DefaultLayouts = []string{}
+
+// TrimWriter removes a timestamp prefix from each line written (separated by '\n')
+// and forwards the trimmed writes to a destination writer.  Internal
+// buffering does occur so it is important to call Flush after all writes
+// are completed.  If no timestamp layout is explicitly specified,
+// auto-detection using a list of pre-defined default formats is attempted.
 type TrimWriter struct {
-	dest     io.Writer
-	re       *regexp.Regexp
-	buf      []byte
-	postTrim bool
-	mut      sync.Mutex
+	dest           io.Writer
+	mu             sync.Mutex
+	buf            []byte
+	layout         string
+	nfields        int
+	detectFailures int
 }
 
-func NewTrimWriter(dest io.Writer, re *regexp.Regexp) *TrimWriter {
-	return &TrimWriter{
-		dest: dest,
-		re:   re,
+// NewTrimWriter creates a writer that strips timestamp prefixes specified using layout. layout
+// identifies the timestamp format to trim using the reference time reference format from Go's
+// stdlib time package. If layout is the empty string, timestamp format auto-detection using
+// pre-selected formats from DefaultLayouts is attempted during initial writes when they take
+// place.
+func NewTrimWriter(dest io.Writer, layout string) *TrimWriter {
+	// layouts need to end in a space because that is how we detect/split off the
+	// log line prefix containing the timestamp
+	if len(layout) > 0 && layout[len(layout)-1] != ' ' {
+		layout += " "
 	}
+	w := &TrimWriter{dest: dest, layout: layout, nfields: timeLayoutFields(layout)}
+	return w
 }
 
+// Flush causes all buffered data to be written to the underlying destination writer.  This should
+// be called after all writes have been completed.
 func (w *TrimWriter) Flush() error {
-	w.mut.Lock()
-	defer w.mut.Unlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	if len(w.buf) == 0 {
 		return nil
@@ -127,8 +149,8 @@ func (w *TrimWriter) Flush() error {
 }
 
 func (w *TrimWriter) Write(p []byte) (int, error) {
-	w.mut.Lock()
-	defer w.mut.Unlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	// Buffered content has already been searched for newlines - track this.
 	pos := len(w.buf)
@@ -151,20 +173,141 @@ func (w *TrimWriter) Write(p []byte) (int, error) {
 	}
 }
 
-func (w *TrimWriter) write(p []byte) error {
-	start := 0
-	loc := w.re.FindIndex(p)
-	if loc != nil {
-		start = loc[1]
+func (w *TrimWriter) write(line []byte) error {
+	const maxDetectFailures = 10
+	const restartDetectionFailures = 2
+	if w.layout == "" && w.detectFailures < maxDetectFailures {
+		// try to auto-detect the layout
+		w.layout = detectLayout(line)
+		w.nfields = timeLayoutFields(w.layout)
+		if w.layout == "" {
+			w.detectFailures++
+		} else {
+			// detected layout; reset failure count
+			w.detectFailures = 0
+		}
 	}
 
-	p = p[start:]
-	for len(p) > 0 {
-		n, err := w.dest.Write(p)
-		p = p[n:]
+	length := 0
+	if w.layout != "" {
+		prefix := timeLayoutPrefix(w.nfields, line)
+		length = timeLength(w.layout, prefix)
+		if length == 0 {
+			// failed to find timestamp
+			w.detectFailures++
+			if w.detectFailures >= restartDetectionFailures {
+				// failed consecutively too much, switch back to layout detection mode
+				w.layout = ""
+				w.detectFailures = 0
+			}
+		} else {
+			// we found a timestamp again, reset failure count
+			w.detectFailures = 0
+		}
+	}
+
+	line = line[length:]
+	for len(line) > 0 {
+		n, err := w.dest.Write(line)
+		line = line[n:]
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// timeLength calculates and returns the number of leading bytes of prefix that are part of the
+// timestamp format specified by layout (Go time package reference time format).  If prefix does
+// not contain a timestamp conforming to the given layout, it returns zero.
+func timeLength(layout, prefix string) (length int) {
+	_, err := time.Parse(layout, prefix)
+	if err == nil {
+		length = len(prefix)
+	} else if err != nil && strings.Contains(err.Error(), "extra text: ") {
+		pe, ok := err.(*time.ParseError)
+		if ok {
+			var extraLength int
+			if strings.Contains(pe.Message, "extra text: \"") {
+				// go > 1.14
+				extraLength = len(pe.Message) - 1 - len(": extra text: \"")
+			} else {
+				// go <= 1.14.  Oler versions don't put quotes around the extra text content
+				extraLength = len(pe.Message) - len(": extra text: ")
+			}
+			length = len(prefix) - extraLength
+		}
+	}
+
+	// also skip leading whitespace on the remaining line
+	for _, c := range prefix[length:] {
+		if c != ' ' {
+			break
+		}
+		length++
+	}
+	return length
+}
+
+// timeLayoutFields returns the number of space-separated fields are in the time layout string
+func timeLayoutFields(layout string) int {
+	return len(strings.Fields(strings.Replace(layout, "_", " ", -1)))
+}
+
+// timeLayoutPrefix Returns a prefix string from line containing nfields whitespace separated
+// fields worth of content.  This is used to generate a superset of timestamp prefix bytes.
+func timeLayoutPrefix(nfields int, line []byte) string {
+	if nfields == 0 {
+		return ""
+	}
+
+	sep := byte(' ')
+	fieldCount := 0
+	prevChar := sep
+	size := 0
+	for i, c := range line {
+		// this loop is similar to strings.Fields but it also tracks the total number of bytes - which is
+		// lost info with strings.Fields when e.g. runs of whitespace are gobbled.
+		if c == sep && prevChar != sep || i == len(line)-1 && c != sep {
+			// transitioned from field to sep or we are on the last field
+			fieldCount++
+			if fieldCount >= nfields {
+				size = i + 1
+				break
+			}
+		}
+		prevChar = c
+	}
+
+	// also skip leading whitespace on the remaining line
+	for _, c := range line[size:] {
+		if c != ' ' {
+			break
+		}
+		size++
+	}
+
+	return string(line[:size])
+}
+
+// detectLayout loops over DefaultLayouts and returns the timestamp layout from it (if any) that
+// matches the timestamp prefix (if any) in line.  If no layouts match it returns an empty string.
+func detectLayout(line []byte) string {
+	for _, candidate := range DefaultLayouts {
+		// convert the layout to a test date (replace _ with " " padding) to parse against itself
+		// and confirm that the layout we are checking is valid.
+		testDate := strings.Replace(candidate, "_", " ", -1)
+		_, err := time.Parse(candidate, testDate)
+		if err != nil {
+			panic(err)
+		}
+
+		nfields := len(strings.Fields(testDate))
+		prefix := timeLayoutPrefix(nfields, line)
+		_, err = time.Parse(candidate, prefix)
+		if err == nil || (err != nil && strings.Contains(err.Error(), "extra text:")) {
+			return candidate
+		}
+	}
+	return ""
 }

--- a/internal/servicelog/formatter_test.go
+++ b/internal/servicelog/formatter_test.go
@@ -76,6 +76,10 @@ another log entry
 and dates in the middle 1/1/1133 are kept
 check that no-trailing-newline case is flushed`[1:]
 
+	// This raw log sample has an initial date format that is ambiguous for detection. The second
+	// and third dates are designed to be incompatible with the first line detected layout causing
+	// those prefixes to not be trimmed.  The two consecutive failures should then force
+	// auto-detection to re-occur causing the fourth+ lines to have trimming begin/work again.
 	trimmedAutodetect := `
 hello my name is joe
 4/ 5/4200 and I work in a button factory
@@ -85,8 +89,7 @@ and dates in the middle 1/1/1133 are kept
 check that no-trailing-newline case is flushed`[1:]
 
 	layout := "1/_2/2006 "
-	servicelog.DefaultLayouts = append(servicelog.DefaultLayouts, "1/2/2006")
-	servicelog.DefaultLayouts = append(servicelog.DefaultLayouts, layout)
+	servicelog.DefaultLayouts = []string{"1/2/2006", layout}
 	chunkSizes := []int{1, 2, 3, 4, 5, 6, 7, 11, 13, 27, 100}
 	for _, size := range chunkSizes {
 		c.Logf("---- chunk size %v, manual layout ----", size)


### PR DESCRIPTION
This adds support for a user-specified regex for matching against service log line prefixes (e.g. redundant time stamps) that are then discarded before pebble attaches its own timestamp/prefix.  This can be specified in a pebble service section like this:
    
```
services:
    foo-serv:
        override: replace
        comand: foo
        time-trim: 1/2/2006
```
    
Before we would get:
    
```
3456-01-02T00:00:01.000Z07:00 [foo-serv] 1/2/3456 [foo]  foo the bar
3456-01-02T00:00:02.000Z07:00 [foo-serv] 1/2/3456 [foo]  bar the baz
...
```
    
and with the time-trim expression, we now get:
    
```
3456-01-02T00:00:01.000Z07:00 [foo-serv] foo the bar
3456-01-02T00:00:02.000Z07:00 [foo-serv] bar the baz
...
```


The current TrimWriter implementation buffers entire lines before trimming the prefix and forwarding the writes.  I initially started writing an implementation that started forwarding writes as soon as an entire timestamp/prefix match was found, but it didn't seem like a good tradeoff in code complexity vs potential mem/cpu gains. I don't expect most log lines will be particularly long (let me know if I'm wrong here).
    
Fixes #91