### PR TITLE
Add --client arg to "pebble version"

### DIFF
--- a/cmd/pebble/cmd_version.go
+++ b/cmd/pebble/cmd_version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/canonical/pebble/client"
-	"github.com/canonical/pebble/cmd"
+	cmdpkg "github.com/canonical/pebble/cmd"
 )
 
 var shortVersionHelp = "Show version details"
@@ -30,15 +30,25 @@ The version command displays the versions of the running client and server.
 
 type cmdVersion struct {
 	clientMixin
+	ClientOnly bool `long:"client"`
+}
+
+var versionDescs = map[string]string{
+	"client": `Only display the client version`,
 }
 
 func init() {
-	addCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, nil, nil)
+	addCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, versionDescs, nil)
 }
 
 func (cmd cmdVersion) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
+	}
+
+	if cmd.ClientOnly {
+		fmt.Fprintln(Stdout, cmdpkg.Version)
+		return nil
 	}
 
 	return printVersions(cmd.client)
@@ -51,7 +61,7 @@ func printVersions(cli *client.Client) error {
 		serverVersion = sysInfo.Version
 	}
 	w := tabWriter()
-	fmt.Fprintf(w, "client\t%s\n", cmd.Version)
+	fmt.Fprintf(w, "client\t%s\n", cmdpkg.Version)
 	fmt.Fprintf(w, "server\t%s\n", serverVersion)
 	w.Flush()
 	return nil

--- a/cmd/pebble/cmd_version_test.go
+++ b/cmd/pebble/cmd_version_test.go
@@ -37,6 +37,16 @@ func (s *PebbleSuite) TestVersion(c *C) {
 	c.Check(s.Stderr(), Equals, "")
 }
 
+func (s *PebbleSuite) TestVersionClientOnly(c *C) {
+	restore := fakeVersion("v1.2.3")
+	defer restore()
+
+	_, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"version", "--client"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "v1.2.3\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
 func (s *PebbleSuite) TestVersionExtraArgs(c *C) {
 	rest, err := pebble.Parser(pebble.Client()).ParseArgs([]string{"version", "extra", "args"})
 	c.Assert(err, Equals, pebble.ErrExtraArgs)


### PR DESCRIPTION
This is a small change that allows you to type `pebble version --client` if you just want the client version, without "pebble version" trying to hit the server (and taking 5 seconds to respond). For example, to avoid [this kind of awkwardness](https://github.com/canonical/pebble/pull/204/files#diff-bdfe89ee8491e51e3f81ada685c51d24188416d8b529b443ee6085a0e0fd4a4aR46):

```
# Get version via "pebble version" to ensure it matches that exactly
PEBBLE_VERSION=$(GOOS=linux GOARCH=amd64 go run ./cmd/pebble version | awk '/client/ { print $2 }')
```

If this PR is merged, we can simplify the above to the following (and it will respond instantly instead of taking 5s):

```
# Get version via "pebble version" to ensure it matches that exactly
PEBBLE_VERSION=$(GOOS=linux GOARCH=amd64 go run ./cmd/pebble version --client)
```
