### PR TITLE
Adds missing ErrDarwin error.

### DIFF
--- a/internal/osutil/osutil_darwin.go
+++ b/internal/osutil/osutil_darwin.go
@@ -1,0 +1,27 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"errors"
+)
+
+// Some things are not implemented on darwin
+var ErrDarwin = errors.New("not implemented on darwin")


### PR DESCRIPTION
When copying code from snapd to pebble we missed ErrDarwin so that pebble can be compiled on Darwin.

See https://github.com/snapcore/snapd/blob/61b66aaa1beb861f308ea7dd75c2f0c042bf29a3/osutil/osutil_darwin.go for reference.