### PR TITLE
Changes service status on success ignore.

### DIFF
--- a/internal/overlord/servstate/handlers.go
+++ b/internal/overlord/servstate/handlers.go
@@ -469,6 +469,11 @@ func (s *serviceData) exited(exitCode int) error {
 		switch action {
 		case plan.ActionIgnore:
 			logger.Noticef("Service %q %s action is %q, not doing anything further", s.config.Name, onType, action)
+			// On success we transition to state stopped.
+			if exitCode == 0 {
+				s.transition(stateStopped)
+				break
+			}
 			s.transition(stateExited)
 
 		case plan.ActionShutdown:

--- a/internal/overlord/servstate/manager_test.go
+++ b/internal/overlord/servstate/manager_test.go
@@ -1356,7 +1356,7 @@ services:
 
 	// Wait till it terminates.
 	s.waitUntilService(c, "test2", func(svc *servstate.ServiceInfo) bool {
-		return svc.Current == servstate.StatusError
+		return svc.Current == servstate.StatusInactive
 	})
 }
 
@@ -1528,7 +1528,7 @@ services:
 
 	// Wait till the main process terminates
 	s.waitUntilService(c, "test2", func(svc *servstate.ServiceInfo) bool {
-		return svc.Current == servstate.StatusError
+		return svc.Current == servstate.StatusInactive
 	})
 
 	// Wait till the zombie has been reaped (no longer in the process table)


### PR DESCRIPTION
When a service under Pebble's control exits with code 0 and has it's OnSuccess service key configured to ignore Pebble set's the services state to one of error.

This change configures this logic so that when a service layer specifies ignoring a service that has exited with a code of 0 it is now placed into an inactive state.

For this PR I have not enabled any new tests instead modified the ones we have that were already checking this condition.