### PR TITLE
Stop all services when Ctrl+C or SIGTERM/SIGQUIT received

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,9 +380,8 @@ Here are some of the things coming soon:
   - [x] Consider showing unified log as output of `pebble run` (use `-v`)
   - [x] Automatically restart services that fail
   - [x] Support for custom health checks (HTTP, TCP, command)
+  - [x] Terminate all services before exiting run command
   - [ ] Automatically remove (double) timestamps from logs
-  - [ ] Improve signal handling, e.g., sending SIGHUP to a service
-  - [ ] Terminate all services before exiting run command
   - [ ] More tests for existing CLI commands
 
 ## Hacking / Development

--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -61,7 +61,7 @@ func (rcmd *cmdRun) Execute(args []string) error {
 	}
 
 	sigs := make(chan os.Signal, 2)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	if err := runDaemon(rcmd, sigs); err != nil {
 		if err == daemon.ErrRestartSocket {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1090,7 +1090,7 @@ func (s *daemonSuite) TestHTTPAPI(c *check.C) {
 	c.Assert(err, ErrorMatches, ".* connection refused")
 }
 
-func (s *daemonSuite) TestServiceManagerShutdown(c *C) {
+func (s *daemonSuite) TestStopRunning(c *C) {
 	// Start the daemon.
 	writeTestLayer(s.pebbleDir, `
 services:
@@ -1112,7 +1112,7 @@ services:
 	rsp.ServeHTTP(rec, req)
 	c.Check(rec.Result().StatusCode, Equals, 202)
 
-	// We have to wait for it be in running state for Shutdown to stop it.
+	// We have to wait for it be in running state for StopRunning to stop it.
 	for i := 0; ; i++ {
 		if i >= 25 {
 			c.Fatalf("timed out waiting or service to start")
@@ -1130,18 +1130,18 @@ services:
 	err = d.Stop(nil)
 	c.Assert(err, IsNil)
 
-	// Ensure the "shutdown" change was created, along with its "stop" tasks.
+	// Ensure the "stop" change was created, along with its "stop" tasks.
 	d.state.Lock()
 	defer d.state.Unlock()
 	changes := d.state.Changes()
 	var change *state.Change
 	for _, ch := range changes {
-		if ch.Kind() == "shutdown" {
+		if ch.Kind() == "stop" {
 			change = ch
 		}
 	}
 	if change == nil {
-		c.Fatalf("shutdown change not found")
+		c.Fatalf("stop change not found")
 	}
 	c.Check(change.Status(), Equals, state.DoneStatus)
 	tasks := change.Tasks()

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -468,8 +468,7 @@ var shutdownTimeout = killWait + 100*time.Millisecond
 
 // Shutdown shuts down the service manager, stopping all running services.
 func (m *ServiceManager) Shutdown() error {
-	// Determine correct dependency order for stopping services.
-	services, err := m.StopOrder(m.runningServices())
+	services, err := m.servicesToStop()
 	if err != nil {
 		return err
 	}
@@ -507,16 +506,35 @@ func (m *ServiceManager) Shutdown() error {
 	return nil
 }
 
-// runningServices returns a slice of the names of running service.
-func (m *ServiceManager) runningServices() []string {
+// servicesToStop returns a slice of service names to stop, in dependency order.
+func (m *ServiceManager) servicesToStop() ([]string, error) {
+	releasePlan, err := m.acquirePlan()
+	if err != nil {
+		return nil, err
+	}
+	defer releasePlan()
+
+	// Get all service names in plan.
+	var services []string
+	for name := range m.plan.Services {
+		services = append(services, name)
+	}
+
+	// Order according to dependency order.
+	stop, err := m.plan.StopOrder(services)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter down to only those that are running.
 	m.servicesLock.Lock()
 	defer m.servicesLock.Unlock()
-
-	var services []string
-	for name, s := range m.services {
-		if s.state == stateRunning {
-			services = append(services, name)
+	var running []string
+	for _, name := range stop {
+		s := m.services[name]
+		if s != nil && s.state == stateRunning {
+			running = append(running, name)
 		}
 	}
-	return services
+	return running, nil
 }

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -489,10 +489,6 @@ func (m *ServiceManager) Shutdown() error {
 	chg := st.NewChange("shutdown", "Shut down service manager")
 	chg.AddAll(taskSet)
 	chg.Set("service-names", services)
-	st.Unlock()
-
-	// Kick off the tasks immediately.
-	st.Lock()
 	st.EnsureBefore(0)
 	st.Unlock()
 

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -70,7 +70,7 @@ var planLayer1 = `
 services:
     test1:
         override: replace
-        command: /bin/sh -c "echo test1 | tee -a %s; sleep 300"
+        command: /bin/sh -c "echo test1 | tee -a %s; sleep 10"
         startup: enabled
         requires:
             - test2
@@ -79,7 +79,7 @@ services:
 
     test2:
         override: replace
-        command: /bin/sh -c "echo test2 | tee -a %s; sleep 300"
+        command: /bin/sh -c "echo test2 | tee -a %s; sleep 10"
 `
 
 var planLayer2 = `
@@ -94,7 +94,7 @@ services:
 
     test5:
         override: replace
-        command: /bin/sh -c "sleep 300"
+        command: /bin/sh -c "sleep 10"
         user: nobody
         group: nogroup
 `
@@ -103,7 +103,7 @@ var planLayer3 = `
 services:
     test2:
         override: merge
-        command: /bin/sh -c "echo test2b | tee -a %s; sleep 300"
+        command: /bin/sh -c "echo test2b | tee -a %s; sleep 10"
 `
 
 var setLoggerOnce sync.Once
@@ -499,14 +499,14 @@ services:
     test1:
         startup: enabled
         override: replace
-        command: /bin/sh -c "echo test1 | tee -a %s; sleep 300"
+        command: /bin/sh -c "echo test1 | tee -a %s; sleep 10"
         before:
             - test2
         requires:
             - test2
     test2:
         override: replace
-        command: /bin/sh -c "echo test2 | tee -a %s; sleep 300"
+        command: /bin/sh -c "echo test2 | tee -a %s; sleep 10"
     test3:
         override: replace
         command: some-bad-command
@@ -515,7 +515,7 @@ services:
         command: echo -e 'too-fast\nsecond line'
     test5:
         override: replace
-        command: /bin/sh -c "sleep 300"
+        command: /bin/sh -c "sleep 10"
         user: nobody
         group: nogroup
 `[1:], s.log, s.log)
@@ -765,7 +765,7 @@ var planLayerEnv = `
 services:
     envtest:
         override: replace
-        command: /bin/sh -c "env | grep PEBBLE_ENV_TEST | sort > %s; sleep 300"
+        command: /bin/sh -c "env | grep PEBBLE_ENV_TEST | sort > %s; sleep 10"
         environment:
             PEBBLE_ENV_TEST_1: foo
             PEBBLE_ENV_TEST_2: bar bazz
@@ -819,7 +819,7 @@ func (s *S) TestActionRestart(c *C) {
 services:
     test2:
         override: merge
-        command: /bin/sh -c "echo test2; exec sleep 300"
+        command: /bin/sh -c "echo test2; exec sleep 10"
         backoff-delay: 50ms
         backoff-limit: 150ms
 `)

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -1453,9 +1453,9 @@ func (s *S) TestShutdown(c *C) {
 	defer s.st.Unlock()
 	c.Check(change.Summary(), Equals, "Shut down service manager")
 	c.Check(change.Status(), Equals, state.DoneStatus)
-	shutdownTasks := change.Tasks()
-	c.Assert(shutdownTasks, HasLen, 1)
-	c.Check(shutdownTasks[0].Kind(), Equals, "stop")
+	tasks := change.Tasks()
+	c.Assert(tasks, HasLen, 1)
+	c.Check(tasks[0].Kind(), Equals, "stop")
 }
 
 func (s *S) shutdownChange() *state.Change {

--- a/internal/overlord/servstate/request.go
+++ b/internal/overlord/servstate/request.go
@@ -46,3 +46,24 @@ func Stop(s *state.State, services []string) (*state.TaskSet, error) {
 	}
 	return state.NewTaskSet(tasks...), nil
 }
+
+// StopRunning creates and returns a task set for stopping all running
+// services. It returns a nil *TaskSet if there are no services to stop.
+func StopRunning(s *state.State, m *ServiceManager) (*state.TaskSet, error) {
+	services, err := servicesToStop(m)
+	if err != nil {
+		return nil, err
+	}
+	if len(services) == 0 {
+		return nil, nil
+	}
+
+	// One change to stop them all.
+	s.Lock()
+	defer s.Unlock()
+	taskSet, err := Stop(s, services)
+	if err != nil {
+		return nil, err
+	}
+	return taskSet, nil
+}


### PR DESCRIPTION
This PR makes Pebble try to gracefully stop all services when SIGINT (Ctrl+C) or SIGTERM/SIGQUIT is received. This goes via the regular "stop" task process, which sends SIGTERM to each process, then waits up to the killWait time (5s) before sending SIGKILL.

The "stop" tasks are added to a new "stop" change. I considered whether a change is appropriate here (given the recent discussion about events), and I do think it is. For one, this is a user-initiated action (Ctrl-C pressed / signal sent), and besides, the tasks are ordinary "stop" tasks to stop the services involved, so they need to be part of an associated change to kick them off. Later when we add events, we can additionally fire a shutdown event of some kind.

Output of `pebble changes` and `pebble tasks` showing the record of the "stop" change and tasks (this is after stopping and restart the Pebble daemon, hence the "autostart" change):

```
$ pebble changes
ID   Status  Spawn                Ready                Summary
1    Done    today at 17:01 NZST  today at 17:01 NZST  Autostart service "sleepy" and 1 more
2    Done    today at 17:01 NZST  today at 17:01 NZST  Stop all running services
3    Done    today at 17:01 NZST  today at 17:01 NZST  Autostart service "sleepy" and 1 more

$ pebble tasks 2
Status  Spawn                Ready                Summary
Done    today at 17:01 NZST  today at 17:01 NZST  Stop service "sleepy"
Done    today at 17:01 NZST  today at 17:01 NZST  Stop service "test"
```

See related issue: https://github.com/canonical/pebble/issues/6.