### PR TITLE
Add --dry option to run command

### DIFF
--- a/cmd/pebble/cmd_run.go
+++ b/cmd/pebble/cmd_run.go
@@ -138,11 +138,15 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal) error {
 	if err != nil {
 		return err
 	}
-	if err := d.Init(); err != nil {
+	if err := d.Validate(); err != nil {
 		return err
 	}
 	if rcmd.Dry {
 		return nil
+	}
+
+	if err := d.Init(); err != nil {
+		return err
 	}
 
 	// Run sanity check now, if anything goes wrong with the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -353,10 +353,18 @@ func logit(handler http.Handler) http.Handler {
 	})
 }
 
+// Validate performs the checks needed to ensure that the Pebble daemon can be started.
+func (d *Daemon) Validate() error {
+	if _, err := d.overlord.ServiceManager().Plan(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Init sets up the Daemon's internal workings.
 // Don't call more than once.
 func (d *Daemon) Init() error {
-	if _, err := d.overlord.ServiceManager().Plan(); err != nil {
+	if err := d.Validate(); err != nil {
 		return err
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -94,7 +94,6 @@ type Daemon struct {
 	tomb                tomb.Tomb
 	router              *mux.Router
 	standbyOpinions     *standby.StandbyOpinions
-	dry                 bool
 
 	// set to remember we need to restart the system
 	restartSystem bool
@@ -360,9 +359,6 @@ func (d *Daemon) Init() error {
 	if _, err := d.overlord.ServiceManager().Plan(); err != nil {
 		return err
 	}
-	if d.dry {
-		return nil
-	}
 
 	listenerMap := make(map[string]net.Listener)
 
@@ -463,9 +459,6 @@ func (d *Daemon) initStandbyHandling() {
 }
 
 func (d *Daemon) Start() {
-	if d.dry {
-		return
-	}
 	if d.rebootIsMissing {
 		// we need to schedule and wait for a system restart
 		d.tomb.Kill(nil)
@@ -799,7 +792,6 @@ func New(opts *Options) (*Daemon, error) {
 		normalSocketPath:    opts.SocketPath,
 		untrustedSocketPath: opts.SocketPath + ".untrusted",
 		httpAddress:         opts.HTTPAddress,
-		dry:                 opts.Dry,
 	}
 
 	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -72,8 +72,6 @@ type Options struct {
 	// ServiceOuput is an optional io.Writer for the service log output, if set, all services
 	// log output will be written to the writer.
 	ServiceOutput io.Writer
-
-	Dry bool
 }
 
 // A Daemon listens for requests and routes them to the right command
@@ -355,10 +353,8 @@ func logit(handler http.Handler) http.Handler {
 
 // Validate performs the checks needed to ensure that the Pebble daemon can be started.
 func (d *Daemon) Validate() error {
-	if _, err := d.overlord.ServiceManager().Plan(); err != nil {
-		return err
-	}
-	return nil
+	_, err := d.overlord.ServiceManager().Plan()
+	return err
 }
 
 // Init sets up the Daemon's internal workings.


### PR DESCRIPTION
This option is useful for validating the Pebble layers without having to actually start the Pebble daemon.
Note that, in any case, pebble will exit. If the plan was valid, pebble will exit with an error code of 0; otherwise, with a non-zero exit code.