### PR TITLE
Flesh out client package docs; small README improvements

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -55,7 +55,7 @@ snappass  disabled  inactive
 
 ## Using Curl to hit the API
 
-For debugging, you can also use [curl](https://curl.se/) in Unix socket mode to hit the Pebble API:
+For debugging, you can also use [curl](https://curl.se/) in unix socket mode to hit the Pebble API:
 
 ```
 $ curl --unix-socket ~/pebble/.pebble.socket 'http://localhost/v1/services?names=snappass' | jq

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ designed with unique features that help with more specific use cases.
 Pebble is organized as a single binary that works as a daemon and also as a
 client to itself. When the daemon runs it loads its own configuration from the
 `$PEBBLE` directory, as defined in the environment, and also records in
-that same directory its state and Unix sockets for communication. If that variable
+that same directory its state and unix sockets for communication. If that variable
 is not defined, Pebble will attempt to look for its configuration from a default
 system-level setup at `/var/lib/pebble/default`. Using that directory is encouraged
 for whole-system setup such as when using Pebble to control services in a container.
@@ -340,7 +340,7 @@ checks:
 
 ## API and clients
 
-The Pebble daemon exposes an API (HTTP over a Unix socket) to allow remote clients to interact with the daemon. It can start and stop services, add configuration layers the plan, and so on.
+The Pebble daemon exposes an API (HTTP over a unix socket) to allow remote clients to interact with the daemon. It can start and stop services, add configuration layers the plan, and so on.
 
 There is currently no official documentation for the API at the HTTP level (apart from the [code itself](https://github.com/canonical/pebble/blob/master/internal/daemon/api.go)!); most users will interact with it via the Pebble command line interface or by using the Go or Python clients.
 

--- a/client/changes.go
+++ b/client/changes.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-// A Change is a modification to the system state.
+// Change is a modification to the system state.
 type Change struct {
 	ID      string  `json:"id"`
 	Kind    string  `json:"kind"`
@@ -38,6 +38,7 @@ type Change struct {
 	data map[string]*json.RawMessage
 }
 
+// ErrNoData is returned when there is no data associated with a given key.
 var ErrNoData = fmt.Errorf("data entry not found")
 
 // Get unmarshals into value the kind-specific data with the provided key.
@@ -49,7 +50,7 @@ func (c *Change) Get(key string, value interface{}) error {
 	return json.Unmarshal(*raw, value)
 }
 
-// A Task is an operation done to change the system's state.
+// Task represents a single operation done to change the system's state.
 type Task struct {
 	ID       string       `json:"id"`
 	Kind     string       `json:"kind"`
@@ -73,6 +74,7 @@ func (t *Task) Get(key string, value interface{}) error {
 	return json.Unmarshal(*raw, value)
 }
 
+// TaskProgress represents the completion progress of a task.
 type TaskProgress struct {
 	Label string `json:"label"`
 	Done  int    `json:"done"`
@@ -96,7 +98,7 @@ func (client *Client) Change(id string) (*Change, error) {
 	return &chgd.Change, nil
 }
 
-// Abort attempts to abort a change that is in not yet ready.
+// Abort attempts to abort a change that is not yet ready.
 func (client *Client) Abort(id string) (*Change, error) {
 	var postData struct {
 		Action string `json:"action"`
@@ -116,8 +118,10 @@ func (client *Client) Abort(id string) (*Change, error) {
 	return &chg, nil
 }
 
+// ChangeSelector represents a selection of changes to query for.
 type ChangeSelector uint8
 
+// String returns a human-readable representation of c.
 func (c ChangeSelector) String() string {
 	switch c {
 	case ChangesInProgress:
@@ -137,11 +141,13 @@ const (
 	ChangesAll = ChangesReady | ChangesInProgress
 )
 
+// ChangesOptions holds the options for a call to Changes.
 type ChangesOptions struct {
 	ServiceName string // if empty, no filtering by service is done
 	Selector    ChangeSelector
 }
 
+// Changes fetches information for the changes specified.
 func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	query := url.Values{}
 	if opts != nil {

--- a/client/changes.go
+++ b/client/changes.go
@@ -121,7 +121,6 @@ func (client *Client) Abort(id string) (*Change, error) {
 // ChangeSelector represents a selection of changes to query for.
 type ChangeSelector uint8
 
-// String returns a human-readable representation of c.
 func (c ChangeSelector) String() string {
 	switch c {
 	case ChangesInProgress:
@@ -141,7 +140,6 @@ const (
 	ChangesAll = ChangesReady | ChangesInProgress
 )
 
-// ChangesOptions holds the options for a call to Changes.
 type ChangesOptions struct {
 	ServiceName string // if empty, no filtering by service is done
 	Selector    ChangeSelector
@@ -175,7 +173,6 @@ func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	return chgs, err
 }
 
-// WaitChangeOptions holds the options for the WaitChange call.
 type WaitChangeOptions struct {
 	// If nonzero, wait at most this long before returning. If a timeout
 	// occurs, WaitChange will return an error.

--- a/client/checks.go
+++ b/client/checks.go
@@ -18,7 +18,6 @@ import (
 	"net/url"
 )
 
-// ChecksOptions are the filtering options for querying health checks.
 type ChecksOptions struct {
 	// Level is the check level to query for. A check is included in the
 	// results if this field is not set, or if it is equal to the check's

--- a/client/checks.go
+++ b/client/checks.go
@@ -31,6 +31,7 @@ type ChecksOptions struct {
 	Names []string
 }
 
+// CheckLevel represents the level of a health check.
 type CheckLevel string
 
 const (
@@ -39,6 +40,7 @@ const (
 	ReadyLevel CheckLevel = "ready"
 )
 
+// CheckStatus represents the status of a health check.
 type CheckStatus string
 
 const (

--- a/client/client.go
+++ b/client/client.go
@@ -35,7 +35,7 @@ import (
 )
 
 // SocketNotFoundError is the error type returned when the client fails
-// to find a Unix socket at the specified path.
+// to find a unix socket at the specified path.
 type SocketNotFoundError struct {
 	// Err is the wrapped error.
 	Err error
@@ -44,7 +44,6 @@ type SocketNotFoundError struct {
 	Path string
 }
 
-// Error implements the error interface.
 func (s SocketNotFoundError) Error() string {
 	if s.Path == "" && s.Err != nil {
 		return s.Err.Error()
@@ -52,7 +51,6 @@ func (s SocketNotFoundError) Error() string {
 	return fmt.Sprintf("socket %q not found", s.Path)
 }
 
-// Unwrap implements errors.Unwrap interface.
 func (s SocketNotFoundError) Unwrap() error {
 	return s.Err
 }
@@ -92,10 +90,10 @@ type doer interface {
 // Config allows the user to customize client behavior.
 type Config struct {
 	// BaseURL contains the base URL where the Pebble daemon is expected to be.
-	// It can be empty for a default behavior of talking over a Unix socket.
+	// It can be empty for a default behavior of talking over a unix socket.
 	BaseURL string
 
-	// Socket is the path to the Unix socket to use.
+	// Socket is the path to the unix socket to use.
 	Socket string
 
 	// DisableKeepAlive indicates that the connections should not be kept
@@ -133,7 +131,6 @@ type jsonWriter interface {
 	WriteJSON(v interface{}) error
 }
 
-// New returns a new Client with the given configuration.
 func New(config *Config) (*Client, error) {
 	if config == nil {
 		config = &Config{}
@@ -143,7 +140,7 @@ func New(config *Config) (*Client, error) {
 	var transport *http.Transport
 
 	if config.BaseURL == "" {
-		// By default talk over a UNIX socket.
+		// By default talk over a unix socket.
 		transport = &http.Transport{Dial: unixDialer(config.Socket), DisableKeepAlives: config.DisableKeepAlive}
 		baseURL := url.URL{Scheme: "http", Host: "localhost"}
 		client = &Client{baseURL: baseURL}
@@ -182,7 +179,7 @@ func getWebsocket(transport *http.Transport, url string) (clientWebsocket, error
 	return conn, err
 }
 
-// CloseIdleConnections closes any idle API connections.
+// CloseIdleConnections closes any API connections that are currently unused.
 func (client *Client) CloseIdleConnections() {
 	c, ok := client.doer.(*http.Client)
 	if ok {
@@ -202,10 +199,9 @@ func (client *Client) WarningsSummary() (count int, timestamp time.Time) {
 	return client.warningCount, client.warningTimestamp
 }
 
-// RequestError is returned when there's an error creating an http.Request.
+// RequestError is returned when there's an error processing the request.
 type RequestError struct{ error }
 
-// Error implements the error interface.
 func (e RequestError) Error() string {
 	return fmt.Sprintf("cannot build request: %v", e.error)
 }
@@ -215,12 +211,10 @@ type ConnectionError struct {
 	error
 }
 
-// Error implements the error interface.
 func (e ConnectionError) Error() string {
 	return fmt.Sprintf("cannot communicate with server: %v", e.error)
 }
 
-// Unwrap implements errors.Unwrap interface.
 func (e ConnectionError) Unwrap() error {
 	return e.error
 }
@@ -418,13 +412,11 @@ type Error struct {
 	StatusCode int
 }
 
-// Error implements the error interface.
 func (e *Error) Error() string {
 	return e.Message
 }
 
 const (
-	// Possible values for Error.Kind
 	ErrorKindLoginRequired     = "login-required"
 	ErrorKindSystemRestart     = "system-restart"
 	ErrorKindDaemonRestart     = "daemon-restart"
@@ -472,7 +464,6 @@ func parseError(r *http.Response) error {
 	return err
 }
 
-// SysInfo holds system information returned from the server.
 type SysInfo struct {
 	// Version is the server version.
 	Version string `json:"version,omitempty"`

--- a/client/client.go
+++ b/client/client.go
@@ -258,7 +258,8 @@ var (
 	doTimeout = 5 * time.Second
 )
 
-// FakeDoRetry fakes the delays used by the do retry loop.
+// FakeDoRetry fakes the delays used by the do retry loop (intended for
+// testing). Calling restore will revert the changes.
 func FakeDoRetry(retry, timeout time.Duration) (restore func()) {
 	oldRetry := doRetry
 	oldTimeout := doTimeout

--- a/client/doc.go
+++ b/client/doc.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package client implements a Go client for Pebble's HTTP-over-Unix-socket
+// API.
+//
+// To use the API, first create a client using [New], and then call the
+// methods on the returned [Client] to interact with the API, such as
+// [Client.Start] or [Client.ListFiles].
+package client

--- a/client/doc.go
+++ b/client/doc.go
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// Package client implements a Go client for Pebble's HTTP-over-Unix-socket
+// Package client implements a Go client for Pebble's HTTP-over-unix-socket
 // API.
 //
 // To use the API, first create a client using [New], and then call the

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -15,7 +15,7 @@
 package client_test
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/canonical/pebble/client"
 )
@@ -29,15 +29,14 @@ func Example() {
 
 	pebble, err := client.New(&client.Config{Socket: ".pebble.socket"})
 	if err != nil {
-		fmt.Println(err)
-		return
+		log.Fatal(err)
 	}
-	files, err := pebble.ListFiles(&client.ListFilesOptions{Path: "/tmp"})
+	changeID, err := pebble.Stop(&client.ServiceOptions{Names: []string{"mysvc"}})
 	if err != nil {
-		fmt.Println(err)
-		return
+		log.Fatal(err)
 	}
-	for _, file := range files {
-		fmt.Println(file.Name())
+	_, err = pebble.WaitChange(changeID, &client.WaitChangeOptions{})
+	if err != nil {
+		log.Fatal(err)
 	}
 }

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client_test
+
+import (
+	"fmt"
+
+	"github.com/canonical/pebble/client"
+)
+
+var runExample = false
+
+func Example() {
+	if !runExample {
+		return // don't run this example under "go test"
+	}
+
+	pebble, err := client.New(&client.Config{Socket: ".pebble.socket"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	files, err := pebble.ListFiles(&client.ListFilesOptions{Path: "/tmp"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	for _, file := range files {
+		fmt.Println(file.Name())
+	}
+}

--- a/client/example_test.go
+++ b/client/example_test.go
@@ -20,11 +20,11 @@ import (
 	"github.com/canonical/pebble/client"
 )
 
-var runExample = false
+var runExample = false // example won't actually be run, just type-checked
 
 func Example() {
 	if !runExample {
-		return // don't run this example under "go test"
+		return
 	}
 
 	pebble, err := client.New(&client.Config{Socket: ".pebble.socket"})

--- a/client/exec.go
+++ b/client/exec.go
@@ -26,7 +26,6 @@ import (
 	"github.com/canonical/pebble/internal/wsutil"
 )
 
-// ExecOptions are the options for an Exec call.
 type ExecOptions struct {
 	// Required: command and arguments (first element is the executable).
 	Command []string
@@ -261,7 +260,6 @@ func (e *ExitError) ExitCode() int {
 	return e.exitCode
 }
 
-// Error implements the error interface.
 func (e *ExitError) Error() string {
 	return fmt.Sprintf("exit status %d", e.exitCode)
 }

--- a/client/files.go
+++ b/client/files.go
@@ -24,7 +24,6 @@ import (
 
 var _ os.FileInfo = (*FileInfo)(nil)
 
-// ListFilesOptions holds the options for a call to ListFiles.
 type ListFilesOptions struct {
 	// Path is the absolute path of the file system entry to be listed.
 	Path string
@@ -39,7 +38,6 @@ type ListFilesOptions struct {
 	Itself bool
 }
 
-// FileInfo holds information about a single file.
 type FileInfo struct {
 	name    string
 	size    int64

--- a/client/files.go
+++ b/client/files.go
@@ -39,6 +39,7 @@ type ListFilesOptions struct {
 	Itself bool
 }
 
+// FileInfo holds information about a single file.
 type FileInfo struct {
 	name    string
 	size    int64

--- a/client/logs.go
+++ b/client/logs.go
@@ -30,7 +30,6 @@ const (
 	logReaderSize = 4 * 1024
 )
 
-// LogsOptions holds the options for a call to Logs or FollowLogs.
 type LogsOptions struct {
 	// WriteLog is called to write a single log to the output (required).
 	WriteLog func(entry LogEntry) error

--- a/client/plan.go
+++ b/client/plan.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 )
 
-// AddLayerOptions holds the options for a call to AddLayer.
 type AddLayerOptions struct {
 	// Combine true means combine the new layer with an existing layer that
 	// has the given label. False (the default) means append a new layer.
@@ -34,7 +33,7 @@ type AddLayerOptions struct {
 	LayerData []byte
 }
 
-// AddLayer adds a layer to the plan's layers.
+// AddLayer adds a layer to the plan's configuration layers.
 func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	var payload = struct {
 		Action  string `json:"action"`
@@ -57,7 +56,6 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	return err
 }
 
-// PlanOptions holds the options for a call to PlanBytes.
 type PlanOptions struct{}
 
 // PlanBytes fetches the plan in YAML format.

--- a/client/plan.go
+++ b/client/plan.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 )
 
+// AddLayerOptions holds the options for a call to AddLayer.
 type AddLayerOptions struct {
 	// Combine true means combine the new layer with an existing layer that
 	// has the given label. False (the default) means append a new layer.
@@ -33,7 +34,7 @@ type AddLayerOptions struct {
 	LayerData []byte
 }
 
-// AddLayer adds a layer to the plan's layers according to opts.Action.
+// AddLayer adds a layer to the plan's layers.
 func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	var payload = struct {
 		Action  string `json:"action"`
@@ -56,6 +57,7 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	return err
 }
 
+// PlanOptions holds the options for a call to PlanBytes.
 type PlanOptions struct{}
 
 // PlanBytes fetches the plan in YAML format.

--- a/client/services.go
+++ b/client/services.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 )
 
-// ServiceOptions holds the options for a service operation such as
-// [Client.Start].
 type ServiceOptions struct {
 	Names []string
 }
@@ -81,7 +79,6 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 	return client.doAsyncFull("POST", "/v1/services", nil, headers, bytes.NewBuffer(data))
 }
 
-// ServicesOptions are the filtering options for querying services.
 type ServicesOptions struct {
 	// Names is the list of service names to query for. If slice is nil or
 	// empty, fetch information for all services.

--- a/client/services.go
+++ b/client/services.go
@@ -22,30 +22,40 @@ import (
 	"strings"
 )
 
+// ServiceOptions holds the options for a service operation such as
+// [Client.Start].
 type ServiceOptions struct {
 	Names []string
 }
 
+// AutoStart starts the services makes as "startup: enabled". opts.Names must
+// be empty for this call.
 func (client *Client) AutoStart(opts *ServiceOptions) (changeID string, err error) {
 	_, changeID, err = client.doMultiServiceAction("autostart", opts.Names)
 	return changeID, err
 }
 
+// Start starts the services named in opts.Names in dependency order.
 func (client *Client) Start(opts *ServiceOptions) (changeID string, err error) {
 	_, changeID, err = client.doMultiServiceAction("start", opts.Names)
 	return changeID, err
 }
 
+// Stop stops the services named in opts.Names in dependency order.
 func (client *Client) Stop(opts *ServiceOptions) (changeID string, err error) {
 	_, changeID, err = client.doMultiServiceAction("stop", opts.Names)
 	return changeID, err
 }
 
+// Restart stops and then starts the services named in opts.Names in
+// dependency order.
 func (client *Client) Restart(opts *ServiceOptions) (changeID string, err error) {
 	_, changeID, err = client.doMultiServiceAction("restart", opts.Names)
 	return changeID, err
 }
 
+// Replan stops and (re)starts the services whose configuration has changed
+// since they were started. opts.Names must be empty for this call.
 func (client *Client) Replan(opts *ServiceOptions) (changeID string, err error) {
 	_, changeID, err = client.doMultiServiceAction("replan", opts.Names)
 	return changeID, err

--- a/client/signals.go
+++ b/client/signals.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 )
 
+// SendSignalOptions holds the options for a call to SendSignal.
 type SendSignalOptions struct {
 	Signal   string
 	Services []string

--- a/client/signals.go
+++ b/client/signals.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 )
 
-// SendSignalOptions holds the options for a call to SendSignal.
 type SendSignalOptions struct {
 	Signal   string
 	Services []string

--- a/client/warnings.go
+++ b/client/warnings.go
@@ -21,10 +21,10 @@ import (
 	"time"
 )
 
-// A Warning is a short messages that's meant to alert about system events.
+// Warning holds a short message that's meant to alert about system events.
 // There'll only ever be one Warning with the same message, and it can be
 // silenced for a while before repeating. After a (supposedly longer) while
-// it'll go away on its own (unless it recurrs).
+// it'll go away on its own (unless it recurs).
 type Warning struct {
 	Message     string        `json:"message"`
 	FirstAdded  time.Time     `json:"first-added"`
@@ -40,7 +40,7 @@ type jsonWarning struct {
 	RepeatAfter string `json:"repeat-after,omitempty"`
 }
 
-// WarningsOptions contains options for querying pebble for warnings
+// WarningsOptions contains options for querying Pebble for warnings
 // supported options:
 // - All: return all warnings, instead of only the un-okayed ones.
 type WarningsOptions struct {
@@ -71,7 +71,7 @@ type warningsAction struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// Okay asks pebble to chill about the warnings that would have been returned by
+// Okay asks the server to silence the warnings that would have been returned by
 // Warnings at the given time.
 func (client *Client) Okay(t time.Time) error {
 	var body bytes.Buffer

--- a/client/warnings.go
+++ b/client/warnings.go
@@ -40,10 +40,8 @@ type jsonWarning struct {
 	RepeatAfter string `json:"repeat-after,omitempty"`
 }
 
-// WarningsOptions contains options for querying Pebble for warnings
-// supported options:
-// - All: return all warnings, instead of only the un-okayed ones.
 type WarningsOptions struct {
+	// All means return all warnings, instead of only the un-okayed ones.
 	All bool
 }
 

--- a/cmd/pebble/cmd_help.go
+++ b/cmd/pebble/cmd_help.go
@@ -200,7 +200,7 @@ the system that is running them.
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
 	pebbleHelpAllFooter       = "Set the PEBBLE environment variable to override the configuration directory \n" +
 		"(which defaults to " + defaultPebbleDir + "). Set PEBBLE_SOCKET to override \n" +
-		"the Unix socket used for the API (defaults to $PEBBLE/.pebble.socket).\n" +
+		"the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).\n" +
 		"\n" +
 		"For more information about a command, run 'pebble help <command>'."
 	pebbleHelpFooter = "For a short summary of all commands, run 'pebble help --all'."


### PR DESCRIPTION
This add a brief package doc comment to the client package, as well as short doc comment to (I think!) every type and method in the client package. This is part of a larger effort to document Pebble more thoroughly -- this PR focusses on the Go reference docs for the `client` package.

Also make a few updates to the README. Removed two bullet points from "Some details worth highlighting", as those are discussed in detail below. Link to API docs instead of providing an inline example. Update "TODO" section items.

Also add an example for the client package docs. It's not really run (in the "too hard basket" for now; I've tested it locally though), but at least it's type checked.