### PR TITLE
Make exec checks consistently not inherit parent environment variables

### DIFF
--- a/internal/overlord/checkstate/checkers.go
+++ b/internal/overlord/checkstate/checkers.go
@@ -128,6 +128,7 @@ func (c *execChecker) check(ctx context.Context) error {
 	}
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = make([]string, 0, len(c.environment)) // avoid nil to ensure we don't inherit parent env
 	for k, v := range c.environment {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}


### PR DESCRIPTION
Currently it inherits them if you don't have any environment variables
set in the config, but does not inherit them if you have one or more
set. This is a quirk of the implementation, and how the
exec.Command.Env field works. Make them not inherited in both cases to
be consistent.

Trivial fix, but also add tests for both cases.

Fixes #127