### PR TITLE
[JUJU-1889] Log forwarding, take two

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ $ pebble run --verbose
 
 #### Log forwarding
 
-Pebble supports forwarding its services' logs to a remote Loki server or syslog receiver (via UDP/TCP). In the `log-targets` section of the plan, you can specify destinations for log forwarding:
+Pebble supports forwarding its services' logs to a remote Loki server or syslog receiver (via UDP/TCP). In the `log-targets` section of the plan, you can specify destinations for log forwarding, for example:
 ```yaml
 log-targets:
     loki-example:
@@ -368,15 +368,16 @@ log-targets:
     syslog-example:
         override: merge
         type: syslog
-        location: tcp://0.0.0.0:1514
+        location: tcp://192.168.10.241:1514
 ```
 
-By default, all services' logs will be forwarded to these targets. There are two ways to control which services' logs are sent to which targets:
-- For each log target, you can optionally specify the `selection` key. The possible values for this key are:
-  - `opt-out`: each service which doesn't **explicitly specify** log targets will have its logs forwarded to this target. This is the default behaviour.
-  - `opt-in`: a service must explicitly specify this log target to have its logs forwarded here.
-  - `disabled`: no logs will be sent to this target. This can be used in combination with `override: replace` to disable a log target defined in an earlier layer.
-- In the definition for each service, you can specify a list `log-targets` of log targets to forward this service's logs to. The names in the list will be matched against targets defined in the `log-targets` section of the plan. If no targets are specified, the service's logs will be sent to all "opt-out" targets.
+By default, all services' logs will be forwarded to these targets. For each log target, you can optionally specify the `selection` key, with the following possible values:
+
+* `opt-out`: each service which doesn't *explicitly specify* log targets will have its logs forwarded to this target. This is the default behaviour.
+* `opt-in`: a service must explicitly specify this log target to have its logs forwarded here.
+* `disabled`: no logs will be sent to this target. This can be used in combination with `override: replace` to disable a log target defined in an earlier layer.
+
+In the definition for each service, you can also specify a list `log-targets` of log targets to forward this service's logs to. The names in the list will be matched against targets defined in the `log-targets` section of the plan. If no targets are specified, the service's logs will be sent to all "opt-out" targets.
 
 For example, in the following (incomplete) plan:
 ```yaml
@@ -564,7 +565,7 @@ services:
         
         # (Optional) A list of log targets to forward this service's logs to.
         # The names given here will be matched against targets defined in the
-        # `log-targets` section of the plan. If no targets are specified, this
+        # "log-targets" section of the plan. If no targets are specified, this
         # service's logs will be forwarded to all "opt-out" targets.
         log-targets: [<log target names>]
 
@@ -682,9 +683,9 @@ log-targets:
         
         # (Required) The URL of the remote log target. For Loki, this needs to
         # be the fully-qualified URL of the push API, including the API
-        # endpoint, e.g. `http://<ip-address>:3100/loki/api/v1/push`.
+        # endpoint, e.g. "http://<ip-address>:3100/loki/api/v1/push".
         # For syslog, this should be the URL of the syslog receiver, in the
-        # format `udp://...` or `tcp://...`.
+        # format "udp://..." or "tcp://...".
         location: <url>
         
         # (Optional) Determines which services' logs will be forwarded to this
@@ -692,7 +693,7 @@ log-targets:
         #   - 'opt-out': all services which don't explicitly specify log
         #      targets will have their logs forwarded to this target.
         #   - 'opt-in': only services which explicitly specify this target in
-        #      the `log-targets` section of the service spec.
+        #      the "log-targets" section of the service spec.
         #   - 'disabled': no logs will be forwarded to this target. This is
         #      useful to deactivate a target defined in an earlier layer.
         # If unspecified, the selection defaults to 'opt-out'.

--- a/README.md
+++ b/README.md
@@ -514,6 +514,12 @@ services:
         # SIGTERM and exit gracefully before SIGKILL terminates it forcefully.
         # Default is 5 seconds ("5s").
         kill-delay: <duration>
+        
+        # (Optional) A list of log targets to forward this service's logs to.
+        # The names given here will be matched against targets defined in the
+        # `log-targets` section of the plan. If no targets are specified, this
+        # service's logs will be forwarded to all "opt-out" targets.
+        log-targets: [<log target names>]
 
 # (Optional) A list of health checks managed by this configuration layer.
 checks:
@@ -608,6 +614,42 @@ checks:
 
             # (Optional) Working directory to run command in.
             working-dir: <directory>
+
+# (Optional) A list of remote log receivers, to which service logs can be sent.
+log-targets:
+
+    <log target name>:
+
+        # (Required) Control how this log target definition is combined with
+        # other pre-existing definitions with the same name in the Pebble plan.
+        #
+        # The value 'merge' will ensure that values in this layer specification
+        # are merged over existing definitions, whereas 'replace' will entirely
+        # override the existing target spec in the plan with the same name.
+        override: merge | replace
+
+        # (Required) The type of log target, which determines the format in
+        # which logs will be sent. Pebble currently supports forwarding to
+        # Loki (over HTTP) and syslog (over UDP/TCP).
+        type: loki | syslog
+        
+        # (Required) The URL of the remote log target. For Loki, this needs to
+        # be the fully-qualified URL of the push API, including the API
+        # endpoint, e.g. `http://<ip-address>:3100/loki/api/v1/push`.
+        # For syslog, this should be the URL of the syslog receiver, in the
+        # format `udp://...` or `tcp://...`.
+        location: <url>
+        
+        # (Optional) Determines which services' logs will be forwarded to this
+        # log target.
+        #   - 'opt-out': all services which don't explicitly specify log
+        #      targets will have their logs forwarded to this target.
+        #   - 'opt-in': only services which explicitly specify this target in
+        #      the `log-targets` section of the service spec.
+        #   - 'disabled': no logs will be forwarded to this target. This is
+        #      useful to deactivate a target defined in an earlier layer.
+        # If unspecified, the selection defaults to 'opt-out'.
+        selection: opt-out | opt-in | disabled
 ```
 
 ## API and clients

--- a/README.md
+++ b/README.md
@@ -385,24 +385,24 @@ services:
     svc1:
         ...
     svc2:
-        log-targets: ['default', 'opt-in']
+        log-targets: ['tgtA', 'tgtC']
     svc3:
-        log-targets: ['disabled']
+        log-targets: ['tgtD']
 
 log-targets:
-    default:
+    tgtA:
         ...
-    opt-out:
+    tgtB:
         selection: opt-out
-    opt-in:
+    tgtC:
         selection: opt-in
-    disabled:
+    tgtD:
         selection: disabled
 ```
 
-- `svc1` doesn't explicitly specify log-targets, so its logs will be forwarded to the `default` and `opt-out` targets.
-- `svc2` explicitly specifies the `default` and `opt-in` targets, so its logs will be sent to those targets. `svc2`'s logs will not be sent to the `opt-out` or `disabled` targets.
-- `svc3` explicitly specifies the `disabled` target, but since this target is disabled, it will not receive any logs. Hence, `svc3`'s logs will not be sent anywhere.
+- `svc1` doesn't explicitly specify log-targets, so its logs will be forwarded to `tgtA` and `tgtB`.
+- `svc2` explicitly specifies `tgtA` and `tgtC`, so its logs will be sent to those targets. `svc2`'s logs will not be sent to `tgtB` or `tgtD`.
+- `svc3` explicitly specifies `tgtD`, but since this target is disabled, it will not receive any logs. Hence, `svc3`'s logs will not be sent anywhere.
 
 ## Container usage
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,53 @@ $ pebble run --verbose
 ...
 ```
 
+#### Log forwarding
+
+Pebble supports forwarding its services' logs to a remote Loki server or syslog receiver (via UDP/TCP). In the `log-targets` section of the plan, you can specify destinations for log forwarding:
+```yaml
+log-targets:
+    loki-example:
+        override: merge
+        type: loki
+        location: http://10.1.77.205:3100/loki/api/v1/push
+    syslog-example:
+        override: merge
+        type: syslog
+        location: tcp://0.0.0.0:1514
+```
+
+By default, all services' logs will be forwarded to these targets. There are two ways to control which services' logs are sent to which targets:
+- For each log target, you can optionally specify the `selection` key. The possible values for this key are:
+  - `opt-out`: each service which doesn't **explicitly specify** log targets will have its logs forwarded to this target. This is the default behaviour.
+  - `opt-in`: a service must explicitly specify this log target to have its logs forwarded here.
+  - `disabled`: no logs will be sent to this target. This can be used in combination with `override: replace` to disable a log target defined in an earlier layer.
+- In the definition for each service, you can specify a list `log-targets` of log targets to forward this service's logs to. The names in the list will be matched against targets defined in the `log-targets` section of the plan. If no targets are specified, the service's logs will be sent to all "opt-out" targets.
+
+For example, in the following (incomplete) plan:
+```yaml
+services:
+    svc1:
+        ...
+    svc2:
+        log-targets: ['default', 'opt-in']
+    svc3:
+        log-targets: ['disabled']
+
+log-targets:
+    default:
+        ...
+    opt-out:
+        selection: opt-out
+    opt-in:
+        selection: opt-in
+    disabled:
+        selection: disabled
+```
+
+- `svc1` doesn't explicitly specify log-targets, so its logs will be forwarded to the `default` and `opt-out` targets.
+- `svc2` explicitly specifies the `default` and `opt-in` targets, so its logs will be sent to those targets. `svc2`'s logs will not be sent to the `opt-out` or `disabled` targets.
+- `svc3` explicitly specifies the `disabled` target, but since this target is disabled, it will not receive any logs. Hence, `svc3`'s logs will not be sent anywhere.
+
 ## Container usage
 
 Pebble works well as a local service manager, but if running Pebble in a separate container, you can use the exec and file management APIs to coordinate with the remote system over the shared unix socket.
@@ -682,7 +729,7 @@ Here are some of the things coming soon:
   - [x] Automatically restart services that fail
   - [x] Support for custom health checks (HTTP, TCP, command)
   - [x] Terminate all services before exiting run command
-  - [ ] Log forwarding (syslog and Loki)
+  - [x] Log forwarding (syslog and Loki)
   - [ ] [Other in-progress PRs](https://github.com/canonical/pebble/pulls)
   - [ ] [Other requested features](https://github.com/canonical/pebble/issues)
 

--- a/internal/overlord/logstate/forwarder.go
+++ b/internal/overlord/logstate/forwarder.go
@@ -105,8 +105,8 @@ func newLogForwarderInternal(
 		parser:      servicelog.NewParser(iterator, parserSize),
 		iteratorCh:  iteratorCh,
 		stopCh:      make(chan chan struct{}, 1),
-		maxMessages: maxMessages,
-		delay:       delay,
+		maxMessages: maxMessages, // TODO: make this value configurable in plan
+		delay:       delay,       // TODO: make this value configurable in plan
 		flushTimer:  flushTimer,
 		timerSet:    false,
 		timeoutCh:   timeoutCh,

--- a/internal/overlord/logstate/forwarder.go
+++ b/internal/overlord/logstate/forwarder.go
@@ -39,7 +39,7 @@ var flushDelay = 1 * time.Second
 // This starts the main control loop, which will spawn an additional iterate
 // goroutine to pull logs from the iterator and send them through a channel.
 // f can be stopped by calling f.stop(), which will gracefully terminate the
-// forward and iterate goroutines.
+// forward and iterate goroutines, and flush out all remaining logs.
 type logForwarder struct {
 	service     string
 	target      *plan.LogTarget

--- a/internal/overlord/logstate/forwarder.go
+++ b/internal/overlord/logstate/forwarder.go
@@ -147,7 +147,7 @@ func (f *logForwarder) forward() {
 			// continue loop
 		}
 
-		if len(f.messages) > f.maxMessages {
+		if len(f.messages) >= f.maxMessages {
 			f.flushBuffer()
 		}
 

--- a/internal/overlord/logstate/forwarder.go
+++ b/internal/overlord/logstate/forwarder.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/canonical/pebble/internal/logger"
+	"github.com/canonical/pebble/internal/plan"
+	"github.com/canonical/pebble/internal/servicelog"
+)
+
+const (
+	parserSize = 4 * 1024
+
+	maxBufferedLogs = 100
+)
+
+var flushDelay = 1 * time.Second
+
+// logForwarder is responsible for forwarding logs from a single service to
+// a single target.
+type logForwarder struct {
+	service string
+	target  *plan.LogTarget
+
+	iterator   servicelog.Iterator
+	parser     *servicelog.Parser
+	iteratorCh chan struct{}
+	stopCh     chan chan struct{}
+
+	messages    []servicelog.Entry
+	maxMessages int
+
+	delay      time.Duration
+	flushTimer *time.Timer
+	timerSet   bool
+	timeoutCh  chan struct{}
+
+	client logClient
+}
+
+func newLogForwarder(
+	service string, target *plan.LogTarget, iterator servicelog.Iterator,
+) (*logForwarder, error) {
+
+	var client logClient
+	var err error
+
+	switch target.Type {
+	case plan.LokiTarget:
+		client = newLokiClient(target.Location)
+
+	case plan.SyslogTarget:
+		client, err = newSyslogClient(target.Location)
+
+	default:
+		return nil, fmt.Errorf(
+			"unknown log target type %q", target.Type)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return newLogForwarderInternal(service, target, iterator, client, maxBufferedLogs, flushDelay), nil
+}
+
+// newLogForwarderInternal is shared by the real and test code.
+func newLogForwarderInternal(
+	service string, target *plan.LogTarget, iterator servicelog.Iterator,
+	client logClient, maxMessages int, delay time.Duration,
+) *logForwarder {
+
+	iteratorCh := make(chan struct{})
+	timeoutCh := make(chan struct{}, 1)
+	// Create timer. Here we set the timer duration to a large value and
+	// immediately stop it, to ensure the timer starts off unset.
+	flushTimer := time.AfterFunc(time.Hour, func() {
+		timeoutCh <- struct{}{}
+		// If we are waiting on iterator.Next, cancel this
+		select {
+		case iteratorCh <- struct{}{}:
+		default:
+		}
+	})
+	flushTimer.Stop()
+
+	return &logForwarder{
+		service:     service,
+		target:      target,
+		iterator:    iterator,
+		parser:      servicelog.NewParser(iterator, parserSize),
+		iteratorCh:  iteratorCh,
+		stopCh:      make(chan chan struct{}, 1),
+		maxMessages: maxMessages,
+		delay:       delay,
+		flushTimer:  flushTimer,
+		timerSet:    false,
+		timeoutCh:   timeoutCh,
+		client:      client,
+	}
+}
+
+// forward continually pulls logs from the service buffer and forwards them
+// to the remote log target.
+// This method will block until the service is stopped, or stop() is called.
+// Hence, it should be run in a separate goroutine.
+func (f *logForwarder) forward() {
+	for {
+		select {
+		// f.stop() called
+		case release := <-f.stopCh:
+			// Pull all remaining logs from parser/iterator
+			for f.parser.Next() {
+				if err := f.parser.Err(); err != nil {
+					logger.Noticef(
+						"Forwarding logs to target %q: error reading logs for service %q: %v",
+						f.target.Name, f.service, err)
+					continue
+				}
+
+				f.messages = append(f.messages, f.parser.Entry())
+			}
+			// Done with iterator - release call to stop()
+			close(release)
+			f.close()
+			return
+
+		// Timeout on buffered messages
+		case <-f.timeoutCh:
+			f.flushBuffer()
+
+		default:
+			// continue loop
+		}
+
+		if len(f.messages) > f.maxMessages {
+			f.flushBuffer()
+		}
+
+		// Check if parser has buffered logs
+		if f.parser.Next() {
+			if err := f.parser.Err(); err != nil {
+				logger.Noticef(
+					"Forwarding logs to target %q: error reading logs for service %q: %v",
+					f.target.Name, f.service, err)
+				continue
+			}
+
+			f.messages = append(f.messages, f.parser.Entry())
+
+			// Set deadline
+			if !f.timerSet {
+				f.flushTimer.Reset(f.delay)
+				f.timerSet = true
+			}
+
+			continue
+		}
+
+		// Parser has no buffered logs. Wait for iterator to receive more data
+		f.iterator.Next(f.iteratorCh)
+	}
+}
+
+// stop stops the forwarding of logs.
+func (f *logForwarder) stop() {
+	// Create a "release" channel - the other goroutine will close this to signal
+	// it has finished, then we can exit the stop() call.
+	release := make(chan struct{})
+	f.stopCh <- release
+
+	// Cancel iterator.Next call - wait for release channel to be closed
+	for {
+		select {
+		case f.iteratorCh <- struct{}{}:
+		case <-release:
+			return
+		}
+	}
+}
+
+// close flushes the buffer, closes the client and cleans up.
+func (f *logForwarder) close() {
+	f.flushBuffer()
+
+	err := f.client.Close()
+	if err != nil {
+		logger.Noticef("Internal error: closing log client %q -> %q: %s",
+			f.service, f.target.Name, err)
+	}
+}
+
+// flushBuffer sends the buffered messages to the client, then resets the buffer.
+func (f *logForwarder) flushBuffer() {
+	err := f.client.Send(f.messages)
+	if err != nil {
+		logger.Noticef(
+			"Forwarding logs to target %q: cannot send logs for service %q: %v",
+			f.target.Name, f.service, err)
+	}
+
+	f.messages = f.messages[:0]
+
+	// Reset timer
+	f.flushTimer.Stop()
+	f.timerSet = false
+	// Drain timer channel
+	select {
+	case <-f.flushTimer.C:
+	default:
+	}
+}
+
+// logClient represents a client that communicates with a log target.
+type logClient interface {
+	Send([]servicelog.Entry) error
+	Close() error
+}

--- a/internal/overlord/logstate/forwarder.go
+++ b/internal/overlord/logstate/forwarder.go
@@ -178,8 +178,8 @@ func (f *logForwarder) iterate(cancel <-chan struct{}, messages chan servicelog.
 		}
 		if err := parser.Err(); err != nil {
 			logger.Noticef(
-				"Forwarding logs to target %q: error reading logs for service %q: %v",
-				f.target.Name, f.service, err)
+				"Cannot read logs from service %q (target %q): %v",
+				f.service, f.target.Name, err)
 		}
 	}
 	close(messages)
@@ -203,8 +203,8 @@ func (f *logForwarder) sendLogs(messages []servicelog.Entry) {
 	err := f.client.Send(messages)
 	if err != nil {
 		logger.Noticef(
-			"Forwarding logs to target %q: cannot send logs for service %q: %v",
-			f.target.Name, f.service, err)
+			"Cannot forward logs from service %q to target %q: %v",
+			f.service, f.target.Name, err)
 	}
 }
 

--- a/internal/overlord/logstate/forwarder_test.go
+++ b/internal/overlord/logstate/forwarder_test.go
@@ -34,7 +34,7 @@ func (s *forwarderSuite) TestForwarder(c *C) {
 	w := servicelog.NewFormatWriter(rb, serviceName)
 
 	cl := &fakeLogClient{make(chan []string, 1)}
-	f := newLogForwarderForTest(serviceName, it, cl, 1*time.Microsecond)
+	f := newLogForwarderForTest(serviceName, it, cl, 10*time.Millisecond)
 
 	forwardStopped := make(chan struct{})
 	go func() {
@@ -50,7 +50,7 @@ func (s *forwarderSuite) TestForwarder(c *C) {
 		select {
 		case req := <-cl.requests:
 			c.Assert(req, DeepEquals, request)
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(1 * time.Second):
 			c.Fatalf("timed out waiting for request %q", request)
 		}
 	}

--- a/internal/overlord/logstate/forwarder_test.go
+++ b/internal/overlord/logstate/forwarder_test.go
@@ -87,10 +87,7 @@ func (s *forwarderSuite) TestBufferFull(c *C) {
 
 	cl := &fakeLogClient{make(chan []string)}
 	f := newLogForwarderForTest(serviceName, it, cl, 1*time.Second)
-
-	go func() {
-		f.forward()
-	}()
+	go f.forward()
 
 	writeLog := func(logLine string) {
 		_, err := fmt.Fprintln(w, logLine)

--- a/internal/overlord/logstate/forwarder_test.go
+++ b/internal/overlord/logstate/forwarder_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/canonical/pebble/internal/servicelog"
+	. "gopkg.in/check.v1"
+)
+
+type forwarderSuite struct{}
+
+var _ = Suite(&forwarderSuite{})
+
+func (s *forwarderSuite) TestForwarder(c *C) {
+	serviceName := "foobar"
+	rb := servicelog.NewRingBuffer(1024)
+	it := rb.HeadIterator(0)
+	w := servicelog.NewFormatWriter(rb, serviceName)
+
+	cl := &fakeLogClient{make(chan []string, 1)}
+	f := newLogForwarderForTest(serviceName, it, cl, 1*time.Microsecond)
+
+	forwardStopped := make(chan struct{})
+	go func() {
+		f.forward()
+		close(forwardStopped)
+	}()
+
+	writeLog := func(logLine string) {
+		_, err := fmt.Fprintln(w, logLine)
+		c.Assert(err, IsNil)
+	}
+	expectLogs := func(request []string) {
+		select {
+		case req := <-cl.requests:
+			c.Assert(req, DeepEquals, request)
+		case <-time.After(10 * time.Millisecond):
+			c.Fatalf("timed out waiting for request %q", request)
+		}
+	}
+
+	writeLog("log line #1")
+	writeLog("log line #2")
+	writeLog("log line #3")
+	expectLogs([]string{"log line #1", "log line #2", "log line #3"})
+
+	writeLog("log line #4")
+	expectLogs([]string{"log line #4"})
+
+	writeLog("log line #5")
+	writeLog("log line #6")
+	expectLogs([]string{"log line #5", "log line #6"})
+
+	writeLog("log line #7")
+	f.stop()
+	// Check that f.forward() has returned
+	select {
+	case <-forwardStopped:
+	case <-time.After(1 * time.Second):
+		c.Fatalf("timed out waiting for f.forward() to return")
+	}
+
+	expectLogs([]string{"log line #7"})
+}
+
+type fakeLogClient struct {
+	requests chan []string
+}
+
+func (c *fakeLogClient) Send(entries []servicelog.Entry) error {
+	request := make([]string, 0, len(entries))
+	for _, e := range entries {
+		request = append(request, strings.TrimRight(e.Message, "\n"))
+	}
+	c.requests <- request
+	return nil
+}
+
+func (c *fakeLogClient) Close() error {
+	return nil
+}
+
+func newLogForwarderForTest(
+	service string, iterator servicelog.Iterator,
+	client logClient, delay time.Duration,
+) *logForwarder {
+	return newLogForwarderInternal(service, nil, iterator, client, 5, delay)
+}

--- a/internal/overlord/logstate/loki.go
+++ b/internal/overlord/logstate/loki.go
@@ -67,10 +67,11 @@ func (c *lokiClient) Send(entries []servicelog.Entry) error {
 
 	requestStruct := lokiRequest{
 		Streams: []lokiStream{{
-			// Add default labels
-			// TODO: allow specifying custom labels
 			Labels: map[string]string{
+				// We need this label to distinguish where the logs came from.
+				// Otherwise, we have no way to tell which service generated these logs.
 				"pebble_service": entries[0].Service, // all entries should be from same service
+				// TODO: allow specifying custom labels
 			},
 			Entries: encodedEntries,
 		}},

--- a/internal/overlord/logstate/loki.go
+++ b/internal/overlord/logstate/loki.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/canonical/pebble/internal/servicelog"
+)
+
+const (
+	lokiClientTimeout = 10 * time.Second
+)
+
+type lokiClient struct {
+	client *http.Client
+	url    string
+}
+
+// Creates a new logClient for Loki.
+// The provided URL is expected to be the fully qualified API path, e.g.
+//
+//	https://202.61.12.93:3100/loki/api/v1/push
+func newLokiClient(url string) *lokiClient {
+	return &lokiClient{
+		client: &http.Client{
+			Timeout: lokiClientTimeout,
+		},
+		url: url,
+	}
+}
+
+func (c *lokiClient) Close() error {
+	c.client.CloseIdleConnections()
+	return nil
+}
+
+func (c *lokiClient) Send(entries []servicelog.Entry) error {
+	if len(entries) == 0 {
+		return nil // no-op
+	}
+
+	encodedEntries := make([]lokiMessage, 0, len(entries))
+	for _, entry := range entries {
+		encodedEntries = append(encodedEntries, encodeEntry(entry))
+	}
+
+	requestStruct := lokiRequest{
+		Streams: []lokiStream{{
+			// Add default labels
+			// TODO: allow specifying custom labels
+			Labels: map[string]string{
+				"pebble_service": entries[0].Service, // all entries should be from same service
+			},
+			Entries: encodedEntries,
+		}},
+	}
+
+	data, err := json.Marshal(requestStruct)
+	if err != nil {
+		return err
+	}
+
+	body := bytes.NewReader(data)
+	resp, err := c.client.Post(c.url, "application/json", body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Check response status code to see if it was successful
+	if sc := resp.StatusCode; sc < 200 || sc >= 300 {
+		// Request to Loki failed
+		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
+		if err != nil {
+			b = append(b, []byte("//couldn't read response body: ")...)
+			b = append(b, []byte(err.Error())...)
+		}
+		return fmt.Errorf("cannot send logs to Loki (HTTP %d), response body:\n%s", resp.StatusCode, b)
+	}
+
+	return nil
+}
+
+func encodeEntry(entry servicelog.Entry) lokiMessage {
+	// Write in format
+	//    ["<unix epoch in nanoseconds>","<log line>"]
+	var encoded lokiMessage
+	encoded[0] = strconv.FormatInt(entry.Time.UnixNano(), 10)
+	encoded[1] = strings.TrimRight(entry.Message, "\n")
+	return encoded
+}
+
+// Loki request types to encode to JSON
+type lokiRequest struct {
+	Streams []lokiStream `json:"streams"`
+}
+
+type lokiStream struct {
+	Labels  map[string]string `json:"stream"`
+	Entries []lokiMessage     `json:"values"`
+}
+
+type lokiMessage [2]string

--- a/internal/overlord/logstate/loki_test.go
+++ b/internal/overlord/logstate/loki_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/canonical/pebble/internal/servicelog"
+	. "gopkg.in/check.v1"
+)
+
+type lokiSuite struct{}
+
+var _ = Suite(&lokiSuite{})
+
+func (s *lokiSuite) TestLokiClient(c *C) {
+	entries := []servicelog.Entry{{
+		Time:    time.Date(2021, 5, 26, 12, 37, 1, 0, time.UTC),
+		Service: "foo",
+		Message: "this is a log entry",
+	}, {
+		Time:    time.Date(2021, 5, 26, 12, 37, 3, 0, time.UTC),
+		Service: "foo",
+		Message: "this is a later log entry",
+	}, {
+		Time:    time.Date(2021, 5, 26, 12, 37, 6, 0, time.UTC),
+		Service: "foo",
+		Message: "this is an even later log entry",
+	}}
+
+	expected := `{"streams":[{"stream":{"pebble_service":"foo"},"values":[["1622032621000000000","this is a log entry"],["1622032623000000000","this is a later log entry"],["1622032626000000000","this is an even later log entry"]]}]}`
+
+	requests := make(chan string, 1)
+	srv := newFakeLokiServer(requests)
+	defer srv.Close()
+
+	cl := newLokiClient(srv.URL())
+	err := cl.Send(entries)
+	c.Assert(err, IsNil)
+
+	select {
+	case msg := <-requests:
+		c.Check(msg, Equals, expected)
+	default:
+		c.Fatalf("no request received; expected:\n%s", expected)
+	}
+
+}
+
+type fakeLokiServer struct {
+	srv      *httptest.Server
+	requests chan string
+}
+
+func newFakeLokiServer(requests chan string) *fakeLokiServer {
+	s := &fakeLokiServer{
+		requests: requests,
+	}
+
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("error reading request body: %v", err),
+				http.StatusInternalServerError)
+			return
+		}
+
+		requests <- string(data)
+	}))
+
+	return s
+}
+
+func (s *fakeLokiServer) URL() string {
+	return s.srv.URL
+}
+
+func (s *fakeLokiServer) Close() {
+	s.srv.Close()
+}

--- a/internal/overlord/logstate/manager.go
+++ b/internal/overlord/logstate/manager.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 
 	"github.com/canonical/pebble/internal/logger"
-	"github.com/canonical/pebble/internal/overlord/servstate"
 	"github.com/canonical/pebble/internal/plan"
 	"github.com/canonical/pebble/internal/servicelog"
 )
@@ -76,7 +75,7 @@ func (m *LogManager) PlanChanged(pl *plan.Plan) {
 	unchangedServices := []string{}
 	for serviceName, oldConfig := range m.services {
 		if newConfig, ok := pl.Services[serviceName]; ok {
-			if !servstate.NeedsRestart(oldConfig, newConfig) {
+			if newConfig.Equal(oldConfig) {
 				unchangedServices = append(unchangedServices, serviceName)
 			}
 		}

--- a/internal/overlord/logstate/manager.go
+++ b/internal/overlord/logstate/manager.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"sync"
+
+	"github.com/canonical/pebble/internal/logger"
+	"github.com/canonical/pebble/internal/overlord/servstate"
+	"github.com/canonical/pebble/internal/plan"
+	"github.com/canonical/pebble/internal/servicelog"
+)
+
+type LogManager struct {
+	forwarders []*logForwarder
+	// service -> targets selected from plan
+	planTargets map[string]map[string]*plan.LogTarget
+	// Keep service config to know what changed
+	services map[string]*plan.Service
+	// Keep ring buffer for each running service
+	buffers map[string]*servicelog.RingBuffer
+	// Keep iterator for each (service, target) pair
+	iterators map[string]map[plan.LogTarget]servicelog.Iterator
+	// Mutex for reading/writing manager structs
+	mu sync.Mutex
+}
+
+func NewLogManager() *LogManager {
+	return &LogManager{
+		buffers: map[string]*servicelog.RingBuffer{},
+	}
+}
+
+// PlanChanged is called by the service manager when the plan changes. We stop
+// all running forwarders, and start new forwarders based on the new plan.
+// There are three distinct cases when creating the new forwarders:
+//   - Existing service and target: create the forwarder using the same
+//     iterator, to avoid log duplication.
+//   - Existing service, new target: create the forwarder using a new iterator
+//     over the existing buffer.
+//   - New service: don't create anything yet. We have to wait until
+//     ServiceStarted is called, and we are given a reference to the service's
+//     ringbuffer.
+func (m *LogManager) PlanChanged(pl *plan.Plan) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Stop all existing forwarders
+	for _, f := range m.forwarders {
+		f.stop()
+	}
+	m.forwarders = []*logForwarder{}
+
+	m.planTargets = selectTargets(pl)
+
+	// Create new buffer/iterator structures for LogManager
+	// We will update these and overwrite LogManager fields at the end
+	buffers := map[string]*servicelog.RingBuffer{}
+	iterators := map[string]map[plan.LogTarget]servicelog.Iterator{}
+
+	// Work out which services haven't changed (will continue running)
+	// For each of these services, ServiceStarted won't be called, so we need to
+	// manually restart those forwarders
+	unchangedServices := []string{}
+	for serviceName, oldConfig := range m.services {
+		if newConfig, ok := pl.Services[serviceName]; ok {
+			if !servstate.NeedsRestart(oldConfig, newConfig) {
+				unchangedServices = append(unchangedServices, serviceName)
+			}
+		}
+	}
+
+	for _, serviceName := range unchangedServices {
+		iterators[serviceName] = map[plan.LogTarget]servicelog.Iterator{}
+		// Copy buffer reference over
+		buffers[serviceName] = m.buffers[serviceName]
+
+		for _, target := range m.planTargets[serviceName] {
+			iterator, ok := m.iterators[serviceName][*target]
+			if !ok {
+				// New target for existing service - need a new iterator
+				iterator = m.buffers[serviceName].HeadIterator(0)
+			}
+
+			// Copy iterator reference over
+			iterators[serviceName][*target] = iterator
+
+			m.startForwarder(serviceName, target, iterator)
+		}
+	}
+
+	// For other services: forwarders will be started in ServiceStarted
+
+	// Update buffers and iterators
+	m.buffers = buffers
+	m.iterators = iterators
+
+	// Update services
+	m.services = map[string]*plan.Service{}
+	for serviceName, service := range pl.Services {
+		m.services[serviceName] = service.Copy()
+	}
+}
+
+// selectTargets goes through the given plan and determines which service's
+// logs should be forwarded to which log targets.
+func selectTargets(p *plan.Plan) map[string]map[string]*plan.LogTarget {
+	planTargets := make(map[string]map[string]*plan.LogTarget, len(p.Services))
+
+	for serviceName, service := range p.Services {
+		planTargets[serviceName] = make(map[string]*plan.LogTarget, len(service.LogTargets))
+
+		for _, targetName := range service.LogTargets {
+			target, ok := p.LogTargets[targetName]
+			if !ok {
+				logger.Noticef("Internal error: log manager cannot find target %q (specified by service %q in plan)",
+					targetName, serviceName)
+				continue
+			}
+			if target.Selection != plan.DisabledSelection {
+				planTargets[serviceName][targetName] = target
+			}
+		}
+
+		// Add opt-out targets if none specified
+		if len(service.LogTargets) == 0 {
+			for targetName, target := range p.LogTargets {
+				// Default (unset) is opt-out
+				if target.Selection == plan.OptOutSelection || target.Selection == plan.UnsetSelection {
+					planTargets[serviceName][targetName] = target
+				}
+			}
+		}
+	}
+
+	return planTargets
+}
+
+// ServiceStarted notifies the log manager that the named service has started,
+// and provides a reference to the service's log buffer.
+func (m *LogManager) ServiceStarted(serviceName string, buffer *servicelog.RingBuffer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.buffers[serviceName] = buffer
+	m.iterators[serviceName] = make(map[plan.LogTarget]servicelog.Iterator,
+		len(m.planTargets[serviceName]))
+
+	for _, target := range m.planTargets[serviceName] {
+		iterator := m.buffers[serviceName].HeadIterator(0)
+		m.iterators[serviceName][*target] = iterator
+
+		m.startForwarder(serviceName, target, iterator)
+	}
+}
+
+// startForwarder starts a new forwarder for the specified service and target,
+// and adds this forwarder to the LogManager's list.
+func (m *LogManager) startForwarder(
+	serviceName string, target *plan.LogTarget, iterator servicelog.Iterator,
+) {
+	f, err := newLogForwarder(serviceName, target, iterator)
+	if err != nil {
+		logger.Noticef("Internal error: cannot create forwarder %q -> %q: %v",
+			serviceName, target.Name, err)
+		return
+	}
+
+	m.forwarders = append(m.forwarders, f)
+	logger.Debugf("Started forwarding logs for service %q to target %q",
+		serviceName, target.Name)
+	go f.forward()
+}
+
+// Ensure implements overlord.StateManager.
+func (m *LogManager) Ensure() error {
+	return nil
+}
+
+// Stop implements overlord.StateStopper and stops all log forwarding.
+func (m *LogManager) Stop() {
+	wg := sync.WaitGroup{}
+	for _, f := range m.forwarders {
+		wg.Add(1)
+		go func(f *logForwarder) {
+			f.stop()
+			wg.Done()
+		}(f)
+	}
+	wg.Wait()
+}

--- a/internal/overlord/logstate/manager_test.go
+++ b/internal/overlord/logstate/manager_test.go
@@ -168,7 +168,7 @@ func checkForwarderExists(c *C, forwarders []*logForwarder, serviceName, targetN
 func (s *managerSuite) TestNoLogDuplication(c *C) {
 	// Reduce Loki flush time
 	flushDelayOld := flushDelay
-	flushDelay = 1 * time.Microsecond
+	flushDelay = 10 * time.Millisecond
 	defer func() {
 		flushDelay = flushDelayOld
 	}()
@@ -177,7 +177,7 @@ func (s *managerSuite) TestNoLogDuplication(c *C) {
 	rb := servicelog.NewRingBuffer(1024)
 
 	// Set up fake "Loki" server
-	requests := make(chan string)
+	requests := make(chan string, 2)
 	srv := newFakeLokiServer(requests)
 	defer srv.Close()
 
@@ -191,7 +191,7 @@ func (s *managerSuite) TestNoLogDuplication(c *C) {
 		select {
 		case req := <-requests:
 			c.Assert(req, Equals, expected)
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(1 * time.Second):
 			c.Fatalf("timed out waiting for request %q", expected)
 		}
 	}

--- a/internal/overlord/logstate/manager_test.go
+++ b/internal/overlord/logstate/manager_test.go
@@ -104,11 +104,10 @@ func (s *managerSuite) TestLogManager(c *C) {
 		},
 	})
 
-	// Start 3 services
+	// Start the three services. We do this concurrently to simulate Pebble's
+	// actual service startup, and check there are no race conditions.
 	var wg sync.WaitGroup
 	wg.Add(3)
-
-	// Call ServiceStarted
 	go func() {
 		defer wg.Done()
 		m.ServiceStarted("svc1", &rb)

--- a/internal/overlord/logstate/manager_test.go
+++ b/internal/overlord/logstate/manager_test.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/canonical/pebble/internal/logger"
+	"github.com/canonical/pebble/internal/plan"
+	"github.com/canonical/pebble/internal/servicelog"
+	. "gopkg.in/check.v1"
+)
+
+type managerSuite struct{}
+
+var _ = Suite(&managerSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (s *managerSuite) TestSelectTargets(c *C) {
+	unset := plan.LogTarget{Selection: plan.UnsetSelection}
+	optout := plan.LogTarget{Selection: plan.OptOutSelection}
+	optin := plan.LogTarget{Selection: plan.OptInSelection}
+	disabled := plan.LogTarget{Selection: plan.DisabledSelection}
+
+	input := plan.Plan{
+		LogTargets: map[string]*plan.LogTarget{
+			"unset":    &unset,
+			"optout":   &optout,
+			"optin":    &optin,
+			"disabled": &disabled,
+		},
+		Services: map[string]*plan.Service{
+			"svc1": {LogTargets: nil},
+			"svc2": {LogTargets: []string{}},
+			"svc3": {LogTargets: []string{"unset"}},
+			"svc4": {LogTargets: []string{"optout"}},
+			"svc5": {LogTargets: []string{"optin"}},
+			"svc6": {LogTargets: []string{"disabled"}},
+			"svc7": {LogTargets: []string{"unset", "optin", "disabled"}},
+		},
+	}
+
+	expected := map[string]map[string]*plan.LogTarget{
+		"svc1": {"unset": &unset, "optout": &optout},
+		"svc2": {"unset": &unset, "optout": &optout},
+		"svc3": {"unset": &unset},
+		"svc4": {"optout": &optout},
+		"svc5": {"optin": &optin},
+		"svc6": {},
+		"svc7": {"unset": &unset, "optin": &optin},
+	}
+
+	logbuf, restore := logger.MockLogger("")
+	defer restore()
+
+	planTargets := selectTargets(&input)
+	c.Check(planTargets, DeepEquals, expected)
+	// Check no error messages were logged
+	c.Check(logbuf.Bytes(), HasLen, 0)
+}
+
+func (s *managerSuite) TestLogManager(c *C) {
+	m := NewLogManager()
+	// Fake ringbuffer so that log manager can create forwarders
+	rb := servicelog.RingBuffer{}
+
+	// Call PlanChanged with new plan
+	m.PlanChanged(&plan.Plan{
+		Services: map[string]*plan.Service{
+			"svc1": {},
+			"svc2": {LogTargets: []string{"optin", "disabled"}},
+			"svc3": {LogTargets: []string{"unset"}},
+		},
+		LogTargets: map[string]*plan.LogTarget{
+			"unset":    {Name: "unset", Type: plan.LokiTarget, Selection: plan.UnsetSelection},
+			"optout":   {Name: "optout", Type: plan.LokiTarget, Selection: plan.OptOutSelection},
+			"optin":    {Name: "optin", Type: plan.LokiTarget, Selection: plan.OptInSelection},
+			"disabled": {Name: "disabled", Type: plan.LokiTarget, Selection: plan.DisabledSelection},
+		},
+	})
+
+	// Start 3 services
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Call ServiceStarted
+	go func() {
+		defer wg.Done()
+		m.ServiceStarted("svc1", &rb)
+	}()
+	go func() {
+		defer wg.Done()
+		m.ServiceStarted("svc2", &rb)
+	}()
+	go func() {
+		defer wg.Done()
+		m.ServiceStarted("svc3", &rb)
+	}()
+
+	wg.Wait()
+	c.Check(m.forwarders, HasLen, 4)
+	checkForwarderExists(c, m.forwarders, "svc1", "unset")
+	checkForwarderExists(c, m.forwarders, "svc1", "optout")
+	checkForwarderExists(c, m.forwarders, "svc2", "optin")
+	checkForwarderExists(c, m.forwarders, "svc3", "unset")
+
+	// Update the plan
+	m.PlanChanged(&plan.Plan{
+		Services: map[string]*plan.Service{
+			"svc1": {},
+			"svc2": {LogTargets: []string{"optout", "disabled"}},
+			"svc4": {LogTargets: []string{"optin"}},
+		},
+		LogTargets: map[string]*plan.LogTarget{
+			"unset":    {Name: "unset", Type: plan.LokiTarget, Selection: plan.UnsetSelection},
+			"optout":   {Name: "optout", Type: plan.LokiTarget, Selection: plan.OptOutSelection},
+			"optin":    {Name: "optin", Type: plan.LokiTarget, Selection: plan.OptInSelection},
+			"disabled": {Name: "disabled", Type: plan.LokiTarget, Selection: plan.DisabledSelection},
+		},
+	})
+
+	// Call ServiceStarted
+	m.ServiceStarted("svc4", &rb)
+
+	c.Check(m.forwarders, HasLen, 4)
+	checkForwarderExists(c, m.forwarders, "svc1", "unset")
+	checkForwarderExists(c, m.forwarders, "svc1", "optout")
+	checkForwarderExists(c, m.forwarders, "svc2", "optout")
+	checkForwarderExists(c, m.forwarders, "svc4", "optin")
+}
+
+// checkForwarderExists checks that a forwarder for the given service and
+// target exists in the provided slice of forwarders.
+func checkForwarderExists(c *C, forwarders []*logForwarder, serviceName, targetName string) {
+	for _, f := range forwarders {
+		if f.service == serviceName && f.target.Name == targetName {
+			return
+		}
+	}
+	c.Errorf("no forwarder found with service: %q, target: %q", serviceName, targetName)
+}
+
+func (s *managerSuite) TestNoLogDuplication(c *C) {
+	// Reduce Loki flush time
+	flushDelayOld := flushDelay
+	flushDelay = 1 * time.Microsecond
+	defer func() {
+		flushDelay = flushDelayOld
+	}()
+
+	m := NewLogManager()
+	rb := servicelog.NewRingBuffer(1024)
+
+	// Set up fake "Loki" server
+	requests := make(chan string)
+	srv := newFakeLokiServer(requests)
+	defer srv.Close()
+
+	// Utility functions for this test
+	writeLog := func(timestamp time.Time, logLine string) {
+		_, err := fmt.Fprintf(rb, "%s [svc1] %s\n",
+			timestamp.UTC().Format("2006-01-02T15:04:05.000Z07:00"), logLine)
+		c.Assert(err, IsNil)
+	}
+	expectLogs := func(expected string) {
+		select {
+		case req := <-requests:
+			c.Assert(req, Equals, expected)
+		case <-time.After(10 * time.Millisecond):
+			c.Fatalf("timed out waiting for request %q", expected)
+		}
+	}
+
+	m.PlanChanged(&plan.Plan{
+		Services: map[string]*plan.Service{
+			"svc1": {},
+		},
+		LogTargets: map[string]*plan.LogTarget{
+			"unset": {
+				Type:      plan.LokiTarget,
+				Location:  srv.URL(),
+				Selection: plan.UnsetSelection,
+			},
+		},
+	})
+	m.ServiceStarted("svc1", rb)
+	c.Assert(m.forwarders, HasLen, 1)
+
+	// Write logs
+	writeLog(time.Date(2023, 1, 31, 1, 23, 45, 67890, time.UTC), "log line #1")
+	writeLog(time.Date(2023, 1, 31, 1, 23, 46, 67890, time.UTC), "log line #2")
+	expectLogs(`{"streams":[{"stream":{"pebble_service":"svc1"},"values":[["1675128225000000000","log line #1"],["1675128226000000000","log line #2"]]}]}`)
+
+	// Call PlanChanged again
+	m.PlanChanged(&plan.Plan{
+		Services: map[string]*plan.Service{
+			"svc1": {},
+		},
+		LogTargets: map[string]*plan.LogTarget{
+			"unset": {
+				Type:      plan.LokiTarget,
+				Location:  srv.URL(),
+				Selection: plan.UnsetSelection,
+			},
+		},
+	})
+	c.Check(m.forwarders, HasLen, 1)
+
+	// Write logs
+	writeLog(time.Date(2023, 1, 31, 1, 23, 47, 67890, time.UTC), "log line #3")
+	writeLog(time.Date(2023, 1, 31, 1, 23, 48, 67890, time.UTC), "log line #4")
+	expectLogs(`{"streams":[{"stream":{"pebble_service":"svc1"},"values":[["1675128227000000000","log line #3"],["1675128228000000000","log line #4"]]}]}`)
+}

--- a/internal/overlord/logstate/syslog.go
+++ b/internal/overlord/logstate/syslog.go
@@ -139,8 +139,7 @@ func (c *syslogClient) encodeEntry(entry servicelog.Entry) {
 		c.pid, c.msgid, c.structuredData, entry.Message)
 
 	// Octet framing as per RFC 5425.
-	framed := fmt.Sprintf("%d %s", len(msg), msg)
-	c.data.Write([]byte(framed))
+	_, _ = fmt.Fprintf(&c.data, "%d %s", len(msg), msg)
 }
 
 // Send messages to remote syslog server.

--- a/internal/overlord/logstate/syslog.go
+++ b/internal/overlord/logstate/syslog.go
@@ -122,6 +122,7 @@ func syslogStructuredData(name string, enterpriseNum int, labels map[string]stri
 }
 
 func (c *syslogClient) encodeEntry(entry servicelog.Entry) {
+	// TODO: optimise memory allocations here
 	// format defined by RFC 5424
 	timestamp := entry.Time.Format(time.RFC3339)
 	msg := fmt.Sprintf("<%d>%d %s %s %s %s %s %s %s",

--- a/internal/overlord/logstate/syslog.go
+++ b/internal/overlord/logstate/syslog.go
@@ -146,6 +146,10 @@ func (c *syslogClient) encodeEntry(entry servicelog.Entry) {
 
 // Send messages to remote syslog server.
 func (c *syslogClient) Send(entries []servicelog.Entry) error {
+	if len(entries) == 0 {
+		return nil // no-op
+	}
+
 	err := c.ensureConnected()
 	if err != nil {
 		return err

--- a/internal/overlord/logstate/syslog.go
+++ b/internal/overlord/logstate/syslog.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/canonical/pebble/internal/servicelog"
+)
+
+const (
+	canonicalPrivEnterpriseNum = 28978
+
+	syslogInitialBackoff = 100 * time.Millisecond
+	syslogMaxBackoff     = 10 * time.Second
+)
+
+type syslogClient struct {
+	// metadata
+	version        int
+	host           string
+	msgid          string
+	priority       int
+	pid            string
+	structuredData string // TODO: use this for future log labels
+
+	// connection info
+	conn          net.Conn
+	address       *url.URL
+	waitReconnect time.Duration
+	closed        bool
+
+	data bytes.Buffer
+}
+
+func newSyslogClient(addr string) (*syslogClient, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "-"
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil || u.Host == "" {
+		u, err = url.Parse("//" + addr)
+	}
+	if err != nil {
+		return nil, err
+	} else if u.Scheme != "tcp" && u.Scheme != "udp" && u.Scheme != "" {
+		return nil, fmt.Errorf("invalid syslog server address scheme %q", u.Scheme)
+	}
+	if u.Scheme == "" {
+		u.Scheme = "tcp"
+	}
+
+	return &syslogClient{
+		version:        1, // RFC5424
+		pid:            "-",
+		host:           hostname,
+		msgid:          "-",
+		priority:       priorityVal(FacilityUserLevelMessage, SeverityInformational),
+		structuredData: syslogStructuredData("pebble", canonicalPrivEnterpriseNum, nil),
+		address:        u,
+	}, nil
+}
+
+// Syslog Priority values - see RFC 5424 6.2.1
+const (
+	// Facility values
+	FacilityUserLevelMessage = 1
+
+	// Severity values
+	SeverityInformational = 6
+)
+
+// priorityVal calculates the syslog Priority value (PRIVAL) from the given
+// Facility and Severity values. See RFC 5424, sec 6.2.1 for details.
+func priorityVal(facility, severity int) int {
+	return facility*8 + severity
+}
+
+// syslogStructuredData formats the given labels into a structured data section
+// for a syslog message, according to RFC5424 section 6.
+func syslogStructuredData(name string, enterpriseNum int, labels map[string]string) string {
+	if len(labels) == 0 {
+		return "-"
+	}
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "[%s@%d", name, enterpriseNum)
+	for key, value := range labels {
+		fmt.Fprintf(&buf, " %s=\"", key)
+		// escape the value according to RFC5424 6.3.3
+		for i := 0; i < len(value); i++ {
+			// don't use "for _, c := range value" as we don't want runes
+			c := value[i]
+			if c == '"' || c == '\\' || c == ']' {
+				buf.WriteByte('\\')
+			}
+			buf.WriteByte(c)
+		}
+		buf.WriteByte('"')
+	}
+	buf.WriteByte(']')
+	return buf.String()
+}
+
+func (c *syslogClient) encodeEntry(entry servicelog.Entry) {
+	// format defined by RFC 5424
+	timestamp := entry.Time.Format(time.RFC3339)
+	msg := fmt.Sprintf("<%d>%d %s %s %s %s %s %s %s",
+		c.priority, c.version, timestamp, c.host, entry.Service,
+		c.pid, c.msgid, c.structuredData, entry.Message)
+
+	// Octet framing as per RFC 5425.
+	framed := fmt.Sprintf("%d %s", len(msg), msg)
+	c.data.Write([]byte(framed))
+}
+
+// Send messages to remote syslog server.
+func (c *syslogClient) Send(entries []servicelog.Entry) error {
+	err := c.ensureConnected()
+	if err != nil {
+		return err
+	}
+
+	c.data.Reset()
+	for _, entry := range entries {
+		c.encodeEntry(entry)
+	}
+
+	_, err = io.Copy(c.conn, &c.data)
+	if err != nil {
+		// The connection might be bad. Close and reset it for later reconnection attempt(s).
+		c.conn.Close()
+		c.conn = nil
+	}
+	return err
+}
+
+func (c *syslogClient) ensureConnected() error {
+	if c.conn != nil {
+		return nil
+	} else if c.closed {
+		return fmt.Errorf("write to closed SyslogBackend")
+	}
+
+	if c.waitReconnect > 0 {
+		time.Sleep(c.waitReconnect)
+	}
+
+	conn, err := net.Dial(c.address.Scheme, c.address.Host)
+	if err != nil {
+		// start an exponential backoff for reconnection attempts
+		if c.waitReconnect == 0 {
+			c.waitReconnect = syslogInitialBackoff
+		}
+		newWait := 2 * c.waitReconnect
+		if newWait > syslogMaxBackoff {
+			newWait = syslogMaxBackoff
+		}
+		c.waitReconnect = newWait
+		return err
+	}
+
+	c.waitReconnect = 0 // reset backoff
+	c.conn = conn
+	return nil
+}
+
+func (c *syslogClient) Close() error {
+	c.closed = true
+	if c.conn == nil {
+		return nil
+	}
+
+	err := c.conn.Close()
+	c.conn = nil
+	return err
+}

--- a/internal/overlord/logstate/syslog.go
+++ b/internal/overlord/logstate/syslog.go
@@ -132,7 +132,6 @@ func syslogStructuredData(name string, enterpriseNum int, labels map[string]stri
 }
 
 func (c *syslogClient) encodeEntry(entry servicelog.Entry) {
-	// TODO: optimise memory allocations here
 	// format defined by RFC 5424
 	timestamp := entry.Time.Format(time.RFC3339)
 	msg := fmt.Sprintf("<%d>%d %s %s %s %s %s %s %s",

--- a/internal/overlord/logstate/syslog.go
+++ b/internal/overlord/logstate/syslog.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/canonical/pebble/internal/servicelog"
@@ -104,8 +105,17 @@ func syslogStructuredData(name string, enterpriseNum int, labels map[string]stri
 	}
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "[%s@%d", name, enterpriseNum)
-	for key, value := range labels {
+
+	// Sort label keys to get deterministic output
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		fmt.Fprintf(&buf, " %s=\"", key)
+		value := labels[key]
 		// escape the value according to RFC5424 6.3.3
 		for i := 0; i < len(value); i++ {
 			// don't use "for _, c := range value" as we don't want runes

--- a/internal/overlord/logstate/syslog_test.go
+++ b/internal/overlord/logstate/syslog_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logstate
+
+import (
+	"bufio"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/canonical/pebble/internal/servicelog"
+	. "gopkg.in/check.v1"
+)
+
+type syslogSuite struct{}
+
+var _ = Suite(&syslogSuite{})
+
+func (s *syslogSuite) TestEncodeEntry(c *C) {
+	client := &syslogClient{
+		version:        1,
+		pid:            "-",
+		host:           "mycontainer",
+		msgid:          "-",
+		priority:       priorityVal(FacilityUserLevelMessage, SeverityInformational),
+		structuredData: syslogStructuredData("pebble", canonicalPrivEnterpriseNum, nil),
+	}
+	client.encodeEntry(servicelog.Entry{
+		Time:    time.Date(2021, 5, 26, 12, 37, 1, 0, time.UTC),
+		Service: "foo",
+		Message: "this is a log entry",
+	})
+	c.Check(client.data.String(), Equals, "68 <14>1 2021-05-26T12:37:01Z mycontainer foo - - - this is a log entry")
+}
+
+func (s *syslogSuite) TestEncodeEntryWithStructuredData(c *C) {
+	client := &syslogClient{
+		version:  1,
+		pid:      "-",
+		host:     "mycontainer",
+		msgid:    "-",
+		priority: priorityVal(FacilityUserLevelMessage, SeverityInformational),
+		structuredData: syslogStructuredData("pebble", canonicalPrivEnterpriseNum,
+			map[string]string{
+				"foo": "bar",
+				"baz": "bing",
+			},
+		),
+	}
+	client.encodeEntry(servicelog.Entry{
+		Time:    time.Date(2021, 5, 26, 12, 37, 1, 0, time.UTC),
+		Service: "foo",
+		Message: "this is a log entry",
+	})
+	c.Check(client.data.String(), Equals, `102 <14>1 2021-05-26T12:37:01Z mycontainer foo - - [pebble@28978 foo="bar" baz="bing"] this is a log entry`)
+}
+
+func (s *syslogSuite) TestSyslogClient(c *C) {
+	// Start a fake syslog server
+	ln, err := net.Listen("tcp", "localhost:0") // will select unused port
+	c.Assert(err, IsNil)
+	defer ln.Close()
+
+	messages := make(chan string)
+	srv := &testSyslogServer{
+		listener: ln,
+		messages: messages,
+	}
+
+	serverStopped := make(chan struct{})
+	go func() {
+		err := srv.run()
+		c.Assert(err, IsNil)
+		close(serverStopped)
+	}()
+
+	// Create a syslog client
+	serverAddr := ln.Addr().String()
+	u, err := url.Parse("tcp://" + serverAddr)
+	c.Assert(err, IsNil)
+	client := &syslogClient{
+		version:        1,
+		pid:            "-",
+		host:           "mycontainer",
+		msgid:          "-",
+		priority:       priorityVal(FacilityUserLevelMessage, SeverityInformational),
+		structuredData: syslogStructuredData("pebble", canonicalPrivEnterpriseNum, nil),
+		address:        u,
+	}
+
+	// Send a message to the syslog server
+	entries := []servicelog.Entry{{
+		Time:    time.Date(2023, 1, 31, 1, 23, 45, 0, time.UTC),
+		Service: "foobar",
+		Message: "test message #1",
+	}, {
+		Time:    time.Date(2023, 1, 31, 1, 23, 46, 0, time.UTC),
+		Service: "foobar",
+		Message: "test message #2",
+	}, {
+		Time:    time.Date(2023, 1, 31, 1, 23, 47, 0, time.UTC),
+		Service: "foobar",
+		Message: "test message #3",
+	}}
+	err = client.Send(entries)
+	c.Assert(err, IsNil)
+	err = client.Close()
+	c.Assert(err, IsNil)
+
+	// Check received message
+	select {
+	case msg := <-messages:
+		c.Check(msg, DeepEquals,
+			"67 <14>1 2023-01-31T01:23:45Z mycontainer foobar - - - test message #1"+
+				"67 <14>1 2023-01-31T01:23:46Z mycontainer foobar - - - test message #2"+
+				"67 <14>1 2023-01-31T01:23:47Z mycontainer foobar - - - test message #3",
+		)
+	case <-time.After(1 * time.Second):
+		c.Fatal("timed out waiting for message")
+	}
+
+	// Check server stops correctly
+	err = srv.close()
+	c.Assert(err, IsNil)
+	select {
+	case <-serverStopped:
+	case <-time.After(1 * time.Second):
+		c.Fatal("timed out waiting for syslog server to stop")
+	}
+}
+
+type testSyslogServer struct {
+	listener net.Listener
+	messages chan string
+}
+
+func (s *testSyslogServer) close() error {
+	return s.listener.Close()
+}
+
+func (s *testSyslogServer) run() error {
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		s.messages <- scanner.Text()
+	}
+	return scanner.Err()
+}

--- a/internal/overlord/logstate/syslog_test.go
+++ b/internal/overlord/logstate/syslog_test.go
@@ -55,7 +55,7 @@ func (s *syslogSuite) TestEncodeEntryWithStructuredData(c *C) {
 		structuredData: syslogStructuredData("pebble", canonicalPrivEnterpriseNum,
 			map[string]string{
 				"foo": "bar",
-				"baz": "bing",
+				"goo": "baz",
 			},
 		),
 	}
@@ -64,7 +64,7 @@ func (s *syslogSuite) TestEncodeEntryWithStructuredData(c *C) {
 		Service: "foo",
 		Message: "this is a log entry",
 	})
-	c.Check(client.data.String(), Equals, `102 <14>1 2021-05-26T12:37:01Z mycontainer foo - - [pebble@28978 foo="bar" baz="bing"] this is a log entry`)
+	c.Check(client.data.String(), Equals, `101 <14>1 2021-05-26T12:37:01Z mycontainer foo - - [pebble@28978 foo="bar" goo="baz"] this is a log entry`)
 }
 
 func (s *syslogSuite) TestSyslogClient(c *C) {

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -437,6 +437,9 @@ func (s *serviceData) startInternal() error {
 		}()
 	}
 
+	// Pass buffer reference to logMgr to start log forwarding
+	s.manager.logMgr.ServiceStarted(serviceName, s.logs)
+
 	return nil
 }
 

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -442,6 +442,7 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 		if newConfig, ok := m.plan.Services[name]; ok {
 			// TODO: be more conservative with restarts. Changes to metadata, log
 			// targets, dependencies, etc shouldn't require a restart.
+			// https://github.com/canonical/pebble/pull/165#discussion_r1142800922
 			if newConfig.Equal(s.config) {
 				continue
 			}

--- a/internal/overlord/servstate/manager.go
+++ b/internal/overlord/servstate/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -34,6 +35,12 @@ type ServiceManager struct {
 
 	randLock sync.Mutex
 	rand     *rand.Rand
+
+	logMgr LogManager
+}
+
+type LogManager interface {
+	ServiceStarted(serviceName string, buffer *servicelog.RingBuffer)
 }
 
 // PlanFunc is the type of function used by NotifyPlanChanged.
@@ -53,7 +60,7 @@ func (e *LabelExists) Error() string {
 	return fmt.Sprintf("layer %q already exists", e.Label)
 }
 
-func NewManager(s *state.State, runner *state.TaskRunner, pebbleDir string, serviceOutput io.Writer, restarter Restarter) (*ServiceManager, error) {
+func NewManager(s *state.State, runner *state.TaskRunner, pebbleDir string, serviceOutput io.Writer, restarter Restarter, logMgr LogManager) (*ServiceManager, error) {
 	manager := &ServiceManager{
 		state:         s,
 		runner:        runner,
@@ -62,6 +69,7 @@ func NewManager(s *state.State, runner *state.TaskRunner, pebbleDir string, serv
 		serviceOutput: serviceOutput,
 		restarter:     restarter,
 		rand:          rand.New(rand.NewSource(time.Now().UnixNano())),
+		logMgr:        logMgr,
 	}
 
 	err := reaper.Start()
@@ -155,9 +163,10 @@ func (m *ServiceManager) updatePlanLayers(layers []*plan.Layer) error {
 		return err
 	}
 	p := &plan.Plan{
-		Layers:   layers,
-		Services: combined.Services,
-		Checks:   combined.Checks,
+		Layers:     layers,
+		Services:   combined.Services,
+		Checks:     combined.Checks,
+		LogTargets: combined.LogTargets,
 	}
 	m.updatePlan(p)
 	return nil
@@ -431,11 +440,11 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 	needsRestart := make(map[string]bool)
 	var stop []string
 	for name, s := range m.services {
-		if config, ok := m.plan.Services[name]; ok {
-			if config.Equal(s.config) {
+		if newConfig, ok := m.plan.Services[name]; ok {
+			if !NeedsRestart(s.config, newConfig) {
 				continue
 			}
-			s.config = config.Copy() // update service config from plan
+			s.config = newConfig.Copy() // update service config from plan
 		}
 		needsRestart[name] = true
 		stop = append(stop, name)
@@ -464,6 +473,19 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 	}
 
 	return stop, start, nil
+}
+
+// NeedsRestart compares the old and new config structs for a service, to
+// determine if the service needs to be restarted. For example, a service
+// should not be restarted if only the log targets have changed.
+func NeedsRestart(old, new *plan.Service) bool {
+	// TODO: make this more conservative. Changes to metadata, dependencies,
+	// service actions, etc shouldn't require a restart.
+	oldCopy := old.Copy()
+	oldCopy.LogTargets = nil
+	newCopy := new.Copy()
+	newCopy.LogTargets = nil
+	return !reflect.DeepEqual(oldCopy, newCopy)
 }
 
 func (m *ServiceManager) SendSignal(services []string, signal string) error {

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/canonical/pebble/internal/overlord/servstate"
 	"github.com/canonical/pebble/internal/overlord/state"
 	"github.com/canonical/pebble/internal/plan"
+	"github.com/canonical/pebble/internal/servicelog"
 	"github.com/canonical/pebble/internal/testutil"
 )
 
@@ -168,7 +169,7 @@ func (s *S) SetUpTest(c *C) {
 
 	s.runner = state.NewTaskRunner(s.st)
 	s.stopDaemon = make(chan struct{})
-	manager, err := servstate.NewManager(s.st, s.runner, s.dir, logOutput, testRestarter{s.stopDaemon})
+	manager, err := servstate.NewManager(s.st, s.runner, s.dir, logOutput, testRestarter{s.stopDaemon}, fakeLogManager{})
 	c.Assert(err, IsNil)
 	s.AddCleanup(manager.Stop)
 	s.manager = manager
@@ -657,7 +658,7 @@ func (s *S) TestAppendLayer(c *C) {
 	dir := c.MkDir()
 	os.Mkdir(filepath.Join(dir, "layers"), 0755)
 	runner := state.NewTaskRunner(s.st)
-	manager, err := servstate.NewManager(s.st, runner, dir, nil, nil)
+	manager, err := servstate.NewManager(s.st, runner, dir, nil, nil, fakeLogManager{})
 	c.Assert(err, IsNil)
 	defer manager.Stop()
 
@@ -740,7 +741,7 @@ func (s *S) TestCombineLayer(c *C) {
 	dir := c.MkDir()
 	os.Mkdir(filepath.Join(dir, "layers"), 0755)
 	runner := state.NewTaskRunner(s.st)
-	manager, err := servstate.NewManager(s.st, runner, dir, nil, nil)
+	manager, err := servstate.NewManager(s.st, runner, dir, nil, nil, fakeLogManager{})
 	c.Assert(err, IsNil)
 	defer manager.Stop()
 
@@ -1670,4 +1671,14 @@ func (s *S) TestStopRunningNoServices(c *C) {
 	taskSet, err := servstate.StopRunning(s.st, s.manager)
 	c.Assert(err, IsNil)
 	c.Assert(taskSet, IsNil)
+}
+
+type fakeLogManager struct{}
+
+func (f fakeLogManager) PlanChanged(p *plan.Plan) {
+	// no-op
+}
+
+func (f fakeLogManager) ServiceStarted(serviceName string, buffer *servicelog.RingBuffer) {
+	// no-op
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -698,7 +698,11 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 		}
 
-		// TODO: check that location is nonempty?
+		if target.Location == "" && target.Selection != DisabledSelection {
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`plan must define "location" for log target %q`, name),
+			}
+		}
 	}
 
 	// Validate service log targets

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -204,6 +205,14 @@ func dedupStrings(arr1, arr2 []string) []string {
 	}
 
 	return merged
+}
+
+// Equal returns true when the two services are equal in value.
+func (s *Service) Equal(other *Service) bool {
+	if s == other {
+		return true
+	}
+	return reflect.DeepEqual(s, other)
 }
 
 type ServiceStartup string

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -43,18 +42,20 @@ const (
 )
 
 type Plan struct {
-	Layers   []*Layer            `yaml:"-"`
-	Services map[string]*Service `yaml:"services,omitempty"`
-	Checks   map[string]*Check   `yaml:"checks,omitempty"`
+	Layers     []*Layer              `yaml:"-"`
+	Services   map[string]*Service   `yaml:"services,omitempty"`
+	Checks     map[string]*Check     `yaml:"checks,omitempty"`
+	LogTargets map[string]*LogTarget `yaml:"log-targets,omitempty"`
 }
 
 type Layer struct {
-	Order       int                 `yaml:"-"`
-	Label       string              `yaml:"-"`
-	Summary     string              `yaml:"summary,omitempty"`
-	Description string              `yaml:"description,omitempty"`
-	Services    map[string]*Service `yaml:"services,omitempty"`
-	Checks      map[string]*Check   `yaml:"checks,omitempty"`
+	Order       int                   `yaml:"-"`
+	Label       string                `yaml:"-"`
+	Summary     string                `yaml:"summary,omitempty"`
+	Description string                `yaml:"description,omitempty"`
+	Services    map[string]*Service   `yaml:"services,omitempty"`
+	Checks      map[string]*Check     `yaml:"checks,omitempty"`
+	LogTargets  map[string]*LogTarget `yaml:"log-targets,omitempty"`
 }
 
 type Service struct {
@@ -86,6 +87,9 @@ type Service struct {
 	BackoffFactor  OptionalFloat            `yaml:"backoff-factor,omitempty"`
 	BackoffLimit   OptionalDuration         `yaml:"backoff-limit,omitempty"`
 	KillDelay      OptionalDuration         `yaml:"kill-delay,omitempty"`
+
+	// Log forwarding
+	LogTargets []string `yaml:"log-targets,omitempty"`
 }
 
 // Copy returns a deep copy of the service.
@@ -114,10 +118,11 @@ func (s *Service) Copy() *Service {
 			copied.OnCheckFailure[k] = v
 		}
 	}
+	copied.LogTargets = append([]string(nil), s.LogTargets...)
 	return &copied
 }
 
-// Merge merges the fields set in other into c.
+// Merge merges the fields set in other into s.
 func (s *Service) Merge(other *Service) {
 	if other.Summary != "" {
 		s.Summary = other.Summary
@@ -178,14 +183,7 @@ func (s *Service) Merge(other *Service) {
 	if other.BackoffLimit.IsSet {
 		s.BackoffLimit = other.BackoffLimit
 	}
-}
-
-// Equal returns true when the two services are equal in value.
-func (s *Service) Equal(other *Service) bool {
-	if s == other {
-		return true
-	}
-	return reflect.DeepEqual(s, other)
+	s.LogTargets = append(s.LogTargets, other.LogTargets...)
 }
 
 type ServiceStartup string
@@ -196,7 +194,8 @@ const (
 	StartupDisabled ServiceStartup = "disabled"
 )
 
-// Override specifies the layer override mechanism (for services and checks).
+// Override specifies the layer override mechanism (for services, checks, and
+// log targets).
 type Override string
 
 const (
@@ -404,6 +403,53 @@ func (c *ExecCheck) Merge(other *ExecCheck) {
 	}
 }
 
+// LogTarget specifies a remote server to forward logs to.
+type LogTarget struct {
+	Name      string        `yaml:"-"`
+	Type      LogTargetType `yaml:"type"`
+	Location  string        `yaml:"location"`
+	Selection Selection     `yaml:"selection,omitempty"`
+	Override  Override      `yaml:"override,omitempty"`
+}
+
+// LogTargetType defines the protocol to use to forward logs.
+type LogTargetType string
+
+const (
+	LokiTarget   LogTargetType = "loki"
+	SyslogTarget LogTargetType = "syslog"
+	UnsetTarget  LogTargetType = ""
+)
+
+// Selection describes which services' logs will be forwarded to this target.
+type Selection string
+
+const (
+	OptOutSelection   Selection = "opt-out"
+	OptInSelection    Selection = "opt-in"
+	DisabledSelection Selection = "disabled"
+	UnsetSelection    Selection = ""
+)
+
+// Copy returns a deep copy of the log target configuration.
+func (t *LogTarget) Copy() *LogTarget {
+	copied := *t
+	return &copied
+}
+
+// Merge merges the fields set in other into t.
+func (t *LogTarget) Merge(other *LogTarget) {
+	if other.Type != "" {
+		t.Type = other.Type
+	}
+	if other.Location != "" {
+		t.Location = other.Location
+	}
+	if other.Selection != "" {
+		t.Selection = other.Selection
+	}
+}
+
 // FormatError is the error returned when a layer has a format error, such as
 // a missing "override" field.
 type FormatError struct {
@@ -418,8 +464,9 @@ func (e *FormatError) Error() string {
 // layers overriding earlier ones.
 func CombineLayers(layers ...*Layer) (*Layer, error) {
 	combined := &Layer{
-		Services: make(map[string]*Service),
-		Checks:   make(map[string]*Check),
+		Services:   make(map[string]*Service),
+		Checks:     make(map[string]*Check),
+		LogTargets: make(map[string]*LogTarget),
 	}
 	if len(layers) == 0 {
 		return combined, nil
@@ -478,6 +525,30 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 		}
 
+		for name, target := range layer.LogTargets {
+			switch target.Override {
+			case MergeOverride:
+				if old, ok := combined.LogTargets[name]; ok {
+					copied := old.Copy()
+					copied.Merge(target)
+					combined.LogTargets[name] = copied
+					break
+				}
+				fallthrough
+			case ReplaceOverride:
+				combined.LogTargets[name] = target.Copy()
+			case UnknownOverride:
+				return nil, &FormatError{
+					Message: fmt.Sprintf(`layer %q must define "override" for log target %q`,
+						layer.Label, target.Name),
+				}
+			default:
+				return nil, &FormatError{
+					Message: fmt.Sprintf(`layer %q has invalid "override" value for log target %q`,
+						layer.Label, target.Name),
+				}
+			}
+		}
 	}
 
 	// Ensure fields in combined layers validate correctly (and set defaults).
@@ -601,6 +672,47 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		}
 	}
 
+	for name, target := range combined.LogTargets {
+		switch target.Type {
+		case LokiTarget, SyslogTarget:
+			// valid, continue
+		case UnsetTarget:
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`plan must define "type" (%q or %q) for log target %q`,
+					LokiTarget, SyslogTarget, name),
+			}
+		default:
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
+					name, target.Type, LokiTarget, SyslogTarget),
+			}
+		}
+
+		switch target.Selection {
+		case OptOutSelection, OptInSelection, DisabledSelection, UnsetSelection:
+			// valid, continue
+		default:
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`log target %q has invalid selection %q, must be %q, %q or %q`,
+					name, target.Selection, OptOutSelection, OptInSelection, DisabledSelection),
+			}
+		}
+
+		// TODO: check that location is nonempty?
+	}
+
+	// Validate service log targets
+	for serviceName, service := range combined.Services {
+		for _, targetName := range service.LogTargets {
+			_, ok := combined.LogTargets[targetName]
+			if !ok {
+				return nil, &FormatError{
+					Message: fmt.Sprintf(`unknown log target %q for service %q`, targetName, serviceName),
+				}
+			}
+		}
+	}
+
 	// Ensure combined layers don't have cycles.
 	err := combined.checkCycles()
 	if err != nil {
@@ -711,8 +823,9 @@ func (l *Layer) checkCycles() error {
 
 func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	layer := Layer{
-		Services: map[string]*Service{},
-		Checks:   map[string]*Check{},
+		Services:   map[string]*Service{},
+		Checks:     map[string]*Check{},
+		LogTargets: map[string]*LogTarget{},
 	}
 	dec := yaml.NewDecoder(bytes.NewBuffer(data))
 	dec.KnownFields(true)
@@ -758,6 +871,20 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 			}
 		}
 		check.Name = name
+	}
+
+	for name, target := range layer.LogTargets {
+		if name == "" {
+			return nil, &FormatError{
+				Message: fmt.Sprintf("cannot use empty string as log target name"),
+			}
+		}
+		if target == nil {
+			return nil, &FormatError{
+				Message: fmt.Sprintf("log target object cannot be null for log target %q", name),
+			}
+		}
+		target.Name = name
 	}
 
 	err = layer.checkCycles()
@@ -859,9 +986,10 @@ func ReadDir(dir string) (*Plan, error) {
 		return nil, err
 	}
 	plan := &Plan{
-		Layers:   layers,
-		Services: combined.Services,
-		Checks:   combined.Checks,
+		Layers:     layers,
+		Services:   combined.Services,
+		Checks:     combined.Checks,
+		LogTargets: combined.LogTargets,
 	}
 	return plan, err
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -183,7 +183,27 @@ func (s *Service) Merge(other *Service) {
 	if other.BackoffLimit.IsSet {
 		s.BackoffLimit = other.BackoffLimit
 	}
-	s.LogTargets = append(s.LogTargets, other.LogTargets...)
+	s.LogTargets = dedupStrings(s.LogTargets, other.LogTargets)
+}
+
+// dedupStrings merges arr1 and arr2 with deduplication (removing any duplicate
+// entries in the merged slice).
+func dedupStrings(arr1, arr2 []string) []string {
+	seen := map[string]struct{}{}
+	var merged []string
+
+	for _, s := range arr1 {
+		if _, ok := seen[s]; !ok {
+			merged = append(merged, s)
+		}
+	}
+	for _, s := range arr2 {
+		if _, ok := seen[s]; !ok {
+			merged = append(merged, s)
+		}
+	}
+
+	return merged
 }
 
 type ServiceStartup string
@@ -194,8 +214,7 @@ const (
 	StartupDisabled ServiceStartup = "disabled"
 )
 
-// Override specifies the layer override mechanism (for services, checks, and
-// log targets).
+// Override specifies the layer override mechanism for an object.
 type Override string
 
 const (

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -886,6 +886,7 @@ var planTests = []planTest{{
 				selection: disabled
 			tgt3:
 				type: loki
+				location: http://10.1.77.206:3100/loki/api/v1/push
 				override: merge
 `},
 	layers: []*plan.Layer{{
@@ -956,6 +957,7 @@ var planTests = []planTest{{
 			"tgt3": {
 				Name:     "tgt3",
 				Type:     plan.LokiTarget,
+				Location: "http://10.1.77.206:3100/loki/api/v1/push",
 				Override: plan.MergeOverride,
 			},
 		},
@@ -1001,6 +1003,7 @@ var planTests = []planTest{{
 			"tgt3": {
 				Name:     "tgt3",
 				Type:     plan.LokiTarget,
+				Location: "http://10.1.77.206:3100/loki/api/v1/push",
 				Override: plan.MergeOverride,
 			},
 		},
@@ -1015,6 +1018,14 @@ var planTests = []planTest{{
 				override: merge
 `},
 }, {
+	summary: "Log target location must be specified",
+	error:   `plan must define "location" for log target "tgt1"`,
+	input: []string{`
+		log-targets:
+			tgt1:
+				type: loki
+				override: merge
+`}}, {
 	summary: "Unsupported log target type",
 	error:   `log target "tgt1" has unsupported type "foobar", must be "loki" or "syslog"`,
 	input: []string{`

--- a/internal/servicelog/iterator.go
+++ b/internal/servicelog/iterator.go
@@ -69,6 +69,10 @@ func (it *iterator) Close() error {
 	return nil
 }
 
+// Next returns true if there is more data to read from the RingBuffer.
+// If a non-nil cancel channel is passed in, Next will wait for more data to
+// become available. Sending on this channel, or closing it, will cause Next to
+// return immediately.
 func (it *iterator) Next(cancel <-chan struct{}) bool {
 	if it.rb == nil {
 		return false


### PR DESCRIPTION
This PR enables forwarding of Pebble service logs to remote Loki servers and UDP/TCP syslog receivers, following the spec [here](https://docs.google.com/document/d/12tJFhIbVIlOcblG6l9_u-K5bCib78lojRJ-hdGBxSsw/edit?usp=sharing).

## Design

Each (service, log target) pair has an associated "forwarder", which pulls logs from the service ringbuffer (using the iterators introduced in #29), and sends them to the log target. Each forwarder runs two goroutines:
- an `iterate` goroutine, which pulls logs from the iterator/parser and sends them on a `messages` channel
- a `forward` goroutine, which reads logs from the `messages` channel, buffers them, and flushes periodically to the remote log target (after 100 logs have been buffered, or 1 second after the first write)

The forwarders are controlled by a "log manager", which is notified when a new service starts, or when the plan changes. On a plan change, the log manager tears down all forwarders, and starts new ones as determined by the plan.

## Plan changes

The Pebble layer specification has changed as follows:
- A new top-level section `log-targets`, where users specify the log targets they want Pebble to interact with.
- A new (optional) field `log-targets` in the service spec. This takes a list of names, which are matched against the targets defined in the `log-targets` top-level section.

The default behaviour is to forward all services' logs to all targets. This makes it easy to get started with log forwarding by just defining a new layer with the log targets - no need to change the service definitions.

Users can have more granular control over log forwarding by:
- Setting the optional `selection` field for a log target;
- In the definition for a service, explicitly listing log targets they want to forward this service's logs to.

More details are in the README.

## Other changes

The `plan.Service.Equal` method was being used by the service manager to determine whether or not to restart a service on a replan. However, not all changes to the service config require a service restart. In particular, a change to the new `log-targets` field should **not** invoke a service restart. Hence, we've defined a `servstate.NeedsRestart(old, new *plan.Service)` function, which compares the old and new config structs for a service and determines if the service needs to be restarted. At the moment, `NeedsRestart` only ignores changes to `log-targets` - future work should also ignore changes to e.g. metadata, so we can be more conservative with restarting services.

This was the only use of `plan.Service.Equal`, hence we've also removed that method.

## Future work

- Add support for custom Loki labels ([spec](https://docs.google.com/document/d/1HUHH9OQW-czPxn1mXr6AVjhwRMM-DRYp02ATllFSxjE/edit)).
- Allow configuring the 100 log limit / 1 second timeout in the plan (?).