### PR TITLE
Implement bootloader interface for GRUB

### DIFF
--- a/internal/bootloader/bootloader.go
+++ b/internal/bootloader/bootloader.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bootloader
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Bootloader provides primitives to retain state across boots and handle
+// boot slots.
+type Bootloader interface {
+	// Name returns the bootloader name.
+	Name() string
+
+	// GetBootVars populates the specified variables from the bootloader.
+	// These variables are preserved across reboots.
+	GetBootVars(names ...string) (map[string]string, error)
+
+	// SetBootVars saves a set of variables to be persisted across reboots.
+	SetBootVars(values map[string]string) error
+
+	// Present returns whether the bootloader is currently present on the
+	// system--in other words, whether this bootloader has been installed to
+	// the current system. Implementations should only return non-nil error if
+	// they can positively identify that the bootloader is installed, but there
+	// is actually an error with the installation.
+	Present() (bool, error)
+
+	// GetActiveSlot obtains the label of the currently booted slot.
+	GetActiveSlot() (label string, err error)
+
+	// SetActiveSlot instructs the bootloader to select the slot with the
+	// specified label on the next reboot.
+	SetActiveSlot(label string) error
+
+	// GetStatus obtains the status of the slot with the specified label.
+	// If there is no saved status for the slot, or if the saved status is not
+	// any of Unbootable, Try or Fail, Try will be returned.
+	GetStatus(label string) (Status, error)
+}
+
+// Status represents the conditions in which a boot attempt was made.
+type Status string
+
+const (
+	// Unbootable indicates that the slot cannot be booted from in any case.
+	// For example, this slot might be empty.
+	Unbootable Status = "unbootable"
+
+	// Try indicates that the slot can potentially be booted from.
+	Try Status = "try"
+
+	// Fail indicates that there was a problem preventing a slot from being
+	// booted from.
+	Fail Status = "fail"
+)
+
+// BootloaderMountpoint is the path where the root directory for the current
+// bootloader configuration is mounted on bootstrap.
+const BootloaderMountpoint = "/var/termus/boot"
+
+type BootloaderNewFunc func(rootdir string) Bootloader
+
+var (
+	// bootloaders list all possible bootloaders by their constructor
+	// function.
+	Bootloaders = []BootloaderNewFunc{
+		NewGRUB,
+	}
+)
+
+// Find obtains an instance of the first supported bootloader that is available
+// on the system.
+func Find() (*Bootloader, error) {
+	for _, newBl := range Bootloaders {
+		bl := newBl(BootloaderMountpoint)
+		isPresent, err := bl.Present()
+		if err != nil {
+			return nil, fmt.Errorf("bootloader %q found but not usable: %w", bl.Name(), err)
+		}
+		if isPresent {
+			return &bl, nil
+		}
+	}
+	return nil, errors.New("cannot determine bootloader")
+}

--- a/internal/bootloader/bootloader_test.go
+++ b/internal/bootloader/bootloader_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bootloader_test
+
+import (
+	"errors"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/bootloader"
+)
+
+type mockBootloader struct {
+	name string
+
+	bootVars         map[string]string
+	getBootVarsError error
+	setBootVarsError error
+
+	isPresent    bool
+	presentError error
+
+	activeSlot         string
+	getActiveSlotError error
+	setActiveSlotError error
+
+	getStatusError error
+	statuses       map[string]bootloader.Status
+}
+
+func (b *mockBootloader) Name() string {
+	return b.name
+}
+
+func (b *mockBootloader) GetBootVars(names ...string) (map[string]string, error) {
+	if b.getBootVarsError != nil {
+		return nil, b.getBootVarsError
+	}
+	var vars map[string]string
+	for _, name := range names {
+		vars[name] = b.bootVars[name]
+	}
+	return vars, nil
+}
+
+func (b *mockBootloader) SetBootVars(values map[string]string) error {
+	if b.setBootVarsError != nil {
+		return b.setBootVarsError
+	}
+	for name, value := range values {
+		b.bootVars[name] = value
+	}
+	return nil
+}
+
+func (b *mockBootloader) Present() (bool, error) {
+	if b.presentError != nil {
+		return false, b.presentError
+	}
+	return b.isPresent, nil
+}
+
+func (b *mockBootloader) GetActiveSlot() (string, error) {
+	if b.getActiveSlotError != nil {
+		return "", b.getActiveSlotError
+	}
+	return b.activeSlot, nil
+}
+
+func (b *mockBootloader) SetActiveSlot(label string) error {
+	if b.setActiveSlotError != nil {
+		return b.setActiveSlotError
+	}
+	b.activeSlot = label
+	return nil
+}
+
+func (b *mockBootloader) GetStatus(label string) (bootloader.Status, error) {
+	if b.getStatusError != nil {
+		return "", b.getStatusError
+	}
+	return b.statuses[label], nil
+}
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&bootloaderSuite{})
+
+type bootloaderSuite struct {
+	b                 *mockBootloader
+	newMockBootloader bootloader.BootloaderNewFunc
+
+	oldBootloaders []bootloader.BootloaderNewFunc
+}
+
+func (s *bootloaderSuite) SetUpTest(c *C) {
+	s.b = &mockBootloader{name: "mock"}
+	s.newMockBootloader = func(string) bootloader.Bootloader {
+		return s.b
+	}
+
+	s.oldBootloaders = bootloader.Bootloaders
+	bootloader.Bootloaders = append(bootloader.Bootloaders, s.newMockBootloader)
+}
+
+func (s *bootloaderSuite) TearDownTest(c *C) {
+	bootloader.Bootloaders = s.oldBootloaders
+}
+
+func (s *bootloaderSuite) TestFind(c *C) {
+	s.b.isPresent = true
+	b, err := bootloader.Find()
+	c.Assert(err, IsNil)
+	c.Assert(*b, DeepEquals, s.b)
+}
+
+func (s *bootloaderSuite) TestFindFailsNotPresent(c *C) {
+	s.b.isPresent = false
+	_, err := bootloader.Find()
+	c.Assert(err, ErrorMatches, "cannot determine bootloader")
+}
+
+func (s *bootloaderSuite) TestFindFailsPresentError(c *C) {
+	s.b.presentError = errors.New("foobar")
+	_, err := bootloader.Find()
+	c.Assert(err, ErrorMatches, `bootloader "mock" found but not usable: foobar`)
+}

--- a/internal/bootloader/grub.go
+++ b/internal/bootloader/grub.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bootloader
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/pebble/internal/bootloader/grubenv"
+	"github.com/canonical/pebble/internal/osutil"
+)
+
+// GRUB implements the Bootloader interface to support bootloader operations
+// on GRUB 2.
+type GRUB struct {
+	// rootdir is the directory where the GRUB prefix is mounted.
+	rootdir string
+}
+
+// newGrub initializes a new instance of the GRUB bootloader.
+func NewGRUB(rootdir string) Bootloader {
+	return &GRUB{
+		rootdir: rootdir,
+	}
+}
+
+func (g *GRUB) envFile() string {
+	return filepath.Join(g.rootdir, "grubenv")
+}
+
+func (g *GRUB) Name() string {
+	return "grub"
+}
+
+func (g *GRUB) GetBootVars(names ...string) (map[string]string, error) {
+	out := make(map[string]string)
+
+	env := grubenv.NewEnv(g.envFile())
+	if err := env.Load(); err != nil {
+		return nil, err
+	}
+
+	for _, name := range names {
+		out[name] = env.Get(name)
+	}
+
+	return out, nil
+}
+
+func (g *GRUB) SetBootVars(values map[string]string) error {
+	env := grubenv.NewEnv(g.envFile())
+	if err := env.Load(); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for k, v := range values {
+		env.Set(k, v)
+	}
+	return env.Save()
+}
+
+func (g *GRUB) Present() (bool, error) {
+	doesExist, _, err := osutil.ExistsIsDir(filepath.Join(g.rootdir, "grub.cfg"))
+	return doesExist, err
+}
+
+func (g *GRUB) GetActiveSlot() (string, error) {
+	vars, err := g.GetBootVars("boot.slot")
+	if err != nil {
+		return "", err
+	}
+	return vars["boot.slot"], nil
+}
+
+func (g *GRUB) SetActiveSlot(label string) error {
+	return g.SetBootVars(map[string]string{
+		"boot.slot": label,
+	})
+}
+
+func (g *GRUB) GetStatus(label string) (Status, error) {
+	varName := "boot." + label + ".status"
+	vars, err := g.GetBootVars(varName)
+	if err != nil {
+		return "", err
+	}
+	s := Status(vars[varName])
+	switch s {
+	case Unbootable, Try, Fail:
+		return s, nil
+	}
+	return Try, nil
+}

--- a/internal/bootloader/grub_test.go
+++ b/internal/bootloader/grub_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bootloader_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/bootloader"
+	"github.com/canonical/pebble/internal/bootloader/grubenv"
+)
+
+var _ = Suite(&grubSuite{})
+
+type grubSuite struct {
+	b bootloader.Bootloader
+
+	rootdir string
+	envFile string
+	cfgFile string
+}
+
+func (s *grubSuite) SetUpTest(c *C) {
+	s.rootdir = c.MkDir()
+	s.b = bootloader.NewGRUB(s.rootdir)
+
+	s.envFile = filepath.Join(s.rootdir, "grubenv")
+	s.cfgFile = filepath.Join(s.rootdir, "grub.cfg")
+
+	env := grubenv.NewEnv(s.envFile)
+	env.Set("my_var", "42")
+	env.Set("my_other_var", "foo")
+	err := env.Save()
+	c.Assert(err, IsNil)
+
+	_, err = os.Create(s.cfgFile)
+	c.Assert(err, IsNil)
+}
+
+func (s *grubSuite) TestName(c *C) {
+	c.Assert(s.b.Name(), Equals, "grub")
+}
+
+func (s *grubSuite) TestGetBootVars(c *C) {
+	vars, err := s.b.GetBootVars("my_var", "my_other_var")
+	c.Assert(err, IsNil)
+	c.Assert(vars, DeepEquals, map[string]string{
+		"my_var":       "42",
+		"my_other_var": "foo",
+	})
+}
+
+func (s *grubSuite) TestGetBootVarsFails(c *C) {
+	newEnvFile := s.envFile + "bak"
+	err := os.Rename(s.envFile, newEnvFile)
+	c.Assert(err, IsNil)
+	defer os.Rename(newEnvFile, s.envFile)
+
+	vars, err := s.b.GetBootVars("my_var", "my_other_var")
+	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(vars, IsNil)
+}
+
+func (s *grubSuite) TestSetBootVars(c *C) {
+	err := s.b.SetBootVars(map[string]string{
+		"my_var":     "43",
+		"my_new_var": "bar",
+	})
+	c.Assert(err, IsNil)
+
+	vars, err := s.b.GetBootVars("my_var", "my_other_var", "my_new_var")
+	c.Assert(err, IsNil)
+	c.Assert(vars, DeepEquals, map[string]string{
+		"my_var":       "43",
+		"my_other_var": "foo",
+		"my_new_var":   "bar",
+	})
+}
+
+func (s *grubSuite) TestSetBootVarsNotExist(c *C) {
+	os.Remove(s.envFile)
+	err := s.b.SetBootVars(map[string]string{
+		"my_var":     "43",
+		"my_new_var": "bar",
+	})
+	c.Assert(err, IsNil)
+
+	vars, err := s.b.GetBootVars("my_var", "my_other_var", "my_new_var")
+	c.Assert(err, IsNil)
+	c.Assert(vars, DeepEquals, map[string]string{
+		"my_var":       "43",
+		"my_other_var": "",
+		"my_new_var":   "bar",
+	})
+}
+
+func (s *grubSuite) TestSetBootVarsFails(c *C) {
+	err := os.Chmod(s.envFile, os.FileMode(0o400))
+	c.Assert(err, IsNil)
+	defer os.Chmod(s.envFile, os.FileMode(0o644))
+
+	err = s.b.SetBootVars(map[string]string{
+		"my_var":     "43",
+		"my_new_var": "bar",
+	})
+	c.Assert(os.IsPermission(err), Equals, true)
+}
+
+func (s *grubSuite) TestPresent(c *C) {
+	isPresent, err := s.b.Present()
+	c.Assert(isPresent, Equals, true)
+	c.Assert(err, IsNil)
+}
+
+func (s *grubSuite) TestNotPresent(c *C) {
+	newCfgFile := s.cfgFile + "bak"
+	os.Rename(s.cfgFile, newCfgFile)
+	defer os.Rename(newCfgFile, s.cfgFile)
+
+	isPresent, err := s.b.Present()
+	c.Assert(isPresent, Equals, false)
+	c.Assert(err, IsNil)
+}
+
+func (s *grubSuite) TestPresentFails(c *C) {
+	err := os.Chmod(s.rootdir, os.FileMode(0o000))
+	c.Assert(err, IsNil)
+	defer os.Chmod(s.rootdir, os.FileMode(0o644))
+
+	isPresent, err := s.b.Present()
+	c.Assert(isPresent, Equals, false)
+	c.Assert(os.IsPermission(err), Equals, true)
+}
+
+func (s *grubSuite) TestGetActiveSlot(c *C) {
+	slot, err := s.b.GetActiveSlot()
+	c.Assert(slot, Equals, "")
+	c.Assert(err, IsNil)
+
+	err = s.b.SetBootVars(map[string]string{
+		"boot.slot": "a",
+	})
+	slot, err = s.b.GetActiveSlot()
+	c.Assert(slot, Equals, "a")
+	c.Assert(err, IsNil)
+}
+
+func (s *grubSuite) TestGetActiveSlotFails(c *C) {
+	newEnvFile := s.envFile + "bak"
+	err := os.Rename(s.envFile, newEnvFile)
+	c.Assert(err, IsNil)
+	defer os.Rename(newEnvFile, s.envFile)
+
+	slot, err := s.b.GetActiveSlot()
+	c.Assert(slot, Equals, "")
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (s *grubSuite) TestSetActiveSlot(c *C) {
+	err := s.b.SetActiveSlot("x")
+	c.Assert(err, IsNil)
+	slot, err := s.b.GetActiveSlot()
+	c.Assert(err, IsNil)
+	c.Assert(slot, Equals, "x")
+}
+
+func (s *grubSuite) TestSetActiveSlotFails(c *C) {
+	err := os.Chmod(s.envFile, os.FileMode(0o400))
+	c.Assert(err, IsNil)
+	defer os.Chmod(s.envFile, os.FileMode(0o644))
+
+	err = s.b.SetActiveSlot("x")
+	c.Assert(os.IsPermission(err), Equals, true)
+}
+
+func (s *grubSuite) TestGetStatusUndefined(c *C) {
+	st, err := s.b.GetStatus("a")
+	c.Assert(err, IsNil)
+	c.Assert(st, Equals, bootloader.Try)
+}
+
+func (s *grubSuite) TestGetStatus(c *C) {
+	err := s.b.SetBootVars(map[string]string{"boot.b.status": "unbootable"})
+	st, err := s.b.GetStatus("b")
+	c.Assert(err, IsNil)
+	c.Assert(st, Equals, bootloader.Unbootable)
+}

--- a/internal/bootloader/grubenv/grubenv.go
+++ b/internal/bootloader/grubenv/grubenv.go
@@ -1,0 +1,117 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package grubenv
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/canonical/x-go/strutil"
+)
+
+// FIXME: support for escaping (embedded \n in grubenv) missing
+type Env struct {
+	env      map[string]string
+	ordering []string
+
+	path string
+}
+
+func NewEnv(path string) *Env {
+	return &Env{
+		env:  make(map[string]string),
+		path: path,
+	}
+}
+
+func (g *Env) Get(name string) string {
+	return g.env[name]
+}
+
+func (g *Env) Set(key, value string) {
+	if !strutil.ListContains(g.ordering, key) {
+		g.ordering = append(g.ordering, key)
+	}
+
+	g.env[key] = value
+}
+
+func (g *Env) Load() error {
+	buf, err := ioutil.ReadFile(g.path)
+	if err != nil {
+		return err
+	}
+	if len(buf) != 1024 {
+		return fmt.Errorf("grubenv %q must be exactly 1024 byte, got %d", g.path, len(buf))
+	}
+	if !bytes.HasPrefix(buf, []byte("# GRUB Environment Block\n")) {
+		return fmt.Errorf("cannot find grubenv header in %q", g.path)
+	}
+	rawEnv := bytes.Split(buf, []byte("\n"))
+	for _, env := range rawEnv[1:] {
+		l := bytes.SplitN(env, []byte("="), 2)
+		// be liberal in what you accept
+		if len(l) < 2 {
+			continue
+		}
+		k := string(l[0])
+		v := string(l[1])
+		g.env[k] = v
+		g.ordering = append(g.ordering, k)
+	}
+
+	return nil
+}
+
+func (g *Env) Save() error {
+	w := bytes.NewBuffer(nil)
+	w.Grow(1024)
+
+	fmt.Fprintf(w, "# GRUB Environment Block\n")
+	for _, k := range g.ordering {
+		if _, err := fmt.Fprintf(w, "%s=%s\n", k, g.env[k]); err != nil {
+			return err
+		}
+	}
+	if w.Len() > 1024 {
+		return fmt.Errorf("cannot write grubenv %q: bigger than 1024 bytes (%d)", g.path, w.Len())
+	}
+	content := w.Bytes()[:w.Cap()]
+	for i := w.Len(); i < len(content); i++ {
+		content[i] = '#'
+	}
+
+	// write in place to avoid the file moving on disk
+	// (thats what grubenv is also doing)
+	f, err := os.Create(g.path)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(content); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	return f.Close()
+}

--- a/internal/bootloader/grubenv/grubenv_test.go
+++ b/internal/bootloader/grubenv/grubenv_test.go
@@ -1,0 +1,92 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2014-2015 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package grubenv_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/bootloader/grubenv"
+	"github.com/canonical/pebble/internal/testutil"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type grubenvTestSuite struct {
+	envPath string
+}
+
+var _ = Suite(&grubenvTestSuite{})
+
+func (g *grubenvTestSuite) SetUpTest(c *C) {
+	g.envPath = filepath.Join(c.MkDir(), "grubenv")
+}
+
+func (g *grubenvTestSuite) TestSet(c *C) {
+	env := grubenv.NewEnv(g.envPath)
+	c.Check(env, NotNil)
+
+	env.Set("key", "value")
+	c.Check(env.Get("key"), Equals, "value")
+}
+
+func (g *grubenvTestSuite) TestSave(c *C) {
+	env := grubenv.NewEnv(g.envPath)
+	c.Check(env, NotNil)
+
+	env.Set("key1", "value1")
+	env.Set("key2", "value2")
+	env.Set("key3", "value3")
+	env.Set("key4", "value4")
+	env.Set("key5", "value5")
+	env.Set("key6", "value6")
+	env.Set("key7", "value7")
+	// set "key1" again, ordering (position) does not change
+	env.Set("key1", "value1")
+
+	err := env.Save()
+	c.Assert(err, IsNil)
+
+	c.Assert(g.envPath, testutil.FileEquals, `# GRUB Environment Block
+key1=value1
+key2=value2
+key3=value3
+key4=value4
+key5=value5
+key6=value6
+key7=value7
+###################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################################`)
+}
+
+func (g *grubenvTestSuite) TestSaveOverflow(c *C) {
+	env := grubenv.NewEnv(g.envPath)
+	c.Check(env, NotNil)
+
+	for i := 0; i < 101; i++ {
+		env.Set(fmt.Sprintf("key%d", i), "foo")
+	}
+
+	err := env.Save()
+	c.Assert(err, ErrorMatches, `cannot write grubenv .*: bigger than 1024 bytes \(1026\)`)
+}


### PR DESCRIPTION
This commits implements the new bootloader interface for GRUB.
For simplicity, slot functionality has been integrated into one interface but we might split it into two interfaces so that the `Bootloader` interface remains compatible with the snapd one.