### PR TITLE
Add last failure (error and details) to checks API and CLI command

### DIFF
--- a/client/checks.go
+++ b/client/checks.go
@@ -65,6 +65,16 @@ type CheckInfo struct {
 	// Threshold is this check's failure threshold, from the layer
 	// configuration.
 	Threshold int `json:"threshold"`
+
+	// LastFailure describes the last failure that occurred for this check
+	// (only present if the number of failures is nonzero).
+	LastFailure *CheckFailure `json:"last-failure"`
+}
+
+// CheckFailure holds information about a single check failure.
+type CheckFailure struct {
+	Error   string `json:"error"`
+	Details string `json:"details"`
 }
 
 // Checks fetches information about specific health checks (or all of them),

--- a/internal/daemon/api_checks.go
+++ b/internal/daemon/api_checks.go
@@ -22,11 +22,17 @@ import (
 )
 
 type checkInfo struct {
-	Name      string `json:"name"`
-	Level     string `json:"level,omitempty"`
-	Status    string `json:"status"`
-	Failures  int    `json:"failures,omitempty"`
-	Threshold int    `json:"threshold"`
+	Name        string        `json:"name"`
+	Level       string        `json:"level,omitempty"`
+	Status      string        `json:"status"`
+	Failures    int           `json:"failures,omitempty"`
+	Threshold   int           `json:"threshold"`
+	LastFailure *checkFailure `json:"last-failure,omitempty"`
+}
+
+type checkFailure struct {
+	Error   string `json:"error"`
+	Details string `json:"details,omitempty"`
 }
 
 func v1GetChecks(c *Command, r *http.Request, _ *userState) Response {
@@ -57,6 +63,12 @@ func v1GetChecks(c *Command, r *http.Request, _ *userState) Response {
 				Status:    string(check.Status),
 				Failures:  check.Failures,
 				Threshold: check.Threshold,
+			}
+			if check.LastError != "" {
+				info.LastFailure = &checkFailure{
+					Error:   check.LastError,
+					Details: check.LastDetails,
+				}
 			}
 			infos = append(infos, info)
 		}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -821,7 +821,7 @@ func (s *daemonSuite) TestRestartShutdown(c *check.C) {
 	st.Unlock()
 
 	sigCh := make(chan os.Signal, 2)
-	// stop (this will timeout but thats not relevant for this test)
+	// stop (this will time out, but that's not relevant for this test)
 	d.Stop(sigCh)
 
 	// ensure that the sigCh got closed as part of the stop

--- a/internal/overlord/checkstate/checkers.go
+++ b/internal/overlord/checkstate/checkers.go
@@ -75,7 +75,7 @@ func (c *httpChecker) check(ctx context.Context) error {
 			details = strings.Join(lines, "\n")
 		}
 		return &detailsError{
-			error:   fmt.Errorf("received non-20x status code %d", response.StatusCode),
+			error:   fmt.Errorf("non-20x status code %d", response.StatusCode),
 			details: details,
 		}
 	}

--- a/internal/overlord/checkstate/checkers_test.go
+++ b/internal/overlord/checkstate/checkers_test.go
@@ -73,14 +73,14 @@ func (s *CheckersSuite) TestHTTP(c *C) {
 	// Non-20x status code returns error
 	chk = &httpChecker{url: server.URL + "/404"}
 	err = chk.check(context.Background())
-	c.Assert(err, ErrorMatches, "received non-20x status code 404")
+	c.Assert(err, ErrorMatches, "non-20x status code 404")
 	c.Assert(path, Equals, "/404")
 
 	// In case of non-20x status, short response body is fully included in error details
 	response = "error details"
 	chk = &httpChecker{url: server.URL + "/500"}
 	err = chk.check(context.Background())
-	c.Assert(err, ErrorMatches, "received non-20x status code 500")
+	c.Assert(err, ErrorMatches, "non-20x status code 500")
 	detailsErr, ok := err.(*detailsError)
 	c.Assert(ok, Equals, true)
 	c.Assert(detailsErr.Details(), Equals, "error details")
@@ -93,7 +93,7 @@ func (s *CheckersSuite) TestHTTP(c *C) {
 	response = output.String()
 	chk = &httpChecker{url: server.URL + "/500"}
 	err = chk.check(context.Background())
-	c.Assert(err, ErrorMatches, "received non-20x status code 500")
+	c.Assert(err, ErrorMatches, "non-20x status code 500")
 	detailsErr, ok = err.(*detailsError)
 	c.Assert(ok, Equals, true)
 	c.Assert(detailsErr.Details(), Matches, `(?s)line 1\n.*line 20\n\(\.\.\.\)`)

--- a/internal/overlord/checkstate/manager.go
+++ b/internal/overlord/checkstate/manager.go
@@ -136,13 +136,13 @@ func (m *CheckManager) Checks() ([]*CheckInfo, error) {
 
 // CheckInfo provides status information about a single check.
 type CheckInfo struct {
-	Name         string
-	Level        plan.CheckLevel
-	Status       CheckStatus
-	Failures     int
-	Threshold    int
-	LastError    string
-	ErrorDetails string
+	Name        string
+	Level       plan.CheckLevel
+	Status      CheckStatus
+	Failures    int
+	Threshold   int
+	LastError   string
+	LastDetails string
 }
 
 type CheckStatus string
@@ -247,7 +247,7 @@ func (c *checkData) info() *CheckInfo {
 	if c.lastErr != nil {
 		info.LastError = c.lastErr.Error()
 		if d, ok := c.lastErr.(interface{ Details() string }); ok {
-			info.ErrorDetails = d.Details()
+			info.LastDetails = d.Details()
 		}
 	}
 	return info

--- a/internal/overlord/checkstate/manager_test.go
+++ b/internal/overlord/checkstate/manager_test.go
@@ -137,7 +137,7 @@ func (s *ManagerSuite) TestTimeout(c *C) {
 	c.Assert(check.Failures, Equals, 1)
 	c.Assert(check.Threshold, Equals, 1)
 	c.Assert(check.LastError, Equals, "exec check timed out")
-	c.Assert(check.ErrorDetails, Equals, "FOO")
+	c.Assert(check.LastDetails, Equals, "FOO")
 }
 
 func (s *ManagerSuite) TestCheckCanceled(c *C) {
@@ -202,7 +202,7 @@ func (s *ManagerSuite) TestCheckCanceled(c *C) {
 	c.Check(info.Failures, Equals, 0)
 	c.Check(info.Threshold, Equals, 1)
 	c.Check(info.LastError, Equals, "")
-	c.Check(info.ErrorDetails, Equals, "")
+	c.Check(info.LastDetails, Equals, "")
 }
 
 func (s *ManagerSuite) TestFailures(c *C) {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -321,7 +321,7 @@ func (s *serviceData) startInternal() error {
 	args, err := shlex.Split(s.config.Command)
 	if err != nil {
 		// Shouldn't happen as it should have failed on parsing, but
-		// it does not hurt to double check and report.
+		// it does not hurt to double-check and report.
 		return fmt.Errorf("cannot parse service command: %s", err)
 	}
 	s.cmd = exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
This is a similar but slightly cleaned up version of what we discussed [here](https://github.com/canonical/pebble/pull/86#discussion_r795942968). We decided against it at the time, but now after having considered using changes/tasks and then [events](https://docs.google.com/document/d/16PJ85fefalQd7JbWSxkRWn0Ye-Hs8S1yE99eW7pk8fA/edit#) for check diagnostics, we've decided that it's probably better to separate out the events/hooks use case from the debugging use case, and we're back to having a simple way to view the check errors.

The response from the API now includes a `last-failure` key as follows (it's only present if `failures` is greater than 0):

```
{
  "name": "chk1",
  "status": "down",
  "failures": 1,
  "threshold": 1,
  "last-failure": {
    "error": "an error message",
    "details": "extended details ..."  // this may or may not be present, depending on the failure
  }
}
```

And the `pebble checks` CLI command is extended with a `Last Failure` field and a `--verbose` option as follows:

```
# In non-verbose mode, the "Last Failure" field is truncated to 60 chars max (with "..." suffix if truncated)
$ pebble checks
Check  Level  Status  Failures  Last Failure
chk1   -      down    1/1       an error message: extended details ...

# In --verbose mode, the first line is the error message and subsequent lines show the details, if any
$ pebble checks --verbose
Check  Level  Status  Failures  Last Failure
chk1   -      down    1/1       an error message:
                                extended details ...
                                may be multiple lines ...
```
