### PR TITLE
Make CI unit test failures more verbose

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Test and build
       run: |
-        go test -race ./...
+        go test -race ./... -check.vv
         go build ./cmd/pebble
 
   root-tests:


### PR DESCRIPTION
When a go test fails due to a panic() inside a spawned child goroutine, only the
stack trace of the goroutine is provided in the CI logs. This makes it impossible
to infer which test in a suite actually caused the failure.

Make CI tests run with -check.vv to print test entry and progress messages to
add context in the event of a child goroutine panic().

For example, S.TestUserGroup would be shown as:

START: manager_test.go:488: S.TestUserGroup
START: manager_test.go:138: S.SetUpTest
PASS: manager_test.go:138: S.SetUpTest	0.001s
START: manager_test.go:174: S.TearDownTest
PASS: manager_test.go:174: S.TearDownTest	0.000s

In the event of any failures, it would be printed after the start message, allowing us
to pinpoint the test that caused the failure.

Verbose printing is only shown for packages which fail a test.


