### PR TITLE
Change the generate directory to 'cmd/'

### DIFF
--- a/cmd/mkversion.sh
+++ b/cmd/mkversion.sh
@@ -19,11 +19,11 @@ set -e
 #   that dh-golang creates and that only contains a subset of the
 #   files of the toplevel buildir. 
 PKG_BUILDDIR=$(dirname "$0")/..
-GO_GENERATE_BUILDDIR="$(pwd)"
+GO_GENERATE_BUILDDIR="$(pwd)/cmd"
 
 # run from "go generate" adjust path
 if [ "$GOPACKAGE" = "cmd" ]; then
-    GO_GENERATE_BUILDDIR="$(pwd)/.."
+    GO_GENERATE_BUILDDIR="$(pwd)"
 fi
 
 OUTPUT_ONLY=false


### PR DESCRIPTION
By default it was populating the 'version_generated.go' file into the top level directory, but we want to populate it in the same directory as the cmd package. (That is where 'pebble version' currently looks for it.)

I did test just running `go generate ./...` from the top level directory, and running in as `cd cmd; go generate`, and it picked up the version string. They are still just git hashes, because we haven't done a version tag, but I can see that mkversion.sh is using 'git describe' as you would expect.