### PR TITLE
[JUJU-1887] Introduces service grace periods for shutdown and pebble shut down signals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,11 @@ services:
         after:
             - <other service name>
 
+        # (Optional) The amount of time afforded to this service to handle
+        # SIGTERM and exit gracefully before being force killed.
+        # Default is 5 seconds ("5s").
+        grace-period: <grace-period>
+
         # (Optional) A list of other services in the plan that this service
         # should start before.
         before:

--- a/client/shutdown.go
+++ b/client/shutdown.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+// ShutdownOptions specifies the options struct to use when calling shutdown.
+// Currently no options are available. This struct is left here for future
+// proofing.
+type ShutdownOptions struct {
+}
+
+// Shutdown issues a call to Pebble instructing Pebble to shutdown.
+func (client *Client) Shutdown(opts *ShutdownOptions) error {
+	_, err := client.doSync("POST", "/v1/shutdown", nil, nil, nil, nil)
+	return err
+}

--- a/client/shutdown_test.go
+++ b/client/shutdown_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/client"
+)
+
+func (cs *clientSuite) TestShutdown(c *C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"status": "OK"
+	}`
+	err := cs.cli.Shutdown(&client.ShutdownOptions{})
+	c.Assert(err, IsNil)
+	c.Assert(cs.req.URL.Path, Equals, "/v1/shutdown")
+	c.Assert(cs.req.Method, Equals, "POST")
+}

--- a/internal/daemon/api.go
+++ b/internal/daemon/api.go
@@ -94,6 +94,10 @@ var api = []*Command{{
 	Path:   "/v1/checks",
 	UserOK: true,
 	GET:    v1GetChecks,
+}, {
+	Path:   "/v1/shutdown",
+	UserOK: true,
+	POST:   v1PostShutdown,
 }}
 
 var (

--- a/internal/daemon/api_shutdown.go
+++ b/internal/daemon/api_shutdown.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"net/http"
+)
+
+// v1PostShutdown is a handler for initiating a Pebble shutdown via the daemon.
+func v1PostShutdown(c *Command, r *http.Request, _ *userState) Response {
+	// We call tomb.Kill as calling stop on the daemon will block and create a
+	// dead lock condition between this handler and stop.
+	c.d.tomb.Kill(nil)
+	return SyncResponse(nil)
+}

--- a/internal/daemon/api_shutdown_test.go
+++ b/internal/daemon/api_shutdown_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "gopkg.in/check.v1"
+)
+
+// TestShutdownKillsDaemonTomb checks to make sure that the call to shutdown
+// sets of the necessary events in the daemon to have it shutdown.
+func (s *apiSuite) TestShutdownKillsDaemonTomb(c *C) {
+	daemon := s.daemon(c)
+	shutdownCmd := apiCmd("/v1/shutdown")
+	req, err := http.NewRequest("GET", "/v1/shutdown", nil)
+	c.Assert(err, IsNil)
+	rsp := v1PostShutdown(shutdownCmd, req, nil).(*resp)
+	rec := httptest.NewRecorder()
+	rsp.ServeHTTP(rec, req)
+	c.Assert(rec.Code, Equals, 200)
+	c.Assert(rsp.Status, Equals, 200)
+	c.Assert(rsp.Type, Equals, ResponseTypeSync)
+
+	_, open := <-daemon.tomb.Dying()
+	c.Assert(open, Equals, false)
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -635,10 +635,6 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	return nil
 }
 
-// This is a little more than servstate.killWait (but that isn't and shouldn't
-// be exported, so just duplicate it here).
-const stopRunningTimeout = 5*time.Second + 100*time.Millisecond
-
 // stopRunningServices stops all running services, waiting for a short time
 // for them all to stop.
 func (d *Daemon) stopRunningServices() error {
@@ -664,8 +660,6 @@ func (d *Daemon) stopRunningServices() error {
 	select {
 	case <-chg.Ready():
 		logger.Debugf("All services stopped.")
-	case <-time.After(stopRunningTimeout):
-		return errors.New("timeout stopping running services")
 	}
 	return nil
 }

--- a/internal/overlord/servstate/export_test.go
+++ b/internal/overlord/servstate/export_test.go
@@ -72,11 +72,13 @@ func FakeOkayWait(wait time.Duration) (restore func()) {
 	}
 }
 
-func FakeKillWait(kill, fail time.Duration) (restore func()) {
-	old1, old2 := killWait, failWait
-	killWait, failWait = kill, fail
+// FakeGraceKillWait changes both the defaultGracePeriod and killWaitDuration
+// respectively for testing purposes.
+func FakeGraceKillWait(gracePeriod, killWait time.Duration) (restore func()) {
+	old1, old2 := defaultGracePeriod, killWaitDuration
+	defaultGracePeriod, killWaitDuration = gracePeriod, killWait
 	return func() {
-		killWait, failWait = old1, old2
+		defaultGracePeriod, killWaitDuration = old1, old2
 	}
 }
 

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -79,6 +79,7 @@ type Service struct {
 	Group       string            `yaml:"group,omitempty"`
 
 	// Auto-restart and backoff functionality
+	GracePeriod    OptionalDuration         `yaml:"grace-period,omitempty"`
 	OnSuccess      ServiceAction            `yaml:"on-success,omitempty"`
 	OnFailure      ServiceAction            `yaml:"on-failure,omitempty"`
 	OnCheckFailure map[string]ServiceAction `yaml:"on-check-failure,omitempty"`
@@ -129,6 +130,9 @@ func (s *Service) Merge(other *Service) {
 	}
 	if other.Command != "" {
 		s.Command = other.Command
+	}
+	if other.GracePeriod.IsSet {
+		s.GracePeriod = other.GracePeriod
 	}
 	if other.UserID != nil {
 		userID := *other.UserID

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -92,6 +92,7 @@ var planTests = []planTest{{
 				override: replace
 				summary: Service summary
 				command: cmd arg1 "arg2 arg3"
+				grace-period: 10s
 				startup: enabled
 				after:
 					- srv2
@@ -159,14 +160,15 @@ var planTests = []planTest{{
 		Description: "A simple layer.",
 		Services: map[string]*plan.Service{
 			"srv1": {
-				Name:     "srv1",
-				Summary:  "Service summary",
-				Override: "replace",
-				Command:  `cmd arg1 "arg2 arg3"`,
-				Startup:  plan.StartupEnabled,
-				Before:   []string{"srv3"},
-				After:    []string{"srv2"},
-				Requires: []string{"srv2", "srv3"},
+				Name:        "srv1",
+				Summary:     "Service summary",
+				Override:    "replace",
+				Command:     `cmd arg1 "arg2 arg3"`,
+				GracePeriod: plan.OptionalDuration{Value: time.Second * 10, IsSet: true},
+				Startup:     plan.StartupEnabled,
+				Before:      []string{"srv3"},
+				After:       []string{"srv2"},
+				Requires:    []string{"srv2", "srv3"},
 				Environment: map[string]string{
 					"var1": "val1",
 					"var0": "val0",
@@ -251,14 +253,15 @@ var planTests = []planTest{{
 		Description: "The second layer.",
 		Services: map[string]*plan.Service{
 			"srv1": {
-				Name:     "srv1",
-				Summary:  "Service summary",
-				Override: "replace",
-				Command:  `cmd arg1 "arg2 arg3"`,
-				Startup:  plan.StartupEnabled,
-				After:    []string{"srv2", "srv4"},
-				Before:   []string{"srv3", "srv5"},
-				Requires: []string{"srv2", "srv3"},
+				Name:        "srv1",
+				Summary:     "Service summary",
+				Override:    "replace",
+				Command:     `cmd arg1 "arg2 arg3"`,
+				GracePeriod: plan.OptionalDuration{Value: time.Second * 10, IsSet: true},
+				Startup:     plan.StartupEnabled,
+				After:       []string{"srv2", "srv4"},
+				Before:      []string{"srv3", "srv5"},
+				Requires:    []string{"srv2", "srv3"},
 				Environment: map[string]string{
 					"var1": "val1",
 					"var0": "val0",


### PR DESCRIPTION
- This commit adds a new cmd arg to pebble run that allows the user to specify the behaviour to take place when Pebble receives sigterm. The two supported values are ignore and terminate.

  This change is needed for Kubernetes and Juju to address bug lp1951415. When Kubernetes decides to remove a pod from the cluster to reschedule else where it sends a sigterm to all containers in the pod at once. Having Pebble ignore this sigterm and giving the charm a chance to run it's tear down hooks to completion before the workload under control exits is critical for the day to day operations of the charm.

- The second change in this commit adds a new api endpoint to Pebble called shutdown. If Pebble is ignoring sigterm messages from controlling applications such as Kubernetes then we need a way to signal to Pebble to shutdown.

- Third change is the ability to define a grace period for services and how long they receive to handle SIGTERM and shut down before being killed by Pebble.

This work is being proposed as part of the overall fix in Juju for https://bugs.launchpad.net/juju/+bug/1951415

Testing:

The easiest way to perform manual testing against this change is to create a pebble service definition and run this with `pebble run --sigterm=ignore`. From there you should be able to send term to the process and watch the log output indicate that it is ignoring the signal. `kill -s TERM <pid>`