### PR TITLE
Add boot-firmware command

### DIFF
--- a/cmd/pebble/cmd_boot_firmware.go
+++ b/cmd/pebble/cmd_boot_firmware.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/canonical/pebble/client"
+	. "github.com/canonical/pebble/cmd"
+	"github.com/canonical/pebble/internal/boot"
+	"github.com/canonical/pebble/internal/daemon"
+	"github.com/canonical/pebble/internal/logger"
+	"github.com/canonical/pebble/internal/plan"
+)
+
+type cmdBootFirmware struct {
+	clientMixin
+
+	Force   bool `long:"force"`
+	Verbose bool `short:"v" long:"verbose"`
+}
+
+var bootFirmwareDescs = map[string]string{
+	"force":   `Skip all checks`,
+	"verbose": `Log all output from services to stdout`,
+}
+
+var shortBootFirmwareHelp = `Bootstrap a system with Pebble running as PID 1`
+
+var longBootFirmwareHelp = `
+The boot-firmware command performs checks on the running system, prepares the
+environment to get a working system and starts the Pebble daemon.
+`
+
+func (cmd *cmdBootFirmware) Execute(args []string) error {
+	if len(args) > 1 {
+		return ErrExtraArgs
+	}
+
+	if !cmd.Force {
+		if err := boot.CheckBootstrap(); err != nil {
+			return err
+		}
+	}
+
+	if err := boot.Bootstrap(); err != nil {
+		return err
+	}
+
+	t0 := time.Now().Truncate(time.Millisecond)
+
+	pebbleDir, socketPath := getEnvPaths()
+	if err := os.MkdirAll(pebbleDir, 0755); err != nil {
+		return err
+	}
+	if _, err := plan.ReadDir(pebbleDir); err != nil {
+		return err
+	}
+
+	dopts := daemon.Options{
+		Dir:        pebbleDir,
+		SocketPath: socketPath,
+	}
+	if cmd.Verbose {
+		dopts.ServiceOutput = os.Stdout
+	}
+
+	d, err := daemon.New(&dopts)
+	if err != nil {
+		return err
+	}
+	if err := d.Init(); err != nil {
+		return err
+	}
+
+	d.Version = Version
+	d.Start()
+
+	logger.Debugf("activation done in %v", time.Now().Truncate(time.Millisecond).Sub(t0))
+
+	servopts := client.ServiceOptions{}
+	changeID, err := cmd.client.AutoStart(&servopts)
+	if err != nil {
+		logger.Noticef("Cannot start default services: %v", err)
+	} else {
+		logger.Noticef("Started default services with change %s.", changeID)
+	}
+
+out:
+	for {
+		select {
+		case <-d.Dying():
+			logger.Noticef("Server exiting!")
+			break out
+		}
+	}
+
+	cmd.client.CloseIdleConnections()
+	if err := d.Stop(nil); err != nil {
+		return err
+	}
+
+	if err := syscall.Reboot(syscall.LINUX_REBOOT_CMD_RESTART); err != nil {
+		return fmt.Errorf("cannot reboot: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	addCommand("boot-firmware", shortBootFirmwareHelp, longBootFirmwareHelp, func() flags.Commander { return &cmdBootFirmware{} }, bootFirmwareDescs, nil)
+}

--- a/cmd/pebble/cmd_boot_firmware_test.go
+++ b/cmd/pebble/cmd_boot_firmware_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main_test
+
+import (
+	"gopkg.in/check.v1"
+
+	pebble "github.com/canonical/pebble/cmd/pebble"
+)
+
+func (s *PebbleSuite) TestBootFirmwareExtraArgs(c *check.C) {
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"boot-firmware", "extra", "args"})
+	c.Assert(err, check.Equals, pebble.ErrExtraArgs)
+	c.Assert(rest, check.HasLen, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestBootFirmware(c *check.C) {
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"boot-firmware"})
+	c.Assert(err, check.ErrorMatches, "cannot bootstrap an unsupported platform")
+	c.Assert(rest, check.HasLen, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestBootFirmwareForce(c *check.C) {
+	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"boot-firmware", "--force"})
+	c.Assert(err, check.ErrorMatches, "cannot bootstrap an unsupported platform")
+	c.Assert(rest, check.HasLen, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "")
+}

--- a/cmd/pebble/defaults_common.go
+++ b/cmd/pebble/defaults_common.go
@@ -1,0 +1,23 @@
+//go:build !termus
+// +build !termus
+
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+// defaultPebbleDir is the Pebble directory used if $PEBBLE is not set. It is
+// created by the daemon ("pebble run") if it doesn't exist, and also used by
+// the pebble client.
+const defaultPebbleDir = "/var/lib/pebble/default"

--- a/cmd/pebble/defaults_termus.go
+++ b/cmd/pebble/defaults_termus.go
@@ -1,0 +1,23 @@
+//go:build termus
+// +build termus
+
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+// defaultPebbleDir is the Pebble directory used if $PEBBLE is not set. It is
+// created by the daemon ("pebble run") if it doesn't exist, and also used by
+// the pebble client.
+const defaultPebbleDir = "/termus/var/lib/pebble"

--- a/internal/boot/bootstrap_common.go
+++ b/internal/boot/bootstrap_common.go
@@ -1,0 +1,28 @@
+//go:build !termus
+// +build !termus
+
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package boot
+
+import "errors"
+
+func CheckBootstrap() error {
+	return errors.New("cannot bootstrap an unsupported platform")
+}
+
+func Bootstrap() error {
+	return errors.New("cannot bootstrap an unsupported platform")
+}

--- a/internal/boot/bootstrap_common.go
+++ b/internal/boot/bootstrap_common.go
@@ -19,10 +19,12 @@ package boot
 
 import "errors"
 
+// CheckBootstrap validates the environment to ensure Bootstrap can be called.
 func CheckBootstrap() error {
 	return errors.New("cannot bootstrap an unsupported platform")
 }
 
+// Bootstrap prepares the environment in order to get the system in a working state.
 func Bootstrap() error {
 	return errors.New("cannot bootstrap an unsupported platform")
 }

--- a/internal/boot/bootstrap_common_test.go
+++ b/internal/boot/bootstrap_common_test.go
@@ -1,7 +1,7 @@
 //go:build !termus
 // +build !termus
 
-// Copyright (c) 2022 Canonical Ltd
+// Copyright (c) 2023 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -17,8 +17,25 @@
 
 package boot
 
-import "errors"
+import (
+	"testing"
 
-func FindPartitionByLabel(label string) (error, string) {
-	return errors.New("cannot find partition on unsupported platform"), ""
+	. "gopkg.in/check.v1"
+)
+
+type bootstrapSuite struct{}
+
+var _ = Suite(&bootstrapSuite{})
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+func (s *bootstrapSuite) TestCheckBootstrap(c *C) {
+	err := CheckBootstrap()
+	c.Assert(err, ErrorMatches, "cannot bootstrap an unsupported platform")
+}
+
+func (s *bootstrapSuite) TestBootstrap(c *C) {
+	err := Bootstrap()
+	c.Assert(err, ErrorMatches, "cannot bootstrap an unsupported platform")
 }

--- a/internal/boot/bootstrap_termus.go
+++ b/internal/boot/bootstrap_termus.go
@@ -39,16 +39,18 @@ func mountCommon() error {
 	return nil
 }
 
+// CheckBootstrap validates the environment to ensure Bootstrap can be called.
 func CheckBootstrap() error {
 	if Getpid() != 1 {
-		return errors.New(`must run as PID 1. Use --force to supress this check`)
+		return errors.New(`must run as PID 1. Use --force to suppress this check`)
 	}
 	if v, ok := os.LookupEnv("TERMUS"); !ok || v != "1" {
-		return errors.New(`TERMUS environment variable must be set to 1. Use --force to supress this check`)
+		return errors.New(`TERMUS environment variable must be set to 1. Use --force to suppress this check`)
 	}
 	return nil
 }
 
+// Bootstrap prepares the environment in order to get the system in a working state.
 func Bootstrap() error {
 	if err := mountCommon(); err != nil {
 		return err

--- a/internal/boot/bootstrap_termus.go
+++ b/internal/boot/bootstrap_termus.go
@@ -1,0 +1,57 @@
+//go:build termus
+// +build termus
+
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package boot
+
+import (
+	"errors"
+	"os"
+)
+
+var Getpid = os.Getpid
+
+var commonMounts = []mount{
+	{"procfs", "/proc", "proc", 0, ""},
+	{"devtmpfs", "/dev", "devtmpfs", 0, ""},
+	{"devpts", "/dev/pts", "devpts", 0, ""},
+}
+
+func mountCommon() error {
+	for _, m := range commonMounts {
+		if err := m.mount(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func CheckBootstrap() error {
+	if Getpid() != 1 {
+		return errors.New(`must run as PID 1. Use --force to supress this check`)
+	}
+	if v, ok := os.LookupEnv("TERMUS"); !ok || v != "1" {
+		return errors.New(`TERMUS environment variable must be set to 1. Use --force to supress this check`)
+	}
+	return nil
+}
+
+func Bootstrap() error {
+	if err := mountCommon(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/boot/bootstrap_termus_test.go
+++ b/internal/boot/bootstrap_termus_test.go
@@ -1,0 +1,58 @@
+//go:build termus
+// +build termus
+
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package boot
+
+import (
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type bootstrapSuite struct{}
+
+var _ = Suite(&bootstrapSuite{})
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+func (s *bootstrapSuite) TestCheckBootstrap(c *C) {
+	err := CheckBootstrap()
+	c.Assert(err, ErrorMatches, "must run as PID 1. Use --force to suppress this check")
+}
+
+func (s *bootstrapSuite) TestCheckBootstrapPID1(c *C) {
+	Getpid = func() int { return 1 }
+	err := CheckBootstrap()
+	c.Assert(err, ErrorMatches, "TERMUS environment variable must be set to 1. Use --force to suppress this check")
+}
+
+func (s *bootstrapSuite) TestCheckBootstrapPID1AndEnv(c *C) {
+	Getpid = func() int { return 1 }
+
+	oldTermus := os.Getenv("TERMUS")
+	defer func() { os.Setenv("TERMUS", oldTermus) }()
+	os.Setenv("TERMUS", "1")
+
+	err := CheckBootstrap()
+	c.Assert(err, IsNil)
+}
+
+func (s *bootstrapSuite) TestBootstrap(c *C) {
+	//err := Bootstrap()
+}

--- a/internal/boot/util_common.go
+++ b/internal/boot/util_common.go
@@ -1,0 +1,24 @@
+//go:build !termus
+// +build !termus
+
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package boot
+
+import "errors"
+
+func FindPartitionByLabel(label string) (error, string) {
+	return errors.New("cannot find partition on unsupported platform"), ""
+}

--- a/internal/boot/util_termus.go
+++ b/internal/boot/util_termus.go
@@ -18,10 +18,14 @@
 package boot
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"syscall"
+)
+
+var (
+	MountImpl   = syscall.Mount
+	UnmountImpl = syscall.Unmount
 )
 
 type mount struct {
@@ -36,23 +40,15 @@ func (m *mount) mount() error {
 	if err := os.MkdirAll(m.target, 0644); err != nil {
 		return fmt.Errorf("cannot create directory %q: %w", m.target, err)
 	}
-	if err := syscall.Mount(m.source, m.target, m.fstype, m.flags, m.data); err != nil {
+	if err := MountImpl(m.source, m.target, m.fstype, m.flags, m.data); err != nil {
 		return fmt.Errorf("cannot mount %q: %w", m.source, err)
 	}
 	return nil
 }
 
 func (m *mount) unmount() error {
-	if err := syscall.Unmount(m.target, 0); err != nil {
+	if err := UnmountImpl(m.target, 0); err != nil {
 		return fmt.Errorf("cannot unmount %q: %w", m.target, err)
 	}
 	return nil
-}
-
-func FindPartitionByLabel(label string) (error, string) {
-	switch label {
-	case "esp":
-		return nil, "/dev/sda2"
-	}
-	return errors.New("cannot find partition"), ""
 }

--- a/internal/boot/util_termus.go
+++ b/internal/boot/util_termus.go
@@ -1,0 +1,58 @@
+//go:build termus
+// +build termus
+
+// Copyright (c) 2022 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package boot
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+type mount struct {
+	source string
+	target string
+	fstype string
+	flags  uintptr
+	data   string
+}
+
+func (m *mount) mount() error {
+	if err := os.MkdirAll(m.target, 0644); err != nil {
+		return fmt.Errorf("cannot create directory %q: %w", m.target, err)
+	}
+	if err := syscall.Mount(m.source, m.target, m.fstype, m.flags, m.data); err != nil {
+		return fmt.Errorf("cannot mount %q: %w", m.source, err)
+	}
+	return nil
+}
+
+func (m *mount) unmount() error {
+	if err := syscall.Unmount(m.target, 0); err != nil {
+		return fmt.Errorf("cannot unmount %q: %w", m.target, err)
+	}
+	return nil
+}
+
+func FindPartitionByLabel(label string) (error, string) {
+	switch label {
+	case "esp":
+		return nil, "/dev/sda2"
+	}
+	return errors.New("cannot find partition"), ""
+}

--- a/internal/boot/util_termus_test.go
+++ b/internal/boot/util_termus_test.go
@@ -1,0 +1,80 @@
+//go:build termus
+// +build termus
+
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package boot
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+)
+
+type utilSuite struct{}
+
+var _ = Suite(&utilSuite{})
+
+func buildMountImpl(err error) func(string, string, string, uintptr, string) error {
+	return func(string, string, string, uintptr, string) error {
+		return err
+	}
+}
+
+func buildUnmountImpl(err error) func(string, int) error {
+	return func(string, int) error {
+		return err
+	}
+}
+
+func (s *utilSuite) TestMount(c *C) {
+	oldMountImpl := MountImpl
+	defer func() { MountImpl = oldMountImpl }()
+	MountImpl = buildMountImpl(nil)
+
+	m := &mount{"/dev/nvme0n1p3", "/boot", "ext4", 0, ""}
+	err := m.mount()
+	c.Assert(err, IsNil)
+}
+
+func (s *utilSuite) TestMountFails(c *C) {
+	oldMountImpl := MountImpl
+	defer func() { MountImpl = oldMountImpl }()
+	MountImpl = buildMountImpl(errors.New("cannot foo"))
+
+	m := &mount{"/dev/nvme0n1p3", "/boot", "ext4", 0, ""}
+	err := m.mount()
+	c.Assert(err, ErrorMatches, `cannot mount "/dev/nvme0n1p3": cannot foo`)
+}
+
+func (s *utilSuite) TestUnmount(c *C) {
+	oldUnmountImpl := UnmountImpl
+	defer func() { UnmountImpl = oldUnmountImpl }()
+	UnmountImpl = buildUnmountImpl(nil)
+
+	m := &mount{"/dev/nvme0n1p3", "/boot", "ext4", 0, ""}
+	err := m.unmount()
+	c.Assert(err, IsNil)
+}
+
+func (s *utilSuite) TestUnmountFails(c *C) {
+	oldUnmountImpl := UnmountImpl
+	defer func() { UnmountImpl = oldUnmountImpl }()
+	UnmountImpl = buildUnmountImpl(errors.New("cannot bar"))
+
+	m := &mount{"/dev/nvme0n1p3", "/boot", "ext4", 0, ""}
+	err := m.unmount()
+	c.Assert(err, ErrorMatches, `cannot unmount "/boot": cannot bar`)
+}


### PR DESCRIPTION
This PR adds support for the `boot-firmware` command. Which does some initialization prior to starting the Pebble daemon on Termus.