### PR TITLE
Add "Using Pebble" documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Each check can be one of three types. The types and their success criteria are:
 * `tcp`: opening the given TCP port must be successful
 * `exec`: executing the specified command must yield a zero exit code
 
-Checks are configured in the layer configuration using the top-level field `checks`. Below is an example layer showing the three different types of checks:
+Checks are configured in the layer configuration using the top-level field `checks`. Full details are given in the [layer specification](#layer-specification), but below is an example layer showing the three different types of checks:
 
 ```
 checks:


### PR DESCRIPTION
This PR adds a large section of documentation to the README about how to use Pebble, and how some of its major features work. This is intended as a mini user manual; several people have asked about how these things work, and I've previously had to say "sorry, it's documented in the code". :-)