### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        go: ['1.17', '1.16', '1.15', '1.14']
+        go: ['1.19', '1.18', '1.17', '1.16', '1.15', '1.14']
 
     name: Go ${{ matrix.go }}
 
@@ -20,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
 
@@ -38,9 +39,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: "1.17"
+        go-version-file: 'go.mod'
 
     - name: Test
       run: |
@@ -61,9 +62,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version-file: 'go.mod'
 
     - name: Ensure no formatting changes
       run: |


### PR DESCRIPTION
- Disable fail-fast for unit tests, so that failing on one version of Go doesn't cancel the tests for all other versions.
- Upgrade actions/setup-go to v3 - as a result, we can now get the Go version from `go.mod`.
- Run unit tests on Go 1.18 and 1.19 as well.