### PR TITLE
Add firmware metadata load support

### DIFF
--- a/internal/firmware/export_test.go
+++ b/internal/firmware/export_test.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package firmware
+
+// UpdateMetaInfoPath provides a hook to allow temporary override of the location
+// of the firmware metadata file
+func UpdateMetaInfoPath(path string) func() {
+	origMetaPath := metaInfoPath
+	metaInfoPath = path
+	return func() {
+		metaInfoPath = origMetaPath
+	}
+}
+
+func MetaInfoFromRunning() (*Info, error) {
+	return metaInfoFromRunning()
+}

--- a/internal/firmware/info.go
+++ b/internal/firmware/info.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ * Package firmware extracts information from the running system by
+ * inspecting metadata files embedded in the root filesystem.
+ */
+package firmware
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// Info provides information about firmware.
+type Info struct {
+	Version         string
+	OriginalName    string
+	OriginalSummary string
+
+	StoreInfo
+}
+
+// Rev returns the revision of the firmware.
+func (i *Info) Rev() Revision {
+	return i.Revision
+}
+
+// Name returns the store approved name of the firmware, otherwise the
+// firmware supplied name (if the store name is not available).
+func (i *Info) Name() string {
+	if i.ApprovedName != "" {
+		return i.ApprovedName
+	}
+	return i.OriginalName
+}
+
+// Summary returns the store approved summary of the firmware, otherwise the
+// firmware supplied summary (if the store summary is not available).
+func (i *Info) Summary() string {
+	if i.ApprovedSummary != "" {
+		return i.ApprovedSummary
+	}
+	return i.OriginalSummary
+}
+
+// GetInfo returns a populated Info structure describing the running firmware.
+func GetInfo() (*Info, error) {
+	// Information from the firmware will later be supplemented by approved
+	// metadata coming from the store.
+	return metaInfoFromRunning()
+}
+
+// StoreInfo holds firmware metadata for which the store is the
+// canonical source.
+//
+// It can be marshalled and will be stored in the system state for
+// each installed firmware so it needs to be evolved carefully.
+type StoreInfo struct {
+	Revision        Revision `json:"revision"`
+	ApprovedName    string   `json:"name,omitempty"`
+	ApprovedSummary string   `json:"summary,omitempty"`
+}
+
+// metaInfoPath points to firmware metadata located in the
+// rootfs of a running system.
+var metaInfoPath string = "/termus/meta/termus.json"
+
+// metaInfo represents firmware metadata created during the firmware
+// build process.
+type metaInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Summary string `json:"summary"`
+}
+
+// metaInfoFromRunning returns the firmware metadata of the running system
+// exported as an Info struct.
+func metaInfoFromRunning() (*Info, error) {
+	data, err := ioutil.ReadFile(metaInfoPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open firmware metadata file %s: %w", metaInfoPath, err)
+	}
+
+	var m metaInfo
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("cannot parse firmware metadata json: %w", err)
+	}
+	return &Info{
+		Version:         m.Version,
+		OriginalName:    m.Name,
+		OriginalSummary: m.Summary,
+	}, nil
+}

--- a/internal/firmware/info_test.go
+++ b/internal/firmware/info_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package firmware_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internal/firmware"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+const metaInfoTestPath = "test/path/fwinfo/json"
+
+func (s *S) TestFwInfoFileMissing(c *C) {
+	path := filepath.Join(c.MkDir(), metaInfoTestPath)
+	defer firmware.UpdateMetaInfoPath(path)()
+
+	_, err := firmware.MetaInfoFromRunning()
+	c.Assert(err, ErrorMatches, `cannot open firmware metadata file.*`)
+}
+
+func (s *S) TestFwInfoFileContentInvalid(c *C) {
+	path := filepath.Join(c.MkDir(), metaInfoTestPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		c.Errorf("failed to create directory tree %s: %v", filepath.Dir(path), err)
+	}
+	if err := ioutil.WriteFile(path, []byte(``), 0755); err != nil {
+		c.Errorf("failed to create file %s", path)
+	}
+	defer firmware.UpdateMetaInfoPath(path)()
+
+	_, err := firmware.MetaInfoFromRunning()
+	c.Assert(err, ErrorMatches, `cannot parse firmware metadata json.*`)
+}
+
+func (s *S) TestFwInfoFileValid(c *C) {
+	path := filepath.Join(c.MkDir(), metaInfoTestPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		c.Errorf("failed to create directory tree %s: %v", filepath.Dir(path), err)
+	}
+	defer firmware.UpdateMetaInfoPath(path)()
+
+	tests := []struct {
+		json string
+		info *firmware.Info
+	}{
+		{
+			`{}`,
+			&firmware.Info{},
+		},
+		{
+			`{"name":"foo"}`,
+			&firmware.Info{OriginalName: "foo"},
+		},
+		{
+			`{"name":"foo", "version":"1.0~dev", "summary":"Foo firmware dev build"}`,
+			&firmware.Info{OriginalName: "foo", Version: "1.0~dev", OriginalSummary: "Foo firmware dev build"},
+		},
+	}
+	for _, t := range tests {
+		if err := ioutil.WriteFile(path, []byte(t.json), 0755); err != nil {
+			c.Errorf("failed to create file %s", path)
+		}
+
+		info, err := firmware.MetaInfoFromRunning()
+		c.Assert(err, IsNil)
+		c.Assert(info, DeepEquals, t.info)
+		// At this point in time GetInfo is only a wrapper around metaInfoFromRunning, but
+		// once more complexity is added (i.e. this breaks) GetInfo needs its own test.
+		info, err = firmware.GetInfo()
+		c.Assert(err, IsNil)
+		c.Assert(info, DeepEquals, t.info)
+	}
+}
+
+func (s *S) TestInfoMethods(c *C) {
+	tests := []struct {
+		info    firmware.Info
+		rev     firmware.Revision
+		name    string
+		summary string
+	}{
+		{
+			firmware.Info{},
+			firmware.Revision{},
+			"",
+			"",
+		},
+		{
+			firmware.Info{OriginalName: "foo", OriginalSummary: "Foo firmware dev build", StoreInfo: firmware.StoreInfo{Revision: firmware.Revision{-1}}},
+			firmware.Revision{-1},
+			"foo",
+			"Foo firmware dev build",
+		},
+		{
+			firmware.Info{
+				OriginalName:    "foo",
+				OriginalSummary: "Foo firmware dev build",
+				StoreInfo: firmware.StoreInfo{
+					Revision:        firmware.Revision{-2},
+					ApprovedName:    "bar",
+					ApprovedSummary: "Bar firmware dev build",
+				},
+			},
+			firmware.Revision{-2},
+			"bar",
+			"Bar firmware dev build",
+		},
+	}
+	for _, t := range tests {
+		c.Assert(t.info.Rev(), DeepEquals, t.rev)
+		c.Assert(t.info.Name(), DeepEquals, t.name)
+		c.Assert(t.info.Summary(), DeepEquals, t.summary)
+	}
+}

--- a/internal/firmware/revision.go
+++ b/internal/firmware/revision.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package firmware
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type Revision struct {
+	N int
+}
+
+func (r Revision) String() string {
+	if r.N == 0 {
+		return "unset"
+	}
+	if r.N < 0 {
+		return fmt.Sprintf("x%d", -r.N)
+	}
+	return strconv.Itoa(r.N)
+}
+
+func (r Revision) Unset() bool {
+	return r.N == 0
+}
+
+func (r Revision) Local() bool {
+	return r.N < 0
+}
+
+func (r Revision) Store() bool {
+	return r.N > 0
+}
+
+func (r Revision) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + r.String() + `"`), nil
+}
+
+func (r *Revision) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	return r.UnmarshalJSON([]byte(`"` + s + `"`))
+}
+
+func (r Revision) MarshalYAML() (interface{}, error) {
+	return r.String(), nil
+}
+
+func (r *Revision) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' && data[len(data)-1] == '"' {
+		parsed, err := ParseRevision(string(data[1 : len(data)-1]))
+		if err == nil {
+			*r = parsed
+			return nil
+		}
+	} else {
+		n, err := strconv.ParseInt(string(data), 10, 64)
+		if err == nil {
+			r.N = int(n)
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid firmware revision: %q", data)
+}
+
+// ParseRevisions returns the representation in r as a revision.
+// See R for a function more suitable for hardcoded revisions.
+func ParseRevision(s string) (Revision, error) {
+	if s == "unset" {
+		return Revision{}, nil
+	}
+	if s != "" && s[0] == 'x' {
+		i, err := strconv.Atoi(s[1:])
+		if err == nil && i > 0 {
+			return Revision{-i}, nil
+		}
+	}
+	i, err := strconv.Atoi(s)
+	if err == nil && i > 0 {
+		return Revision{i}, nil
+	}
+	return Revision{}, fmt.Errorf("invalid firmware revision: %#v", s)
+}
+
+// R returns a Revision given an int or a string.
+// Providing an invalid revision type or value causes a runtime panic.
+// See ParseRevision for a polite function that does not panic.
+func R(r interface{}) Revision {
+	switch r := r.(type) {
+	case string:
+		revision, err := ParseRevision(r)
+		if err != nil {
+			panic(err)
+		}
+		return revision
+	case int:
+		return Revision{r}
+	default:
+		panic(fmt.Errorf("cannot use %v (%T) as a firmware revision", r, r))
+	}
+}

--- a/internal/firmware/revision_test.go
+++ b/internal/firmware/revision_test.go
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package firmware_test
+
+import (
+	"encoding/json"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/pebble/internal/firmware"
+)
+
+// Keep this in sync between firmware and client packages.
+
+type revisionSuite struct{}
+
+var _ = Suite(&revisionSuite{})
+
+func (s revisionSuite) TestString(c *C) {
+	c.Assert(firmware.R(0).String(), Equals, "unset")
+	c.Assert(firmware.R(10).String(), Equals, "10")
+	c.Assert(firmware.R(-9).String(), Equals, "x9")
+}
+
+func (s revisionSuite) TestUnset(c *C) {
+	c.Assert(firmware.R(0).Unset(), Equals, true)
+	c.Assert(firmware.R(10).Unset(), Equals, false)
+	c.Assert(firmware.R(-9).Unset(), Equals, false)
+}
+
+func (s revisionSuite) TestLocal(c *C) {
+	c.Assert(firmware.R(0).Local(), Equals, false)
+	c.Assert(firmware.R(10).Local(), Equals, false)
+	c.Assert(firmware.R(-9).Local(), Equals, true)
+}
+
+func (s revisionSuite) TestStore(c *C) {
+	c.Assert(firmware.R(0).Store(), Equals, false)
+	c.Assert(firmware.R(10).Store(), Equals, true)
+	c.Assert(firmware.R(-9).Store(), Equals, false)
+}
+
+func (s revisionSuite) TestJSON(c *C) {
+	for _, n := range []int{0, 10, -9} {
+		r := firmware.R(n)
+		data, err := json.Marshal(firmware.R(n))
+		c.Assert(err, IsNil)
+		c.Assert(string(data), Equals, `"`+r.String()+`"`)
+
+		var got firmware.Revision
+		err = json.Unmarshal(data, &got)
+		c.Assert(err, IsNil)
+		c.Assert(got, Equals, r)
+
+		got = firmware.Revision{}
+		err = json.Unmarshal([]byte(strconv.Itoa(r.N)), &got)
+		c.Assert(err, IsNil)
+		c.Assert(got, Equals, r)
+	}
+}
+
+func (s revisionSuite) TestYAML(c *C) {
+	for _, v := range []struct {
+		n int
+		s string
+	}{
+		{0, "unset"},
+		{10, `"10"`},
+		{-9, "x9"},
+	} {
+		r := firmware.R(v.n)
+		data, err := yaml.Marshal(firmware.R(v.n))
+		c.Assert(err, IsNil)
+		c.Assert(string(data), Equals, v.s+"\n")
+
+		var got firmware.Revision
+		err = yaml.Unmarshal(data, &got)
+		c.Assert(err, IsNil)
+		c.Assert(got, Equals, r)
+
+		got = firmware.Revision{}
+		err = json.Unmarshal([]byte(strconv.Itoa(r.N)), &got)
+		c.Assert(err, IsNil)
+		c.Assert(got, Equals, r)
+	}
+}
+
+func (s revisionSuite) ParseRevision(c *C) {
+	type testItem struct {
+		s string
+		n int
+		e string
+	}
+
+	var tests = []testItem{{
+		s: "unset",
+		n: 0,
+	}, {
+		s: "x1",
+		n: -1,
+	}, {
+		s: "1",
+		n: 1,
+	}, {
+		s: "x-1",
+		e: `invalid firmware revision: "x-1"`,
+	}, {
+		s: "x0",
+		e: `invalid firmware revision: "x0"`,
+	}, {
+		s: "-1",
+		e: `invalid firmware revision: "-1"`,
+	}, {
+		s: "0",
+		e: `invalid firmware revision: "0"`,
+	}}
+
+	for _, test := range tests {
+		r, err := firmware.ParseRevision(test.s)
+		if test.e != "" {
+			c.Assert(err.Error(), Equals, test.e)
+			continue
+		}
+		c.Assert(r, Equals, firmware.R(test.n))
+	}
+}
+
+func (s *revisionSuite) TestR(c *C) {
+	type testItem struct {
+		v interface{}
+		n int
+		e string
+	}
+
+	var tests = []testItem{{
+		v: 0,
+		n: 0,
+	}, {
+		v: -1,
+		n: -1,
+	}, {
+		v: 1,
+		n: 1,
+	}, {
+		v: "unset",
+		n: 0,
+	}, {
+		v: "x1",
+		n: -1,
+	}, {
+		v: "1",
+		n: 1,
+	}, {
+		v: "x-1",
+		e: `invalid firmware revision: "x-1"`,
+	}, {
+		v: "x0",
+		e: `invalid firmware revision: "x0"`,
+	}, {
+		v: "-1",
+		e: `invalid firmware revision: "-1"`,
+	}, {
+		v: "0",
+		e: `invalid firmware revision: "0"`,
+	}, {
+		v: int64(1),
+		e: `cannot use 1 \(int64\) as a firmware revision`,
+	}}
+
+	for _, test := range tests {
+		if test.e != "" {
+			f := func() { firmware.R(test.v) }
+			c.Assert(f, PanicMatches, test.e)
+			continue
+		}
+
+		c.Assert(firmware.R(test.v), Equals, firmware.R(test.n))
+	}
+}


### PR DESCRIPTION
Firmware metadata are accessible in the root filesystem of the running firmware at the following location, encoded as JSON:

/termus/meta/termus.json

Information obtained from this file represents build-time attributes of the firmware that is required by the firmware state manager.

Revision is taken verbatim from the snapd project while the firmware info logic takes inspiration from the snap info code.