### PR TITLE
[JUJU-1887] Adds kill delay duration for service shutdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,10 @@ services:
         # half a minute ("30s").
         backoff-limit: <duration>
 
+        # (Optional) The amount of time afforded to this service to handle
+        # SIGTERM and exit gracefully before SIGKILL terminates it forcefully.
+        # Default is 5 seconds ("5s").
+        kill-delay: <duration>
 
 # (Optional) A list of health checks managed by this configuration layer.
 checks:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -635,10 +635,6 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 	return nil
 }
 
-// This is a little more than servstate.killWait (but that isn't and shouldn't
-// be exported, so just duplicate it here).
-const stopRunningTimeout = 5*time.Second + 100*time.Millisecond
-
 // stopRunningServices stops all running services, waiting for a short time
 // for them all to stop.
 func (d *Daemon) stopRunningServices() error {
@@ -664,7 +660,7 @@ func (d *Daemon) stopRunningServices() error {
 	select {
 	case <-chg.Ready():
 		logger.Debugf("All services stopped.")
-	case <-time.After(stopRunningTimeout):
+	case <-time.After(d.overlord.ServiceManager().StopTimeout()):
 		return errors.New("timeout stopping running services")
 	}
 	return nil

--- a/internal/overlord/servstate/export_test.go
+++ b/internal/overlord/servstate/export_test.go
@@ -65,18 +65,20 @@ func (m *ServiceManager) GetJitter(duration time.Duration) time.Duration {
 }
 
 func FakeOkayWait(wait time.Duration) (restore func()) {
-	old := okayWait
-	okayWait = wait
+	old := okayDelay
+	okayDelay = wait
 	return func() {
-		okayWait = old
+		okayDelay = old
 	}
 }
 
-func FakeKillWait(kill, fail time.Duration) (restore func()) {
-	old1, old2 := killWait, failWait
-	killWait, failWait = kill, fail
+// FakeKillFailDelay changes both the killDelayDefault and failDelay
+// respectively for testing purposes.
+func FakeKillFailDelay(newKillDelay, newFailDelay time.Duration) (restore func()) {
+	old1, old2 := killDelayDefault, failDelay
+	killDelayDefault, failDelay = newKillDelay, newFailDelay
 	return func() {
-		killWait, failWait = old1, old2
+		killDelayDefault, failDelay = old1, old2
 	}
 }
 

--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -54,9 +54,18 @@ func TaskServiceRequest(task *state.Task) (*ServiceRequest, error) {
 }
 
 var (
-	okayWait = 1 * time.Second
-	killWait = 5 * time.Second
-	failWait = 10 * time.Second
+	// okayDelay is the time to wait after starting a service before we conclude
+	// that it's running successfully.
+	okayDelay = 1 * time.Second
+
+	// killDelayDefault is the duration afforded to services for processing
+	// SIGTERM signals and shutting down cleanly if the service hasn't specified
+	// their own duration.
+	killDelayDefault = 5 * time.Second
+
+	// failDelay is the duration given to services for shutting down when Pebble
+	// sends a SIGKILL signal.
+	failDelay = 5 * time.Second
 )
 
 const (
@@ -307,7 +316,7 @@ func (s *serviceData) start() error {
 			return err
 		}
 		s.transition(stateStarting)
-		time.AfterFunc(okayWait, func() { logError(s.okayWaitElapsed()) })
+		time.AfterFunc(okayDelay, func() { logError(s.okayWaitElapsed()) })
 
 	default:
 		return fmt.Errorf("cannot start service while %s", s.state)
@@ -592,6 +601,17 @@ func (s *serviceData) sendSignal(signal string) error {
 	return nil
 }
 
+// killDelay reports the duration that this service should be given when being
+// asked to shutdown gracefully before being force terminated. The value
+// returned will either be the services pre configured value or the default
+// kill delay for pebble.
+func (s *serviceData) killDelay() time.Duration {
+	if s.config.KillDelay.IsSet {
+		return s.config.KillDelay.Value
+	}
+	return killDelayDefault
+}
+
 // stop is called to stop a running (or backing off) service.
 func (s *serviceData) stop() error {
 	s.manager.servicesLock.Lock()
@@ -606,7 +626,7 @@ func (s *serviceData) stop() error {
 			logger.Noticef("Cannot send SIGTERM to process: %v", err)
 		}
 		s.transition(stateTerminating)
-		time.AfterFunc(killWait, func() { logError(s.terminateTimeElapsed()) })
+		time.AfterFunc(s.killDelay(), func() { logError(s.terminateTimeElapsed()) })
 
 	case stateBackoff:
 		logger.Noticef("Service %q stopped while waiting for backoff", s.config.Name)
@@ -654,8 +674,9 @@ func (s *serviceData) terminateTimeElapsed() error {
 		if err != nil {
 			logger.Noticef("Cannot send SIGKILL to process: %v", err)
 		}
+
 		s.transitionRestarting(stateKilling, s.restarting)
-		time.AfterFunc(failWait-killWait, func() { logError(s.killTimeElapsed()) })
+		time.AfterFunc(failDelay, func() { logError(s.killTimeElapsed()) })
 
 	default:
 		// Ignore if timer elapsed in any other state.
@@ -732,7 +753,7 @@ func (s *serviceData) checkFailed(action plan.ServiceAction) {
 					logger.Noticef("Cannot send SIGTERM to process: %v", err)
 				}
 				s.transitionRestarting(stateTerminating, true)
-				time.AfterFunc(killWait, func() { logError(s.terminateTimeElapsed()) })
+				time.AfterFunc(s.killDelay(), func() { logError(s.terminateTimeElapsed()) })
 			case stateBackoff:
 				logger.Noticef("Service %q %s action is %q, waiting for current backoff",
 					s.config.Name, onType, action)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -85,6 +85,7 @@ type Service struct {
 	BackoffDelay   OptionalDuration         `yaml:"backoff-delay,omitempty"`
 	BackoffFactor  OptionalFloat            `yaml:"backoff-factor,omitempty"`
 	BackoffLimit   OptionalDuration         `yaml:"backoff-limit,omitempty"`
+	KillDelay      OptionalDuration         `yaml:"kill-delay,omitempty"`
 }
 
 // Copy returns a deep copy of the service.
@@ -129,6 +130,9 @@ func (s *Service) Merge(other *Service) {
 	}
 	if other.Command != "" {
 		s.Command = other.Command
+	}
+	if other.KillDelay.IsSet {
+		s.KillDelay = other.KillDelay
 	}
 	if other.UserID != nil {
 		userID := *other.UserID

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -92,6 +92,7 @@ var planTests = []planTest{{
 				override: replace
 				summary: Service summary
 				command: cmd arg1 "arg2 arg3"
+				kill-delay: 10s
 				startup: enabled
 				after:
 					- srv2
@@ -159,14 +160,15 @@ var planTests = []planTest{{
 		Description: "A simple layer.",
 		Services: map[string]*plan.Service{
 			"srv1": {
-				Name:     "srv1",
-				Summary:  "Service summary",
-				Override: "replace",
-				Command:  `cmd arg1 "arg2 arg3"`,
-				Startup:  plan.StartupEnabled,
-				Before:   []string{"srv3"},
-				After:    []string{"srv2"},
-				Requires: []string{"srv2", "srv3"},
+				Name:      "srv1",
+				Summary:   "Service summary",
+				Override:  "replace",
+				Command:   `cmd arg1 "arg2 arg3"`,
+				KillDelay: plan.OptionalDuration{Value: time.Second * 10, IsSet: true},
+				Startup:   plan.StartupEnabled,
+				Before:    []string{"srv3"},
+				After:     []string{"srv2"},
+				Requires:  []string{"srv2", "srv3"},
 				Environment: map[string]string{
 					"var1": "val1",
 					"var0": "val0",
@@ -251,14 +253,15 @@ var planTests = []planTest{{
 		Description: "The second layer.",
 		Services: map[string]*plan.Service{
 			"srv1": {
-				Name:     "srv1",
-				Summary:  "Service summary",
-				Override: "replace",
-				Command:  `cmd arg1 "arg2 arg3"`,
-				Startup:  plan.StartupEnabled,
-				After:    []string{"srv2", "srv4"},
-				Before:   []string{"srv3", "srv5"},
-				Requires: []string{"srv2", "srv3"},
+				Name:      "srv1",
+				Summary:   "Service summary",
+				Override:  "replace",
+				Command:   `cmd arg1 "arg2 arg3"`,
+				KillDelay: plan.OptionalDuration{Value: time.Second * 10, IsSet: true},
+				Startup:   plan.StartupEnabled,
+				After:     []string{"srv2", "srv4"},
+				Before:    []string{"srv3", "srv5"},
+				Requires:  []string{"srv2", "srv3"},
 				Environment: map[string]string{
 					"var1": "val1",
 					"var0": "val0",


### PR DESCRIPTION
- This change adds a new key to the Pebble service plan spec called kill-delay. This allows the author of a service definition to control the amount of time Pebble allows before sending SIGTERM and SIGKILL to a process.

- This change also increases the default duration afforded to pebble for kill-delay from 5s to 25s.