### PR TITLE
Remove unused "Installation" heading in contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ It resembles well known tools such as _supervisord_, _runit_, or _s6_, in that i
 easily manage non-system processes independently from the system services, but it was
 designed with unique features that help with more specific use cases.
 
-  - [Installation](#installation)
   - [General model](#general-model)
   - [Layer configuration examples](#layer-configuration-examples)
   - [Using Pebble](#using-pebble)


### PR DESCRIPTION
Amends #168 - I made some changes but forgot to remove the "Installation" entry I had added to the table of contents.