### PR TITLE
Correct services in the YAML schema docs as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ summary: <summary>
 description: |
     <description>
 
-# (Required) A list of services managed by this configuration layer
+# (Optional) A list of services managed by this configuration layer
 services:
 
     <service name>:


### PR DESCRIPTION
The Pebble configuration do not have to define any services. The only side effect
is that no default services will be started when the daemon starts (and a notice
message will be printed out).

```
flotter@flotter-pc:~/pebble$ ./pebble run
2022-06-20T13:25:18.021Z [pebble] Started daemon.
2022-06-20T13:25:18.028Z [pebble] POST /v1/services 3.095222ms 400
2022-06-20T13:25:18.029Z [pebble] Cannot start default services: no default services
```

This PR corrects the wording in the README.md file to reflect services are optional.