### PR TITLE
Update to Go 1.19 "go fmt" comment formatting

### DIFF
--- a/cmd/pebble/cmd_warnings.go
+++ b/cmd/pebble/cmd_warnings.go
@@ -131,7 +131,6 @@ func (cmd *cmdWarnings) Execute(args []string) error {
 // - trim trailing whitespace
 // - word wrap at "max" chars preserving line indent
 // - keep \n intact and break there
-//
 func writeWarning(w io.Writer, descr string, termWidth int) error {
 	var err error
 	descr = strings.TrimRightFunc(descr, unicode.IsSpace)

--- a/internal/osutil/io.go
+++ b/internal/osutil/io.go
@@ -61,7 +61,7 @@ type AtomicFile struct {
 // NewAtomicFile builds an AtomicFile backed by an *os.File that will have
 // the given filename, permissions and uid/gid when Committed.
 //
-//   It _might_ be implemented using O_TMPFILE (see open(2)).
+// It _might_ be implemented using O_TMPFILE (see open(2)).
 //
 // Note that it won't follow symlinks and will replace existing symlinks with
 // the real file, unless the AtomicWriteFollow flag is specified.

--- a/internal/osutil/mountentry_linux.go
+++ b/internal/osutil/mountentry_linux.go
@@ -30,14 +30,14 @@ import (
 //
 // Fields are named after names in struct returned by getmntent(3).
 //
-// struct mntent {
-//     char *mnt_fsname;   /* name of mounted filesystem */
-//     char *mnt_dir;      /* filesystem path prefix */
-//     char *mnt_type;     /* mount type (see Mntent.h) */
-//     char *mnt_opts;     /* mount options (see Mntent.h) */
-//     int   mnt_freq;     /* dump frequency in days */
-//     int   mnt_passno;   /* pass number on parallel fsck */
-// };
+//	struct mntent {
+//	    char *mnt_fsname;   /* name of mounted filesystem */
+//	    char *mnt_dir;      /* filesystem path prefix */
+//	    char *mnt_type;     /* mount type (see Mntent.h) */
+//	    char *mnt_opts;     /* mount options (see Mntent.h) */
+//	    int   mnt_freq;     /* dump frequency in days */
+//	    int   mnt_passno;   /* pass number on parallel fsck */
+//	};
 type MountEntry struct {
 	Name    string
 	Dir     string

--- a/internal/overlord/state/change.go
+++ b/internal/overlord/state/change.go
@@ -274,10 +274,9 @@ func init() {
 // of the individual tasks related to the change, according to the following
 // decision sequence:
 //
-//     - With at least one task in DoStatus, return DoStatus
-//     - With at least one task in ErrorStatus, return ErrorStatus
-//     - Otherwise, return DoneStatus
-//
+//   - With at least one task in DoStatus, return DoStatus
+//   - With at least one task in ErrorStatus, return ErrorStatus
+//   - Otherwise, return DoneStatus
 func (c *Change) Status() Status {
 	c.state.reading()
 	if c.status == DefaultStatus {

--- a/internal/overlord/state/change_test.go
+++ b/internal/overlord/state/change_test.go
@@ -526,16 +526,15 @@ func (cs *changeSuite) TestAbortKⁿ(c *C) {
 
 // Task wait order:
 //
-//             => t21 => t22
-//           /               \
-// t11 => t12                 => t41 => t42
-//           \               /
-//             => t31 => t32
+//	            => t21 => t22
+//	          /               \
+//	t11 => t12                 => t41 => t42
+//	          \               /
+//	            => t31 => t32
 //
 // setup and result lines are <task>:<status>[:<lane>,...]
 //
 // "*" as task name means "all remaining".
-//
 var abortLanesTests = []struct {
 	setup  string
 	abort  []int

--- a/internal/overlord/state/state.go
+++ b/internal/overlord/state/state.go
@@ -359,14 +359,12 @@ func (s *State) tasksIn(tids []string) []*Task {
 
 // Prune does several cleanup tasks to the in-memory state:
 //
-//  * it removes changes that became ready for more than pruneWait and aborts
-//    tasks spawned for more than abortWait.
-//
-//  * it removes tasks unlinked to changes after pruneWait. When there are more
-//    changes than the limit set via "maxReadyChanges" those changes in ready
-//    state will also removed even if they are below the pruneWait duration.
-//
-//  * it removes expired warnings.
+//   - it removes changes that became ready for more than pruneWait and aborts
+//     tasks spawned for more than abortWait.
+//   - it removes tasks unlinked to changes after pruneWait. When there are more
+//     changes than the limit set via "maxReadyChanges" those changes in ready
+//     state will also removed even if they are below the pruneWait duration.
+//   - it removes expired warnings.
 func (s *State) Prune(pruneWait, abortWait time.Duration, maxReadyChanges int) {
 	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)

--- a/internal/overlord/state/taskrunner_test.go
+++ b/internal/overlord/state/taskrunner_test.go
@@ -88,19 +88,19 @@ func ensureChange(c *C, r *state.TaskRunner, sb *stateBackend, chg *state.Change
 // handlers will be called, assuming the provided setup is in place.
 //
 // Setup options:
-//     <task>:was-<status>    - set task status before calling ensure (must be sensible)
-//     <task>:(do|undo)-block - block handler until task tomb dies
-//     <task>:(do|undo)-retry - return from handler with with state.Retry
-//     <task>:(do|undo)-error - return from handler with an error
-//     <task>:...:1,2         - one of the above, and add task to lanes 1 and 2
-//     chg:abort              - call abort on the change
+//
+//	<task>:was-<status>    - set task status before calling ensure (must be sensible)
+//	<task>:(do|undo)-block - block handler until task tomb dies
+//	<task>:(do|undo)-retry - return from handler with with state.Retry
+//	<task>:(do|undo)-error - return from handler with an error
+//	<task>:...:1,2         - one of the above, and add task to lanes 1 and 2
+//	chg:abort              - call abort on the change
 //
 // Task wait order: ( t11 | t12 ) => ( t21 ) => ( t31 | t32 )
 //
 // Task t12 has no undo.
 //
 // Final task statuses are tested based on the resulting events list.
-//
 var sequenceTests = []struct{ setup, result string }{{
 	setup:  "",
 	result: "t11:do t12:do t21:do t31:do t32:do",

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -82,10 +82,10 @@ var inTesting bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") 
 // MakeProgressBar creates an appropriate progress.Meter for the environ in
 // which it is called:
 //
-// * if MockMeter has been called, return that.
-// * if no terminal is attached, or we think we're running a test, a
-//   minimalistic QuietMeter is returned.
-// * otherwise, an ANSIMeter is returned.
+//   - if MockMeter has been called, return that.
+//   - if no terminal is attached, or we think we're running a test, a
+//     minimalistic QuietMeter is returned.
+//   - otherwise, an ANSIMeter is returned.
 //
 // TODO: instead of making the pivot at creation time, do it at every call.
 func MakeProgressBar() Meter {

--- a/internal/servicelog/formatter.go
+++ b/internal/servicelog/formatter.go
@@ -37,13 +37,16 @@ const (
 // NewFormatWriter returns a io.Writer that inserts timestamp and service name for every
 // line in the stream.
 // For the input:
-//   first\n
-//   second\n
-//   third\n
+//
+//	first\n
+//	second\n
+//	third\n
+//
 // The expected output is:
-//   2021-05-13T03:16:51.001Z [test] first\n
-//   2021-05-13T03:16:52.002Z [test] second\n
-//   2021-05-13T03:16:53.003Z [test] third\n
+//
+//	2021-05-13T03:16:51.001Z [test] first\n
+//	2021-05-13T03:16:52.002Z [test] second\n
+//	2021-05-13T03:16:53.003Z [test] third\n
 func NewFormatWriter(dest io.Writer, serviceName string) io.Writer {
 	return &formatter{
 		serviceName:    serviceName,

--- a/internal/strutil/pathiter.go
+++ b/internal/strutil/pathiter.go
@@ -28,13 +28,12 @@ import (
 // openat calls.
 //
 // A simple example on how to use the iterator:
-// ```
-// iter:= NewPathIterator(path)
-// for iter.Next() {
-//    // Use iter.CurrentName() with openat(2) family of functions.
-//    // Use iter.CurrentPath() or iter.CurrentBase() for context.
-// }
-// ```
+//
+//	iter:= NewPathIterator(path)
+//	for iter.Next() {
+//	    // Use iter.CurrentName() with openat(2) family of functions.
+//	    // Use iter.CurrentPath() or iter.CurrentBase() for context.
+//	}
 type PathIterator struct {
 	path        string
 	left, right int

--- a/internal/strutil/shlex/shlex.go
+++ b/internal/strutil/shlex/shlex.go
@@ -20,22 +20,21 @@ shell-style rules for quoting and commenting.
 
 The basic use case uses the default ASCII lexer to split a string into sub-strings:
 
-  shlex.Split("one \"two three\" four") -> []string{"one", "two three", "four"}
+	shlex.Split("one \"two three\" four") -> []string{"one", "two three", "four"}
 
 To process a stream of strings:
 
-  l := NewLexer(os.Stdin)
-  for ; token, err := l.Next(); err != nil {
-  	// process token
-  }
+	l := NewLexer(os.Stdin)
+	for ; token, err := l.Next(); err != nil {
+		// process token
+	}
 
 To access the raw token stream (which includes tokens for comments):
 
-  t := NewTokenizer(os.Stdin)
-  for ; token, err := t.Next(); err != nil {
-	// process token
-  }
-
+	  t := NewTokenizer(os.Stdin)
+	  for ; token, err := t.Next(); err != nil {
+		// process token
+	  }
 */
 package shlex
 

--- a/internal/strutil/version.go
+++ b/internal/strutil/version.go
@@ -155,9 +155,10 @@ func compareSubversion(va, vb string) int {
 // VersionCompare compare two version strings that follow the debian
 // version policy and
 // Returns:
-//   -1 if a is smaller than b
-//    0 if a equals b
-//   +1 if a is bigger than b
+//
+//	-1 if a is smaller than b
+//	 0 if a equals b
+//	+1 if a is bigger than b
 func VersionCompare(va, vb string) (res int, err error) {
 	// FIXME: return err here instead
 	if !VersionIsValid(va) {

--- a/internal/testutil/exec.go
+++ b/internal/testutil/exec.go
@@ -163,10 +163,11 @@ func (cmd *FakeCmd) Restore() {
 
 // Calls returns a list of calls that were made to the fake command.
 // of the form:
-// [][]string{
-//     {"cmd", "arg1", "arg2"}, // first invocation of "cmd"
-//     {"cmd", "arg1", "arg2"}, // second invocation of "cmd"
-// }
+//
+//	[][]string{
+//	    {"cmd", "arg1", "arg2"}, // first invocation of "cmd"
+//	    {"cmd", "arg1", "arg2"}, // second invocation of "cmd"
+//	}
 func (cmd *FakeCmd) Calls() [][]string {
 	raw, err := ioutil.ReadFile(cmd.logFile)
 	if os.IsNotExist(err) {

--- a/internal/testutil/intcheckers.go
+++ b/internal/testutil/intcheckers.go
@@ -59,35 +59,41 @@ func (checker *intChecker) Check(params []interface{}, names []string) (result b
 // IntLessThan checker verifies that one integer is less than other integer.
 //
 // For example:
-//     c.Assert(1, IntLessThan, 2)
+//
+//	c.Assert(1, IntLessThan, 2)
 var IntLessThan = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntLessThan", Params: []string{"a", "b"}}, rel: "<"}
 
 // IntLessEqual checker verifies that one integer is less than or equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntLessEqual, 1)
+//
+//	c.Assert(1, IntLessEqual, 1)
 var IntLessEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntLessEqual", Params: []string{"a", "b"}}, rel: "<="}
 
 // IntEqual checker verifies that one integer is equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntEqual, 1)
+//
+//	c.Assert(1, IntEqual, 1)
 var IntEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntEqual", Params: []string{"a", "b"}}, rel: "=="}
 
 // IntNotEqual checker verifies that one integer is not equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntNotEqual, 2)
+//
+//	c.Assert(1, IntNotEqual, 2)
 var IntNotEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntNotEqual", Params: []string{"a", "b"}}, rel: "!="}
 
 // IntGreaterThan checker verifies that one integer is greater than other integer.
 //
 // For example:
-//     c.Assert(2, IntGreaterThan, 1)
+//
+//	c.Assert(2, IntGreaterThan, 1)
 var IntGreaterThan = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntGreaterThan", Params: []string{"a", "b"}}, rel: ">"}
 
 // IntGreaterEqual checker verifies that one integer is greater than or equal to other integer.
 //
 // For example:
-//     c.Assert(1, IntGreaterEqual, 2)
+//
+//	c.Assert(1, IntGreaterEqual, 2)
 var IntGreaterEqual = &intChecker{CheckerInfo: &check.CheckerInfo{Name: "IntGreaterEqual", Params: []string{"a", "b"}}, rel: ">="}

--- a/internal/timeutil/schedule.go
+++ b/internal/timeutil/schedule.go
@@ -463,8 +463,8 @@ func parseClockRange(s string) (start, end Clock, err error) {
 
 // ParseLegacySchedule takes an obsolete schedule string in the form of:
 //
-// 9:00-15:00 (every day between 9am and 3pm)
-// 9:00-15:00/21:00-22:00 (every day between 9am,5pm and 9pm,10pm)
+//	9:00-15:00 (every day between 9am and 3pm)
+//	9:00-15:00/21:00-22:00 (every day between 9am,5pm and 9pm,10pm)
 //
 // and returns a list of Schedule types or an error
 func ParseLegacySchedule(scheduleSpec string) ([]*Schedule, error) {
@@ -489,29 +489,30 @@ func ParseLegacySchedule(scheduleSpec string) ([]*Schedule, error) {
 
 // ParseSchedule parses a schedule in V2 format. The format is described as:
 //
-//     eventlist = eventset *( ",," eventset )
-//     eventset = wdaylist / timelist / wdaylist "," timelist
+//	eventlist = eventset *( ",," eventset )
+//	eventset = wdaylist / timelist / wdaylist "," timelist
 //
-//     wdaylist = wdayset *( "," wdayset )
-//     wdayset = wday / wdayspan
-//     wday =  ( "sun" / "mon" / "tue" / "wed" / "thu" / "fri" / "sat" ) [ DIGIT ]
-//     wdayspan = wday "-" wday
+//	wdaylist = wdayset *( "," wdayset )
+//	wdayset = wday / wdayspan
+//	wday =  ( "sun" / "mon" / "tue" / "wed" / "thu" / "fri" / "sat" ) [ DIGIT ]
+//	wdayspan = wday "-" wday
 //
-//     timelist = timeset *( "," timeset )
-//     timeset = time / timespan
-//     time = 2DIGIT ":" 2DIGIT
-//     timespan = time ( "-" / "~" ) time [ "/" ( time / count ) ]
-//     count = 1*DIGIT
+//	timelist = timeset *( "," timeset )
+//	timeset = time / timespan
+//	time = 2DIGIT ":" 2DIGIT
+//	timespan = time ( "-" / "~" ) time [ "/" ( time / count ) ]
+//	count = 1*DIGIT
 //
 // Examples:
-// mon,10:00,,fri,15:00 (Monday at 10:00, Friday at 15:00)
-// mon,fri,10:00,15:00 (Monday at 10:00 and 15:00, Friday at 10:00 and 15:00)
-// mon-wed,fri,9:00-11:00/2 (Monday to Wednesday and on Friday, twice between
-//                           9:00 and 11:00)
-// mon,9:00~11:00,,wed,22:00~23:00 (Monday, sometime between 9:00 and 11:00, and
-//                                  on Wednesday, sometime between 22:00 and 23:00)
-// mon,wed  (Monday and on Wednesday)
-// mon,,wed (same as above)
+//
+//	mon,10:00,,fri,15:00 (Monday at 10:00, Friday at 15:00)
+//	mon,fri,10:00,15:00 (Monday at 10:00 and 15:00, Friday at 10:00 and 15:00)
+//	mon-wed,fri,9:00-11:00/2 (Monday to Wednesday and on Friday, twice between
+//	                          9:00 and 11:00)
+//	mon,9:00~11:00,,wed,22:00~23:00 (Monday, sometime between 9:00 and 11:00, and
+//	                                 on Wednesday, sometime between 22:00 and 23:00)
+//	mon,wed  (Monday and on Wednesday)
+//	mon,,wed (same as above)
 //
 // Returns a slice of schedules or an error if parsing failed
 func ParseSchedule(scheduleSpec string) ([]*Schedule, error) {


### PR DESCRIPTION
Run `go fmt ./...` with Go 1.19 (and fix up a couple of places manually).