### PR TITLE
Add configuration file validation

### DIFF
--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -168,7 +168,7 @@ type helpCategory struct {
 var helpCategories = []helpCategory{{
 	Label:       "Run",
 	Description: "run pebble",
-	Commands:    []string{"run", "help", "version"},
+	Commands:    []string{"run", "validate", "help", "version"},
 }, {
 	Label:       "Plan",
 	Description: "view and change configuration",

--- a/cmd/pebble/cmd_validate.go
+++ b/cmd/pebble/cmd_validate.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/canonical/pebble/internal/plan"
+	"github.com/jessevdk/go-flags"
+)
+
+var shortValidateHelp = "Validate daemon configration"
+var longValidateHelp = `
+Perform validation of daemon configuration files and exit.
+`
+
+type cmdValidate struct {
+	clientMixin
+}
+
+func init() {
+	addCommand("validate", shortValidateHelp, longValidateHelp, func() flags.Commander { return &cmdValidate{} }, nil, nil)
+}
+
+func (cmd cmdValidate) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	pebbleDir, _ := getEnvPaths()
+
+	_, err := plan.ReadDir(pebbleDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configuration validation failed: %v\n", err)
+		panic(&exitStatus{1})
+	}
+
+	return nil
+}

--- a/cmd/pebble/cmd_validate.go
+++ b/cmd/pebble/cmd_validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2022 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -15,16 +15,15 @@
 package main
 
 import (
-	"fmt"
-	"os"
+	"github.com/jessevdk/go-flags"
 
 	"github.com/canonical/pebble/internal/plan"
-	"github.com/jessevdk/go-flags"
 )
 
-var shortValidateHelp = "Validate daemon configration"
+var shortValidateHelp = "Validate daemon configuration"
 var longValidateHelp = `
-Perform validation of daemon configuration files and exit.
+Validate the Pebble configuration layers in the $PEBBLE/layers directory,
+exiting with an error message and non-zero exit code on failure.
 `
 
 type cmdValidate struct {
@@ -43,10 +42,5 @@ func (cmd cmdValidate) Execute(args []string) error {
 	pebbleDir, _ := getEnvPaths()
 
 	_, err := plan.ReadDir(pebbleDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "configuration validation failed: %v\n", err)
-		panic(&exitStatus{1})
-	}
-
-	return nil
+	return err
 }

--- a/cmd/pebble/cmd_validate_test.go
+++ b/cmd/pebble/cmd_validate_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	pebble "github.com/canonical/pebble/cmd/pebble"
+)
+
+func (s *PebbleSuite) TestValidateCommand(c *C) {
+	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"validate"})
+	c.Assert(err, IsNil)
+}

--- a/cmd/pebble/cmd_validate_test.go
+++ b/cmd/pebble/cmd_validate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2022 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -15,12 +15,45 @@
 package main_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	. "gopkg.in/check.v1"
 
 	pebble "github.com/canonical/pebble/cmd/pebble"
 )
 
-func (s *PebbleSuite) TestValidateCommand(c *C) {
-	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"validate"})
+func (s *PebbleSuite) TestValidateCommandYamlOK(c *C) {
+	var err error
+
+	layersDir := filepath.Join(s.pebbleDir, "layers")
+	err = os.Mkdir(layersDir, 0755)
 	c.Assert(err, IsNil)
+
+	fpath := filepath.Join(layersDir, "001-kerncraft.yaml")
+	err = ioutil.WriteFile(fpath, []byte("summary: Kerncraft Layer"), 0644)
+	c.Assert(err, IsNil)
+
+	_, err = pebble.Parser(pebble.Client()).ParseArgs([]string{"validate"})
+	c.Assert(err, IsNil)
+}
+
+// TestValidateCommandYamlInvalidSchema does not attempt to test the plan validation
+// logic. The purpose of this test is to ensure the plumbing is in place to report
+// a YAML schema violation using the 'validate' command.
+func (s *PebbleSuite) TestValidateCommandYamlInvalidSchema(c *C) {
+	var err error
+
+	layersDir := filepath.Join(s.pebbleDir, "layers")
+	err = os.Mkdir(layersDir, 0755)
+	c.Assert(err, IsNil)
+
+	fpath := filepath.Join(layersDir, "001-kerncraft.yaml")
+	err = ioutil.WriteFile(fpath, []byte("randomkey: Kerncraft Layer"), 0644)
+	c.Assert(err, IsNil)
+
+	_, err = pebble.Parser(pebble.Client()).ParseArgs([]string{"validate"})
+	c.Assert(err, ErrorMatches, "cannot parse layer \"kerncraft\": yaml: unmarshal errors:\n"+
+		"  line 1: field randomkey not found in type plan.Layer")
 }


### PR DESCRIPTION
Kerncraft (and other craft tools) needs to validate supplied or
generated Pebble configuration snippets. Instead of duplicating
schema validation in the craft tool, the safer and more
maintainable approach will be to ask the selected Pebble
version to validate the given set of configuration layers.

Add a configuration validation option to Pebble.

On failure Pebble will output existing configuration schema error
messages and return a non-zero exit code.

For example:

```
0 $ go build ./cmd/pebble
0 $ PEBBLE=~/pebble ./pebble validate
error: cannot parse layer "layer": yaml: unmarshal errors:
  line 1: field servicez not found in type plan.Layer
1 $ PEBBLE=~/pebble ./pebble validate
0 $ 
```