### PR TITLE
Add "current-since" field to services API and CLI

### DIFF
--- a/client/services.go
+++ b/client/services.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type ServiceOptions struct {
@@ -80,9 +81,10 @@ type ServicesOptions struct {
 
 // ServiceInfo holds status information for a single service.
 type ServiceInfo struct {
-	Name    string         `json:"name"`
-	Startup ServiceStartup `json:"startup"`
-	Current ServiceStatus  `json:"current"`
+	Name      string         `json:"name"`
+	Startup   ServiceStartup `json:"startup"`
+	Current   ServiceStatus  `json:"current"`
+	StartTime time.Time      `json:"start-time"`
 }
 
 // ServiceStartup defines the different startup modes for a service.

--- a/client/services.go
+++ b/client/services.go
@@ -81,10 +81,10 @@ type ServicesOptions struct {
 
 // ServiceInfo holds status information for a single service.
 type ServiceInfo struct {
-	Name      string         `json:"name"`
-	Startup   ServiceStartup `json:"startup"`
-	Current   ServiceStatus  `json:"current"`
-	StartTime time.Time      `json:"start-time"`
+	Name         string         `json:"name"`
+	Startup      ServiceStartup `json:"startup"`
+	Current      ServiceStatus  `json:"current"`
+	CurrentSince time.Time      `json:"current-since"`
 }
 
 // ServiceStartup defines the different startup modes for a service.

--- a/client/services_test.go
+++ b/client/services_test.go
@@ -17,6 +17,7 @@ package client_test
 import (
 	"encoding/json"
 	"net/url"
+	"time"
 
 	"gopkg.in/check.v1"
 
@@ -87,7 +88,7 @@ func (cs *clientSuite) TestServicesGet(c *check.C) {
 	cs.rsp = `{
 		"result": [
 			{"name": "svc1", "startup": "enabled", "current": "inactive"},
-			{"name": "svc2", "startup": "disabled", "current": "active"}
+			{"name": "svc2", "startup": "disabled", "current": "active", "current-since": "2022-04-28T17:05:23Z"}
 		],
 		"status": "OK",
 		"status-code": 200,
@@ -101,7 +102,7 @@ func (cs *clientSuite) TestServicesGet(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(services, check.DeepEquals, []*client.ServiceInfo{
 		{Name: "svc1", Startup: client.StartupEnabled, Current: client.StatusInactive},
-		{Name: "svc2", Startup: client.StartupDisabled, Current: client.StatusActive},
+		{Name: "svc2", Startup: client.StartupDisabled, Current: client.StatusActive, CurrentSince: time.Date(2022, 4, 28, 17, 5, 23, 0, time.UTC)},
 	})
 	c.Assert(cs.req.Method, check.Equals, "GET")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v1/services")

--- a/cmd/pebble/cmd_services.go
+++ b/cmd/pebble/cmd_services.go
@@ -60,14 +60,14 @@ func (cmd *cmdServices) Execute(args []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	fmt.Fprintln(w, "Service\tStartup\tCurrent\tStart Time")
+	fmt.Fprintln(w, "Service\tStartup\tCurrent\tSince")
 
 	for _, svc := range services {
-		startTime := "-"
-		if !svc.StartTime.IsZero() {
-			startTime = cmd.fmtTime(svc.StartTime)
+		since := "-"
+		if !svc.CurrentSince.IsZero() {
+			since = cmd.fmtTime(svc.CurrentSince)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", svc.Name, svc.Startup, svc.Current, startTime)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", svc.Name, svc.Startup, svc.Current, since)
 	}
 	return nil
 }

--- a/cmd/pebble/cmd_services.go
+++ b/cmd/pebble/cmd_services.go
@@ -24,6 +24,7 @@ import (
 
 type cmdServices struct {
 	clientMixin
+	timeMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
@@ -59,14 +60,20 @@ func (cmd *cmdServices) Execute(args []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	fmt.Fprintln(w, "Service\tStartup\tCurrent")
+	fmt.Fprintln(w, "Service\tStartup\tCurrent\tStart Time")
 
 	for _, svc := range services {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", svc.Name, svc.Startup, svc.Current)
+		startTime := "-"
+		if !svc.StartTime.IsZero() {
+			startTime = cmd.fmtTime(svc.StartTime)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", svc.Name, svc.Startup, svc.Current, startTime)
 	}
 	return nil
 }
 
 func init() {
-	addCommand("services", shortServicesHelp, longServicesHelp, func() flags.Commander { return &cmdServices{} }, nil, nil)
+	addCommand("services", shortServicesHelp, longServicesHelp,
+		func() flags.Commander { return &cmdServices{} },
+		timeDescs, nil)
 }

--- a/cmd/pebble/cmd_services_test.go
+++ b/cmd/pebble/cmd_services_test.go
@@ -33,7 +33,7 @@ func (s *PebbleSuite) TestServices(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "svc1", "current": "inactive", "startup": "enabled"},
+		{"name": "svc1", "current": "inactive", "startup": "enabled", "current-since": "2022-04-28T17:05:23+12:00"},
 		{"name": "svc2", "current": "inactive", "startup": "enabled"},
 		{"name": "svc3", "current": "backoff", "startup": "enabled"}
 	]
@@ -44,7 +44,7 @@ func (s *PebbleSuite) TestServices(c *check.C) {
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
 Service  Startup  Current   Since
-svc1     enabled  inactive  -
+svc1     enabled  inactive  2022-04-28
 svc2     enabled  inactive  -
 svc3     enabled  backoff   -
 `[1:])

--- a/cmd/pebble/cmd_services_test.go
+++ b/cmd/pebble/cmd_services_test.go
@@ -43,7 +43,7 @@ func (s *PebbleSuite) TestServices(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Service  Startup  Current   Start Time
+Service  Startup  Current   Since
 svc1     enabled  inactive  -
 svc2     enabled  inactive  -
 svc3     enabled  backoff   -
@@ -60,7 +60,7 @@ func (s *PebbleSuite) TestServicesNames(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "bar", "current": "active", "startup": "disabled", "start-time": "2022-04-28T17:05:23+12:00"},
+		{"name": "bar", "current": "active", "startup": "disabled", "current-since": "2022-04-28T17:05:23+12:00"},
 		{"name": "foo", "current": "inactive", "startup": "enabled"}
 	]
 }`)
@@ -69,7 +69,7 @@ func (s *PebbleSuite) TestServicesNames(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Service  Startup   Current   Start Time
+Service  Startup   Current   Since
 bar      disabled  active    2022-04-28T17:05:23+12:00
 foo      enabled   inactive  -
 `[1:])

--- a/cmd/pebble/cmd_services_test.go
+++ b/cmd/pebble/cmd_services_test.go
@@ -43,10 +43,10 @@ func (s *PebbleSuite) TestServices(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Service  Startup  Current
-svc1     enabled  inactive
-svc2     enabled  inactive
-svc3     enabled  backoff
+Service  Startup  Current   Start Time
+svc1     enabled  inactive  -
+svc2     enabled  inactive  -
+svc3     enabled  backoff   -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -60,18 +60,18 @@ func (s *PebbleSuite) TestServicesNames(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "bar", "current": "active", "startup": "disabled"},
+		{"name": "bar", "current": "active", "startup": "disabled", "start-time": "2022-04-28T17:05:23+12:00"},
 		{"name": "foo", "current": "inactive", "startup": "enabled"}
 	]
 }`)
 	})
-	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"services", "foo", "bar"})
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"services", "foo", "bar", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Service  Startup   Current
-bar      disabled  active
-foo      enabled   inactive
+Service  Startup   Current   Start Time
+bar      disabled  active    2022-04-28T17:05:23+12:00
+foo      enabled   inactive  -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/internal/daemon/api_services.go
+++ b/internal/daemon/api_services.go
@@ -28,10 +28,10 @@ import (
 )
 
 type serviceInfo struct {
-	Name      string     `json:"name"`
-	Startup   string     `json:"startup"`
-	Current   string     `json:"current"`
-	StartTime *time.Time `json:"start-time,omitempty"` // pointer as omitempty doesn't work with time.Time directly
+	Name         string     `json:"name"`
+	Startup      string     `json:"startup"`
+	Current      string     `json:"current"`
+	CurrentSince *time.Time `json:"current-since,omitempty"` // pointer as omitempty doesn't work with time.Time directly
 }
 
 func v1GetServices(c *Command, r *http.Request, _ *userState) Response {
@@ -50,8 +50,8 @@ func v1GetServices(c *Command, r *http.Request, _ *userState) Response {
 			Startup: string(svc.Startup),
 			Current: string(svc.Current),
 		}
-		if !svc.StartTime.IsZero() {
-			info.StartTime = &svc.StartTime
+		if !svc.CurrentSince.IsZero() {
+			info.CurrentSince = &svc.CurrentSince
 		}
 		infos = append(infos, info)
 	}

--- a/internal/daemon/api_services.go
+++ b/internal/daemon/api_services.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/canonical/pebble/internal/overlord/servstate"
 	"github.com/canonical/pebble/internal/overlord/state"
@@ -27,9 +28,10 @@ import (
 )
 
 type serviceInfo struct {
-	Name    string `json:"name"`
-	Startup string `json:"startup"`
-	Current string `json:"current"`
+	Name      string     `json:"name"`
+	Startup   string     `json:"startup"`
+	Current   string     `json:"current"`
+	StartTime *time.Time `json:"start-time,omitempty"` // pointer as omitempty doesn't work with time.Time directly
 }
 
 func v1GetServices(c *Command, r *http.Request, _ *userState) Response {
@@ -47,6 +49,9 @@ func v1GetServices(c *Command, r *http.Request, _ *userState) Response {
 			Name:    svc.Name,
 			Startup: string(svc.Startup),
 			Current: string(svc.Current),
+		}
+		if !svc.StartTime.IsZero() {
+			info.StartTime = &svc.StartTime
 		}
 		infos = append(infos, info)
 	}

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -92,6 +92,7 @@ type serviceData struct {
 	backoffTime time.Duration
 	resetTimer  *time.Timer
 	restarting  bool
+	startTime   time.Time
 	restarts    int
 }
 
@@ -366,6 +367,7 @@ func (s *serviceData) startInternal() error {
 		return fmt.Errorf("cannot start service: %w", err)
 	}
 	logger.Debugf("Service %q started with PID %d", serviceName, s.cmd.Process.Pid)
+	s.startTime = time.Now()
 	s.resetTimer = time.AfterFunc(s.config.BackoffLimit.Value, func() { logError(s.backoffResetElapsed()) })
 
 	// Start a goroutine to wait for the process to finish.
@@ -424,6 +426,7 @@ func (s *serviceData) exited(exitCode int) error {
 	s.manager.servicesLock.Lock()
 	defer s.manager.servicesLock.Unlock()
 
+	s.startTime = time.Time{}
 	if s.resetTimer != nil {
 		s.resetTimer.Stop()
 	}

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -93,7 +93,6 @@ type serviceData struct {
 	resetTimer  *time.Timer
 	restarting  bool
 	startTime   time.Time
-	restarts    int
 }
 
 func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
@@ -600,7 +599,6 @@ func (s *serviceData) backoffTimeElapsed() error {
 
 	switch s.state {
 	case stateBackoff:
-		s.restarts++
 		err := s.startInternal()
 		if err != nil {
 			return err

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -235,10 +235,11 @@ func (m *ServiceManager) Ensure() error {
 }
 
 type ServiceInfo struct {
-	Name     string
-	Startup  ServiceStartup
-	Current  ServiceStatus
-	Restarts int
+	Name      string
+	Startup   ServiceStartup
+	Current   ServiceStatus
+	StartTime time.Time
+	Restarts  int
 }
 
 type ServiceStartup string
@@ -300,6 +301,7 @@ func (m *ServiceManager) Services(names []string) ([]*ServiceInfo, error) {
 			default:
 				info.Current = StatusError
 			}
+			info.StartTime = s.startTime
 			info.Restarts = s.restarts
 		}
 		services = append(services, info)

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -302,7 +302,6 @@ func (m *ServiceManager) Services(names []string) ([]*ServiceInfo, error) {
 				info.Current = StatusError
 			}
 			info.StartTime = s.startTime
-			info.Restarts = s.restarts
 		}
 		services = append(services, info)
 	}

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -753,6 +753,7 @@ services:
 }
 
 func (s *S) TestServices(c *C) {
+	started := time.Now()
 	services, err := s.manager.Services(nil)
 	c.Assert(err, IsNil)
 	c.Assert(services, DeepEquals, []*servstate.ServiceInfo{
@@ -775,6 +776,8 @@ func (s *S) TestServices(c *C) {
 
 	services, err = s.manager.Services(nil)
 	c.Assert(err, IsNil)
+	c.Assert(services[1].StartTime.After(started) && services[1].StartTime.Before(started.Add(5*time.Second)), Equals, true)
+	services[1].StartTime = time.Time{}
 	c.Assert(services, DeepEquals, []*servstate.ServiceInfo{
 		{Name: "test1", Current: servstate.StatusInactive, Startup: servstate.StartupEnabled},
 		{Name: "test2", Current: servstate.StatusActive, Startup: servstate.StartupDisabled},

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -776,8 +776,8 @@ func (s *S) TestServices(c *C) {
 
 	services, err = s.manager.Services(nil)
 	c.Assert(err, IsNil)
-	c.Assert(services[1].StartTime.After(started) && services[1].StartTime.Before(started.Add(5*time.Second)), Equals, true)
-	services[1].StartTime = time.Time{}
+	c.Assert(services[1].CurrentSince.After(started) && services[1].CurrentSince.Before(started.Add(5*time.Second)), Equals, true)
+	services[1].CurrentSince = time.Time{}
 	c.Assert(services, DeepEquals, []*servstate.ServiceInfo{
 		{Name: "test1", Current: servstate.StatusInactive, Startup: servstate.StartupEnabled},
 		{Name: "test2", Current: servstate.StatusActive, Startup: servstate.StartupDisabled},


### PR DESCRIPTION
This PR adds a `current-since` field to the API, meaning the time at which the "current" field last changed, for example started (current changed from `inactive` to `active`), and so on. It's related to https://github.com/canonical/pebble/issues/104 (though in a previous iteration it was "start time", not "curren since").

Here's how it looks like the CLI:

```
$ pebble services
Service  Startup  Current  Since
test2    enabled  active   today at 17:08 NZST

$ pebble services --abs-time
Service  Startup  Current  Since
test2    enabled  active   2022-04-28T17:08:45+12:00
```

This PR also removes the "restarts" field which isn't being used and was internal-only. Per #104, we're going to use changes/tasks or events instead.