### PR TITLE
Record "recover-check" change and task logs when health check is failing

### DIFF
--- a/internal/overlord/overlord.go
+++ b/internal/overlord/overlord.go
@@ -114,7 +114,7 @@ func New(pebbleDir string, restartHandler restart.Handler, serviceOutput io.Writ
 	o.commandMgr = cmdstate.NewManager(o.runner)
 	o.addManager(o.commandMgr)
 
-	o.checkMgr = checkstate.NewManager()
+	o.checkMgr = checkstate.NewManager(s)
 
 	// Tell check manager about plan updates.
 	o.serviceMgr.NotifyPlanChanged(o.checkMgr.PlanChanged)

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -948,7 +948,7 @@ services:
 
 func (s *S) TestOnCheckFailureRestartWhileRunning(c *C) {
 	// Create check manager and tell it about plan updates
-	checkMgr := checkstate.NewManager()
+	checkMgr := checkstate.NewManager(s.st)
 	defer checkMgr.PlanChanged(&plan.Plan{})
 	s.manager.NotifyPlanChanged(checkMgr.PlanChanged)
 
@@ -999,7 +999,6 @@ checks:
 		c.Assert(err, IsNil)
 		if len(checks) == 1 && checks[0].Status != checkstate.CheckStatusUp {
 			c.Assert(checks[0].Failures, Equals, 1)
-			c.Assert(checks[0].LastError, Matches, ".* executable file not found .*")
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -1030,7 +1029,6 @@ checks:
 	c.Assert(err, IsNil)
 	c.Assert(len(checks), Equals, 1)
 	c.Assert(checks[0].Status, Equals, checkstate.CheckStatusDown)
-	c.Assert(checks[0].LastError, Matches, ".* executable file not found .*")
 	svc := s.serviceByName(c, "test2")
 	c.Assert(svc.Current, Equals, servstate.StatusActive)
 	c.Assert(s.manager.BackoffNum("test2"), Equals, 1)
@@ -1038,7 +1036,7 @@ checks:
 
 func (s *S) TestOnCheckFailureRestartDuringBackoff(c *C) {
 	// Create check manager and tell it about plan updates
-	checkMgr := checkstate.NewManager()
+	checkMgr := checkstate.NewManager(s.st)
 	defer checkMgr.PlanChanged(&plan.Plan{})
 	s.manager.NotifyPlanChanged(checkMgr.PlanChanged)
 
@@ -1111,12 +1109,11 @@ checks:
 	c.Assert(err, IsNil)
 	c.Assert(len(checks), Equals, 1)
 	c.Assert(checks[0].Status, Equals, checkstate.CheckStatusDown)
-	c.Assert(checks[0].LastError, Matches, ".* executable file not found .*")
 }
 
 func (s *S) TestOnCheckFailureIgnore(c *C) {
 	// Create check manager and tell it about plan updates
-	checkMgr := checkstate.NewManager()
+	checkMgr := checkstate.NewManager(s.st)
 	defer checkMgr.PlanChanged(&plan.Plan{})
 	s.manager.NotifyPlanChanged(checkMgr.PlanChanged)
 
@@ -1166,7 +1163,6 @@ checks:
 		c.Assert(err, IsNil)
 		if len(checks) == 1 && checks[0].Status != checkstate.CheckStatusUp {
 			c.Assert(checks[0].Failures, Equals, 1)
-			c.Assert(checks[0].LastError, Matches, ".* executable file not found .*")
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -1181,14 +1177,13 @@ checks:
 	c.Assert(err, IsNil)
 	c.Assert(len(checks), Equals, 1)
 	c.Assert(checks[0].Status, Equals, checkstate.CheckStatusDown)
-	c.Assert(checks[0].LastError, Matches, ".* executable file not found .*")
 	svc := s.serviceByName(c, "test2")
 	c.Assert(svc.Current, Equals, servstate.StatusActive)
 }
 
 func (s *S) TestOnCheckFailureShutdown(c *C) {
 	// Create check manager and tell it about plan updates
-	checkMgr := checkstate.NewManager()
+	checkMgr := checkstate.NewManager(s.st)
 	defer checkMgr.PlanChanged(&plan.Plan{})
 	s.manager.NotifyPlanChanged(checkMgr.PlanChanged)
 
@@ -1238,7 +1233,6 @@ checks:
 		c.Assert(err, IsNil)
 		if len(checks) == 1 && checks[0].Status != checkstate.CheckStatusUp {
 			c.Assert(checks[0].Failures, Equals, 1)
-			c.Assert(checks[0].LastError, Matches, ".* executable file not found .*")
 			break
 		}
 		time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
Also record a task for every failure until the threshold, and close
the change (set it to Done) when the health check goes successful
again. The error message and any details is included in the task log.

This is similar to the "recover-service" change in https://github.com/canonical/pebble/pull/117,
but for health checks.

Fixes #103.