### PR TITLE
Fix checks timeout definition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ checks:
         period: <duration>
 
         # (Optional) If this time elapses before a single check operation has
-        # finished, it is cancelled and considered an error. Must not be less
+        # finished, it is cancelled and considered an error. Must not be more
         # than the period, and must not be zero. Default is "3s".
         timeout: <duration>
 

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ checks:
         period: <duration>
 
         # (Optional) If this time elapses before a single check operation has
-        # finished, it is cancelled and considered an error. Must not be more
+        # finished, it is cancelled and considered an error. Must be less
         # than the period, and must not be zero. Default is "3s".
         timeout: <duration>
 


### PR DESCRIPTION
small correction in Layer specification section in README.md. updated timeout definition: `timeout must not be more than the period` is the correct description NOT `timeout must not be less than the period`. defaults of timeout and period confirm that.