### PR TITLE
Bump test coverage for some commands

### DIFF
--- a/cmd/pebble/cmd_add_test.go
+++ b/cmd/pebble/cmd_add_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/check.v1"
@@ -27,16 +28,21 @@ import (
 	pebble "github.com/canonical/pebble/cmd/pebble"
 )
 
-func assertBodyEquals(c *check.C, body io.ReadCloser, expected map[string]interface{}) {
+func decodeBody(c *check.C, body io.ReadCloser) map[string]interface{} {
 	defer body.Close()
 	var actual map[string]interface{}
 	err := json.NewDecoder(body).Decode(&actual)
 	c.Assert(err, check.IsNil)
-	c.Assert(actual, check.DeepEquals, expected)
+	return actual
+}
+
+func assertBodyEquals(c *check.C, body io.ReadCloser, expected map[string]interface{}) {
+	c.Assert(decodeBody(c, body), check.DeepEquals, expected)
 }
 
 func (s *PebbleSuite) TestAdd(c *check.C) {
 	for _, combine := range []bool{false, true} {
+		triggerLayerContent := "trigger layer"
 		layerYAML := `
 services:
    foo:
@@ -47,18 +53,34 @@ services:
 		s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v1/layers")
-			assertBodyEquals(c, r.Body, map[string]interface{}{
-				"action":  "add",
-				"combine": combine,
-				"label":   "foo",
-				"format":  "yaml",
-				"layer":   layerYAML,
-			})
-			fmt.Fprint(w, `{
+
+			body := decodeBody(c, r.Body)
+
+			layerContent, ok := body["layer"]
+			c.Assert(ok, check.Equals, true)
+
+			if layerContent == triggerLayerContent {
+				fmt.Fprint(w, `{
+    "type": "error",
+    "result": {
+		"message": "triggered"
+	}
+}`)
+			} else {
+				c.Check(body, check.DeepEquals, map[string]interface{}{
+					"action":  "add",
+					"combine": combine,
+					"label":   "foo",
+					"format":  "yaml",
+					"layer":   layerYAML,
+				})
+				fmt.Fprint(w, `{
     "type": "sync",
     "status-code": 200,
     "result": true
 }`)
+			}
+
 		})
 
 		tempDir := c.MkDir()
@@ -66,16 +88,39 @@ services:
 		err := ioutil.WriteFile(layerPath, []byte(layerYAML), 0755)
 		c.Assert(err, check.IsNil)
 
-		args := []string{"add"}
-		if combine {
-			args = append(args, "--combine")
-		}
-		args = append(args, "foo", layerPath)
-		rest, err := pebble.Parser(pebble.Client()).ParseArgs(args)
+		unreadableLayerPath := filepath.Join(tempDir, "unreadable-layer.yaml")
+		err = ioutil.WriteFile(unreadableLayerPath, []byte(layerYAML), 0055)
 		c.Assert(err, check.IsNil)
-		c.Assert(rest, check.HasLen, 0)
-		c.Check(s.Stdout(), check.Matches, `Layer "foo" added successfully.*\n`)
-		c.Check(s.Stderr(), check.Equals, "")
-		s.ResetStdStreams()
+
+		// The trigger layer will trigger an error in the mocked API response
+		triggerLayerPath := filepath.Join(tempDir, "trigger-layer.yaml")
+		err = ioutil.WriteFile(triggerLayerPath, []byte(triggerLayerContent), 0755)
+		c.Assert(err, check.IsNil)
+
+		var args []string
+		for _, path := range []string{layerPath, unreadableLayerPath, triggerLayerPath} {
+			args = []string{"add"}
+			if combine {
+				args = append(args, "--combine")
+			}
+			args = append(args, "foo", path)
+			rest, err := pebble.Parser(pebble.Client()).ParseArgs(args)
+
+			if path == layerPath {
+				c.Assert(err, check.IsNil)
+				c.Assert(rest, check.HasLen, 0)
+				c.Check(s.Stdout(), check.Matches, `Layer "foo" added successfully.*\n`)
+				c.Check(s.Stderr(), check.Equals, "")
+				s.ResetStdStreams()
+			} else if path == triggerLayerPath {
+				c.Assert(err, check.ErrorMatches, "triggered")
+			} else if path == unreadableLayerPath {
+				c.Assert(os.IsPermission(err), check.Equals, true)
+			}
+		}
+
+		args = append(args, "extra", "arguments", "invalid")
+		_, err = pebble.Parser(pebble.Client()).ParseArgs(args)
+		c.Assert(err, check.Equals, pebble.ErrExtraArgs)
 	}
 }

--- a/cmd/pebble/cmd_add_test.go
+++ b/cmd/pebble/cmd_add_test.go
@@ -15,9 +15,7 @@
 package main_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -27,18 +25,6 @@ import (
 
 	pebble "github.com/canonical/pebble/cmd/pebble"
 )
-
-func decodeBody(c *check.C, body io.ReadCloser) map[string]interface{} {
-	defer body.Close()
-	var actual map[string]interface{}
-	err := json.NewDecoder(body).Decode(&actual)
-	c.Assert(err, check.IsNil)
-	return actual
-}
-
-func assertBodyEquals(c *check.C, body io.ReadCloser, expected map[string]interface{}) {
-	c.Assert(decodeBody(c, body), check.DeepEquals, expected)
-}
 
 func (s *PebbleSuite) TestAdd(c *check.C) {
 	for _, combine := range []bool{false, true} {
@@ -54,7 +40,7 @@ services:
 			c.Check(r.Method, check.Equals, "POST")
 			c.Check(r.URL.Path, check.Equals, "/v1/layers")
 
-			body := decodeBody(c, r.Body)
+			body := DecodedRequestBody(c, r)
 
 			layerContent, ok := body["layer"]
 			c.Assert(ok, check.Equals, true)

--- a/cmd/pebble/cmd_logs_test.go
+++ b/cmd/pebble/cmd_logs_test.go
@@ -72,6 +72,12 @@ func (s *PebbleSuite) TestLogsJSON(c *C) {
 	c.Check(s.Stderr(), Equals, "")
 }
 
+func (s *PebbleSuite) TestLogsInvalidFormat(c *C) {
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"logs", "--format", "invalid"})
+	c.Assert(err.Error(), Equals, `invalid output format (expected "json" or "text", not "invalid")`)
+	c.Assert(rest, HasLen, 1)
+}
+
 func (s *PebbleSuite) TestLogsN(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")
@@ -114,6 +120,12 @@ func (s *PebbleSuite) TestLogsAll(c *C) {
 2021-05-03T03:55:49.654Z [snappass] log two
 `[1:])
 	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestLogsInvalidNumber(c *C) {
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"logs", "-ninvalid"})
+	c.Assert(err.Error(), Equals, `expected n to be a non-negative integer or "all", not "invalid"`)
+	c.Assert(rest, HasLen, 1)
 }
 
 func (s *PebbleSuite) TestLogsFollow(c *C) {

--- a/cmd/pebble/cmd_plan_test.go
+++ b/cmd/pebble/cmd_plan_test.go
@@ -25,48 +25,48 @@ import (
 )
 
 func (s *PebbleSuite) TestGetPlan(c *check.C) {
-	fail := false
-
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, check.Equals, "GET")
 		c.Check(r.URL.Path, check.Equals, "/v1/plan")
 		c.Check(r.URL.Query(), check.DeepEquals, url.Values{"format": []string{"yaml"}})
-
-		if fail {
-			fmt.Fprint(w, `{
-    "type": "error",
-    "result": {"message": "could not do the thing"}
-}`)
-		} else {
-			fmt.Fprint(w, `{
+		fmt.Fprint(w, `{
     "type": "sync",
     "status-code": 200,
     "result": "services:\n    foo:\n        override: replace\n        command: cmd\n"
 }`)
-		}
 	})
 
 	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"plan"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, `
+	c.Assert(s.Stdout(), check.Equals, `
 services:
     foo:
         override: replace
         command: cmd
 `[1:])
-	c.Check(s.Stderr(), check.Equals, "")
-	s.ResetStdStreams()
-
-	fail = true
-	rest, err = pebble.Parser(pebble.Client()).ParseArgs([]string{"plan"})
-	c.Assert(err.Error(), check.Equals, "could not do the thing")
-	c.Assert(rest, check.HasLen, 1)
-	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "")
+	c.Assert(s.Stderr(), check.Equals, ``)
 }
 
-func (s *PebbleSuite) TestExtraArguments(c *check.C) {
+func (s *PebbleSuite) TestGetPlanFails(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/plan")
+		c.Check(r.URL.Query(), check.DeepEquals, url.Values{"format": []string{"yaml"}})
+		fmt.Fprint(w, `{
+    "type": "error",
+    "result": {"message": "could not do the thing"}
+}`)
+	})
+
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"plan"})
+	c.Assert(err.Error(), check.Equals, "could not do the thing")
+	c.Assert(rest, check.HasLen, 1)
+	c.Assert(s.Stdout(), check.Equals, ``)
+	c.Assert(s.Stderr(), check.Equals, ``)
+}
+
+func (s *PebbleSuite) TestPlanExtraArgs(c *check.C) {
 	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"plan", "extra", "args"})
 	c.Assert(err, check.Equals, pebble.ErrExtraArgs)
 	c.Check(rest, check.HasLen, 1)

--- a/cmd/pebble/cmd_signal_test.go
+++ b/cmd/pebble/cmd_signal_test.go
@@ -25,9 +25,10 @@ import (
 
 func (s *PebbleSuite) TestSignalShortName(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		assertBodyEquals(c, r.Body, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"signal":   "SIGHUP",
 			"services": []interface{}{"s1"},
 		})
@@ -45,9 +46,10 @@ func (s *PebbleSuite) TestSignalShortName(c *check.C) {
 
 func (s *PebbleSuite) TestSignalFullName(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		assertBodyEquals(c, r.Body, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"signal":   "SIGHUP",
 			"services": []interface{}{"s2"},
 		})
@@ -65,9 +67,10 @@ func (s *PebbleSuite) TestSignalFullName(c *check.C) {
 
 func (s *PebbleSuite) TestSignalMultipleServices(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		assertBodyEquals(c, r.Body, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"signal":   "SIGHUP",
 			"services": []interface{}{"s1", "s2"},
 		})
@@ -90,9 +93,10 @@ func (s *PebbleSuite) TestSignalErrorLowercase(c *check.C) {
 
 func (s *PebbleSuite) TestSignalServerError(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		assertBodyEquals(c, r.Body, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]interface{}{
 			"signal":   "SIGHUP",
 			"services": []interface{}{"s1"},
 		})

--- a/cmd/pebble/cmd_version_test.go
+++ b/cmd/pebble/cmd_version_test.go
@@ -23,7 +23,7 @@ import (
 	pebble "github.com/canonical/pebble/cmd/pebble"
 )
 
-func (s *PebbleSuite) TestVersionCommand(c *C) {
+func (s *PebbleSuite) TestVersion(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"version":"7.89"}}`)
 	})
@@ -33,9 +33,11 @@ func (s *PebbleSuite) TestVersionCommand(c *C) {
 
 	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "client  4.56\nserver  7.89\n")
-	c.Assert(s.Stderr(), Equals, "")
+	c.Check(s.Stdout(), Equals, "client  4.56\nserver  7.89\n")
+	c.Check(s.Stderr(), Equals, "")
+}
 
+func (s *PebbleSuite) TestVersionExtraArgs(c *C) {
 	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"version", "extra", "args"})
 	c.Assert(err, Equals, pebble.ErrExtraArgs)
 	c.Assert(rest, HasLen, 1)

--- a/cmd/pebble/cmd_version_test.go
+++ b/cmd/pebble/cmd_version_test.go
@@ -35,4 +35,8 @@ func (s *PebbleSuite) TestVersionCommand(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.Stdout(), Equals, "client  4.56\nserver  7.89\n")
 	c.Assert(s.Stderr(), Equals, "")
+
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"version", "extra", "args"})
+	c.Assert(err, Equals, pebble.ErrExtraArgs)
+	c.Assert(rest, HasLen, 1)
 }


### PR DESCRIPTION
This is a relatively small patch that improves upon the existing test suites for well-tested Pebble commands to achieve near-complete code coverage. I'm working on adding tests for the rest of commands but as these will be slightly larger patches I will do separate PRs for each of them.