### PR TITLE
Use "pebble version --client" in GitHub Action now that that exists

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -43,7 +43,7 @@ jobs:
         go build -trimpath -ldflags='-s -w' -o dist/build/pebble ./cmd/pebble
 
         # Get version via "pebble version" to ensure it matches that exactly
-        PEBBLE_VERSION=$(GOOS=linux GOARCH=amd64 go run ./cmd/pebble version | awk '/client/ { print $2 }')
+        PEBBLE_VERSION=$(GOOS=linux GOARCH=amd64 go run ./cmd/pebble version --client)
 
         ARCHIVE_FILE=pebble_${PEBBLE_VERSION}_${GOOS}_${GOARCH}.tar.gz
         echo Creating archive $ARCHIVE_FILE


### PR DESCRIPTION
This simplifies, and avoids the 5-second delay from trying to look up the server version. Note that the `--client` arg for `pebble version` was added very recently in https://github.com/canonical/pebble/pull/208.