### PR TITLE
Add a GitHub Action for building and uploading binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  binaries:
+    name: GoReleaser release
+    runs-on: ubuntu-latest
+    container:
+      image: goreleaser/goreleaser-cross:v1.20.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: Run GoReleaser
+        run: goreleaser release --clean
+
+      - name: Upload binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*_checksums.txt
+            dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cmd/VERSION
 .idea
 .vscode
 /pebble
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,28 @@
+before:
+  hooks:
+    - go generate ./cmd
+
+builds:
+  - main: ./cmd/pebble
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - "-trimpath"
+
+archives:
+  - format: tar.gz
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    files:
+      - src: COPYING
+        dst: ./COPYING
+      - src: README.md
+        dst: ./README.md
+    rlcp: true  # See https://goreleaser.com/deprecations/#archivesrlcp
+
+snapshot:
+  name_template: '{{ if ne .Version "0.0.0" }}{{ .Version }}{{ else }}{{ .ShortCommit }}-devel{{ end }}'


### PR DESCRIPTION
DRAFT: Still playing with this on my fork.

This uses GoReleaser, which is widely used and well-maintained. Wouldn't be hard to do it ourselves just using "go build" either if we wanted to do that.

Fixes #202.