### PR TITLE
Explicitly set HOME and USER env vars if service user+group set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,8 @@ jobs:
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^execSuite\.TestUserGroup$
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^execSuite\.TestUserIDGroupID$
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^filesSuite\.TestWriteUserGroupReal$
+        go test -c ./internal/overlord/servstate/
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./servstate.test -check.v -check.f ^S.TestUserGroup$
 
   format:
     runs-on: ubuntu-latest

--- a/internal/overlord/cmdstate/handlers.go
+++ b/internal/overlord/cmdstate/handlers.go
@@ -328,6 +328,11 @@ func (e *execution) do(ctx context.Context, task *state.Task) error {
 
 	cmd := exec.CommandContext(ctx, e.command[0], e.command[1:]...)
 
+	// Ensure cmd.Env is not nil (does not inherit parent env). This is not
+	// strictly necessary as cmdstate.Exec always sets some environment
+	// variables, but code defensively.
+	cmd.Env = make([]string, 0, len(e.environment))
+
 	for k, v := range e.environment {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}


### PR DESCRIPTION
This ensures that Pebble overrides the `HOME` and `USER` environment variables when starting a service if the service config's `user` and `group` are set. It addresses the issue described in #126.

Also add TestUserGroup to test this (must be run as root).

Fixes #126.