### PR TITLE
Add `osutil.Mount()` and `osutil.Unmount()`

### DIFF
--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -111,3 +111,21 @@ func FakeSyscallGetpgid(f func(int) (int, error)) (restore func()) {
 		syscallGetpgid = oldSyscallGetpgid
 	}
 }
+
+func FakeSyscallSync(f func()) (restore func()) {
+	oldSyscallSync := syscallSync
+	syscallSync = f
+	return func() { syscallSync = oldSyscallSync }
+}
+
+func FakeSyscallMount(f func(source, target, fstype string, flags uintptr, data string) error) (restore func()) {
+	oldSyscallMount := syscallMount
+	syscallMount = f
+	return func() { syscallMount = oldSyscallMount }
+}
+
+func FakeSyscallUnmount(f func(target string, flags int) error) (restore func()) {
+	oldSyscallUnmount := syscallUnmount
+	syscallUnmount = f
+	return func() { syscallUnmount = oldSyscallUnmount }
+}

--- a/internal/osutil/mount_linux.go
+++ b/internal/osutil/mount_linux.go
@@ -30,7 +30,7 @@ var (
 	syscallUnmount = unix.Unmount
 )
 
-// MountOptions has all the options that can be passed to Mount()
+// MountOptions holds the options that can be passed to Mount.
 type MountOptions struct {
 	// Source is the device node to be mounted.
 	Source string
@@ -69,9 +69,9 @@ func IsMounted(baseDir string) (bool, error) {
 	return false, nil
 }
 
-// Mount attaches a filesystem accessible via the device node specified by the source
-// to the specified target. If not existing, target will be created before
-// mounting the filesystem.
+// Mount attaches a filesystem accessible via the device node specified by the
+// source to the specified target. If target doesn't exist, it will be created
+// before mounting the filesystem.
 func Mount(opts *MountOptions) error {
 	if err := os.MkdirAll(opts.Target, 0755); err != nil {
 		return fmt.Errorf("cannot create directory %q: %w", opts.Target, err)

--- a/internal/osutil/mount_linux.go
+++ b/internal/osutil/mount_linux.go
@@ -57,7 +57,7 @@ func Mount(source, baseDir, fstype string, readOnly bool) error {
 		flags |= unix.MS_RDONLY
 	}
 	if err := syscallMount(source, baseDir, fstype, flags, ""); err != nil {
-		return fmt.Errorf("cannot mount %q: %w", source, err)
+		return err
 	}
 	return nil
 }
@@ -66,7 +66,7 @@ func Mount(source, baseDir, fstype string, readOnly bool) error {
 func Unmount(baseDir string) error {
 	syscallSync()
 	if err := syscallUnmount(baseDir, 0); err != nil {
-		return fmt.Errorf("cannot unmount %q: %w", baseDir, err)
+		return err
 	}
 	return nil
 }

--- a/internal/osutil/mount_linux_test.go
+++ b/internal/osutil/mount_linux_test.go
@@ -16,10 +16,12 @@ package osutil_test
 
 import (
 	"errors"
-	"golang.org/x/sys/unix"
-	. "gopkg.in/check.v1"
 	"os"
 	"path"
+
+	. "gopkg.in/check.v1"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/canonical/pebble/internal/osutil"
 )

--- a/internal/osutil/mount_linux_test.go
+++ b/internal/osutil/mount_linux_test.go
@@ -110,7 +110,7 @@ func (s *mountSuite) TestMountFailsOnSyscall(c *C) {
 		return errors.New("cannot foo")
 	})()
 	err := osutil.Mount("/dev/whatever", c.MkDir(), "ext4", false)
-	c.Assert(err, ErrorMatches, `cannot mount "/dev/whatever": cannot foo`)
+	c.Assert(err, ErrorMatches, `cannot foo`)
 }
 
 func (s *mountSuite) TestMountFailsOnMkDir(c *C) {
@@ -144,5 +144,5 @@ func (s *mountSuite) TestUnmountFails(c *C) {
 		return errors.New("cannot bar")
 	})()
 	err := osutil.Unmount(mountpoint)
-	c.Assert(err, ErrorMatches, `cannot unmount .*: cannot bar`)
+	c.Assert(err, ErrorMatches, `cannot bar`)
 }

--- a/internal/osutil/mount_linux_test.go
+++ b/internal/osutil/mount_linux_test.go
@@ -15,7 +15,11 @@
 package osutil_test
 
 import (
+	"errors"
+	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
+	"os"
+	"path"
 
 	"github.com/canonical/pebble/internal/osutil"
 )
@@ -55,4 +59,88 @@ func (s *mountSuite) TestIsMountedBroken(c *C) {
 	mounted, err := osutil.IsMounted("/snap/ubuntu-core/855")
 	c.Check(err, ErrorMatches, "incorrect number of fields, .*")
 	c.Check(mounted, Equals, false)
+}
+
+func (s *mountSuite) TestMount(c *C) {
+	devNode := "/dev/nvme0n1p3"
+	mountpoint := path.Join(c.MkDir(), "test", "mountpoint")
+	fsType := "btrfs"
+
+	defer osutil.FakeSyscallMount(func(source, target, fstype string, flags uintptr, data string) error {
+		c.Assert(source, Equals, devNode)
+		c.Assert(target, Equals, mountpoint)
+		c.Assert(fstype, Equals, fsType)
+		c.Assert(flags, Equals, uintptr(0))
+		c.Assert(data, Equals, "")
+		return nil
+	})()
+
+	err := osutil.Mount(devNode, mountpoint, fsType, false)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.IsDir(mountpoint), Equals, true)
+
+	info, err := os.Stat(mountpoint)
+	c.Assert(err, IsNil)
+	c.Assert(info.Mode()&os.ModePerm, Equals, os.FileMode(0755))
+}
+
+func (s *mountSuite) TestMountReadOnly(c *C) {
+	devNode := "/dev/nvme0n1p3"
+	mountpoint := path.Join(c.MkDir(), "test", "ro", "mountpoint")
+	fsType := "btrfs"
+
+	defer osutil.FakeSyscallMount(func(source, target, fstype string, flags uintptr, data string) error {
+		c.Assert(source, Equals, devNode)
+		c.Assert(target, Equals, mountpoint)
+		c.Assert(fstype, Equals, fsType)
+		c.Assert(flags, Equals, uintptr(unix.MS_RDONLY))
+		c.Assert(data, Equals, "")
+		return nil
+	})()
+
+	err := osutil.Mount(devNode, mountpoint, fsType, true)
+	c.Assert(err, IsNil)
+	c.Assert(osutil.IsDir(mountpoint), Equals, true)
+}
+
+func (s *mountSuite) TestMountFailsOnSyscall(c *C) {
+	defer osutil.FakeSyscallMount(func(source, target, fstype string, flags uintptr, data string) error {
+		return errors.New("cannot foo")
+	})()
+	err := osutil.Mount("/dev/whatever", c.MkDir(), "ext4", false)
+	c.Assert(err, ErrorMatches, `cannot mount "/dev/whatever": cannot foo`)
+}
+
+func (s *mountSuite) TestMountFailsOnMkDir(c *C) {
+	root := c.MkDir()
+	mountpoint := path.Join(root, "test", "mountpoint")
+
+	err := os.Chmod(root, 0400)
+	c.Assert(err, IsNil)
+
+	err = osutil.Mount("/dev/whatever", mountpoint, "ext4", false)
+	c.Assert(err, ErrorMatches, `cannot create directory .*: .*permission denied`)
+}
+
+func (s *mountSuite) TestUnmount(c *C) {
+	mountpoint := "/mnt/foo"
+	callsToSync := 0
+	defer osutil.FakeSyscallSync(func() { callsToSync++ })()
+	defer osutil.FakeSyscallUnmount(func(target string, flags int) error {
+		c.Assert(target, Equals, mountpoint)
+		c.Assert(flags, Equals, 0)
+		return nil
+	})()
+	err := osutil.Unmount(mountpoint)
+	c.Assert(err, IsNil)
+	c.Assert(callsToSync, Equals, 1)
+}
+
+func (s *mountSuite) TestUnmountFails(c *C) {
+	mountpoint := "/mnt/foo"
+	defer osutil.FakeSyscallUnmount(func(target string, flags int) error {
+		return errors.New("cannot bar")
+	})()
+	err := osutil.Unmount(mountpoint)
+	c.Assert(err, ErrorMatches, `cannot unmount .*: cannot bar`)
 }


### PR DESCRIPTION
This patch extends the `osutil` API to include two functions, `osutil.Mount()` and `osutil.Unmount()` that allow the mounting and safe unmounting of disk partitions in Pebble.

If merged, this would remove the need for implementing this functions in the `bootstrap` package (see #176).