### PR TITLE
Allow `!replace`-ing service `log-targets` in merge

### DIFF
--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -90,7 +90,7 @@ type Service struct {
 	KillDelay      OptionalDuration         `yaml:"kill-delay,omitempty"`
 
 	// Log forwarding
-	LogTargets *LogTargets `yaml:"log-targets,omitempty"`
+	LogTargets LogTargets `yaml:"log-targets,omitempty"`
 }
 
 // Copy returns a deep copy of the service.
@@ -184,7 +184,7 @@ func (s *Service) Merge(other *Service) {
 	if other.BackoffLimit.IsSet {
 		s.BackoffLimit = other.BackoffLimit
 	}
-	s.LogTargets.Merge(other.LogTargets)
+	s.LogTargets = MergeLogTargets(s.LogTargets, other.LogTargets)
 }
 
 // appendUnique appends into a the elements from b which are not yet present
@@ -246,9 +246,9 @@ const (
 )
 
 type LogTargets struct {
-	targets []string
-	keyword string
-	replace bool
+	Targets []string
+	Keyword string
+	Replace bool
 }
 
 const (
@@ -263,12 +263,12 @@ const (
 
 func (t *LogTargets) UnmarshalYAML(value *yaml.Node) error {
 	// Check for !replace tag
-	t.replace = (value.Tag == logTargetsReplaceTag)
+	t.Replace = (value.Tag == logTargetsReplaceTag)
 
 	if value.Kind == yaml.ScalarNode {
 		switch value.Value {
 		case defaultLogTargets, allLogTargets, noLogTargets:
-			t.keyword = value.Value
+			t.Keyword = value.Value
 			return nil
 		default:
 			return fmt.Errorf("invalid value %q for LogTargets", value.Value)
@@ -276,35 +276,36 @@ func (t *LogTargets) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	// unmarshal to []string
-	return value.Decode(&t.targets)
+	return value.Decode(&t.Targets)
 }
 
 // Copy returns a deep copy of this LogTargets struct.
-func (t *LogTargets) Copy() *LogTargets {
-	return &LogTargets{
-		targets: append([]string(nil), t.targets...),
-		keyword: t.keyword,
-		replace: t.replace,
+func (t *LogTargets) Copy() LogTargets {
+	return LogTargets{
+		Targets: append([]string(nil), t.Targets...),
+		Keyword: t.Keyword,
+		Replace: t.Replace,
 	}
 }
 
-// Merge merges the fields set in other into t.
-func (t *LogTargets) Merge(other *LogTargets) {
-	if other.replace {
-		t.targets = append([]string(nil), other.targets...)
-		t.keyword = other.keyword
-		return
+// MergeLogTargets returns the result of merging other into t.
+func MergeLogTargets(t, other LogTargets) (res LogTargets) {
+	if other.Replace {
+		return other
 	}
 
-	t.targets = appendUnique(t.targets, other.targets...)
-	if other.keyword != "" {
-		t.keyword = other.keyword
+	res.Targets = appendUnique(t.Targets, other.Targets...)
+	if other.Keyword == "" {
+		res.Keyword = t.Keyword
+	} else {
+		res.Keyword = other.Keyword
 	}
+	return
 }
 
 func (t *LogTargets) LogsTo(tgt *LogTarget) bool {
 	// Handle keywords
-	switch t.keyword {
+	switch t.Keyword {
 	case allLogTargets:
 		return tgt.Selection != DisabledSelection
 	case defaultLogTargets:
@@ -317,12 +318,12 @@ func (t *LogTargets) LogsTo(tgt *LogTarget) bool {
 	if tgt.Selection == DisabledSelection {
 		return false
 	}
-	if len(t.targets) == 0 {
+	if len(t.Targets) == 0 {
 		if tgt.Selection == UnsetSelection || tgt.Selection == OptOutSelection {
 			return true
 		}
 	}
-	for _, targetName := range t.targets {
+	for _, targetName := range t.Targets {
 		if targetName == tgt.Name {
 			return true
 		}
@@ -824,7 +825,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 	// Validate service log targets
 	for serviceName, service := range combined.Services {
-		for _, targetName := range service.LogTargets.targets {
+		for _, targetName := range service.LogTargets.Targets {
 			_, ok := combined.LogTargets[targetName]
 			if !ok {
 				return nil, &FormatError{

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -90,7 +90,7 @@ type Service struct {
 	KillDelay      OptionalDuration         `yaml:"kill-delay,omitempty"`
 
 	// Log forwarding
-	LogTargets []string `yaml:"log-targets,omitempty"`
+	LogTargets *LogTargets `yaml:"log-targets,omitempty"`
 }
 
 // Copy returns a deep copy of the service.
@@ -119,7 +119,7 @@ func (s *Service) Copy() *Service {
 			copied.OnCheckFailure[k] = v
 		}
 	}
-	copied.LogTargets = append([]string(nil), s.LogTargets...)
+	copied.LogTargets = s.LogTargets.Copy()
 	return &copied
 }
 
@@ -184,7 +184,7 @@ func (s *Service) Merge(other *Service) {
 	if other.BackoffLimit.IsSet {
 		s.BackoffLimit = other.BackoffLimit
 	}
-	s.LogTargets = appendUnique(s.LogTargets, other.LogTargets...)
+	s.LogTargets.Merge(other.LogTargets)
 }
 
 // appendUnique appends into a the elements from b which are not yet present
@@ -216,20 +216,7 @@ func (s *Service) Equal(other *Service) bool {
 //   - t.Selection is "opt-out" or empty, and s.LogTargets is empty; or
 //   - t.Selection is not "disabled", and s.LogTargets contains t.
 func (s *Service) LogsTo(t *LogTarget) bool {
-	if t.Selection == DisabledSelection {
-		return false
-	}
-	if len(s.LogTargets) == 0 {
-		if t.Selection == UnsetSelection || t.Selection == OptOutSelection {
-			return true
-		}
-	}
-	for _, targetName := range s.LogTargets {
-		if targetName == t.Name {
-			return true
-		}
-	}
-	return false
+	return s.LogTargets.LogsTo(t)
 }
 
 type ServiceStartup string
@@ -257,6 +244,91 @@ const (
 	ActionShutdown ServiceAction = "shutdown"
 	ActionIgnore   ServiceAction = "ignore"
 )
+
+type LogTargets struct {
+	targets []string
+	keyword string
+	replace bool
+}
+
+const (
+	// Valid keywords for LogTargets
+	defaultLogTargets = "default"
+	allLogTargets     = "all"
+	noLogTargets      = "none"
+
+	// Tag used to replace value (rather than append)
+	logTargetsReplaceTag = "!replace"
+)
+
+func (t *LogTargets) UnmarshalYAML(value *yaml.Node) error {
+	// Check for !replace tag
+	t.replace = (value.Tag == logTargetsReplaceTag)
+
+	if value.Kind == yaml.ScalarNode {
+		switch value.Value {
+		case defaultLogTargets, allLogTargets, noLogTargets:
+			t.keyword = value.Value
+			return nil
+		default:
+			return fmt.Errorf("invalid value %q for LogTargets", value.Value)
+		}
+	}
+
+	// unmarshal to []string
+	return value.Decode(&t.targets)
+}
+
+// Copy returns a deep copy of this LogTargets struct.
+func (t *LogTargets) Copy() *LogTargets {
+	return &LogTargets{
+		targets: append([]string(nil), t.targets...),
+		keyword: t.keyword,
+		replace: t.replace,
+	}
+}
+
+// Merge merges the fields set in other into t.
+func (t *LogTargets) Merge(other *LogTargets) {
+	if other.replace {
+		t.targets = append([]string(nil), other.targets...)
+		t.keyword = other.keyword
+		return
+	}
+
+	t.targets = appendUnique(t.targets, other.targets...)
+	if other.keyword != "" {
+		t.keyword = other.keyword
+	}
+}
+
+func (t *LogTargets) LogsTo(tgt *LogTarget) bool {
+	// Handle keywords
+	switch t.keyword {
+	case allLogTargets:
+		return tgt.Selection != DisabledSelection
+	case defaultLogTargets:
+		return tgt.Selection == OptOutSelection || tgt.Selection == UnsetSelection
+	case noLogTargets:
+		return false
+	}
+
+	// No keyword
+	if tgt.Selection == DisabledSelection {
+		return false
+	}
+	if len(t.targets) == 0 {
+		if tgt.Selection == UnsetSelection || tgt.Selection == OptOutSelection {
+			return true
+		}
+	}
+	for _, targetName := range t.targets {
+		if targetName == tgt.Name {
+			return true
+		}
+	}
+	return false
+}
 
 // Check specifies configuration for a single health check.
 type Check struct {
@@ -752,7 +824,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 	// Validate service log targets
 	for serviceName, service := range combined.Services {
-		for _, targetName := range service.LogTargets {
+		for _, targetName := range service.LogTargets.targets {
 			_, ok := combined.LogTargets[targetName]
 			if !ok {
 				return nil, &FormatError{

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -806,7 +806,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1"},
 				},
 			},
@@ -818,7 +818,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -902,7 +902,7 @@ var planTests = []planTest{{
 				Command:  "foo",
 				Override: plan.MergeOverride,
 				Startup:  plan.StartupEnabled,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1"},
 				},
 			},
@@ -911,7 +911,7 @@ var planTests = []planTest{{
 				Command:  "bar",
 				Override: plan.MergeOverride,
 				Startup:  plan.StartupEnabled,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -939,7 +939,7 @@ var planTests = []planTest{{
 				Name:     "svc1",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
 				},
 			},
@@ -948,7 +948,7 @@ var planTests = []planTest{{
 				Command:  "bar",
 				Override: plan.ReplaceOverride,
 				Startup:  plan.StartupEnabled,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
 				},
 			},
@@ -984,7 +984,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt3"},
 				},
 			},
@@ -996,7 +996,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
 				},
 			},
@@ -1133,7 +1133,7 @@ var planTests = []planTest{{
 				Name:     "svc1",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.DefaultLogTargets,
 				},
 			},
@@ -1141,7 +1141,7 @@ var planTests = []planTest{{
 				Name:     "svc2",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.AllLogTargets,
 				},
 			},
@@ -1149,7 +1149,7 @@ var planTests = []planTest{{
 				Name:     "svc3",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.NoLogTargets,
 				},
 			},
@@ -1157,7 +1157,7 @@ var planTests = []planTest{{
 				Name:     "svc4",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -1165,7 +1165,7 @@ var planTests = []planTest{{
 				Name:     "svc5",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.DefaultLogTargets,
 					Replace: true,
 				},
@@ -1174,7 +1174,7 @@ var planTests = []planTest{{
 				Name:     "svc6",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.AllLogTargets,
 					Replace: true,
 				},
@@ -1183,7 +1183,7 @@ var planTests = []planTest{{
 				Name:     "svc7",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.NoLogTargets,
 					Replace: true,
 				},
@@ -1192,7 +1192,7 @@ var planTests = []planTest{{
 				Name:     "svc8",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 					Replace: true,
 				},
@@ -1286,7 +1286,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2", "tgt3"},
 				},
 			},
@@ -1297,9 +1297,8 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
-					Replace: true,
 				},
 			},
 			"svc3": {
@@ -1309,7 +1308,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.DefaultLogTargets,
 				},
 			},
@@ -1320,7 +1319,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -1616,25 +1615,25 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "disabled", Selection: plan.DisabledSelection},
 	}
 	services := []*plan.Service{
-		{Name: "svc1", LogTargets: plan.LogTargets{
+		{Name: "svc1", LogTargets: &plan.LogTargets{
 			Targets: nil,
 		}},
-		{Name: "svc2", LogTargets: plan.LogTargets{
+		{Name: "svc2", LogTargets: &plan.LogTargets{
 			Targets: []string{},
 		}},
-		{Name: "svc3", LogTargets: plan.LogTargets{
+		{Name: "svc3", LogTargets: &plan.LogTargets{
 			Targets: []string{"unset"},
 		}},
-		{Name: "svc4", LogTargets: plan.LogTargets{
+		{Name: "svc4", LogTargets: &plan.LogTargets{
 			Targets: []string{"optout"},
 		}},
-		{Name: "svc5", LogTargets: plan.LogTargets{
+		{Name: "svc5", LogTargets: &plan.LogTargets{
 			Targets: []string{"optin"},
 		}},
-		{Name: "svc6", LogTargets: plan.LogTargets{
+		{Name: "svc6", LogTargets: &plan.LogTargets{
 			Targets: []string{"disabled"},
 		}},
-		{Name: "svc7", LogTargets: plan.LogTargets{
+		{Name: "svc7", LogTargets: &plan.LogTargets{
 			Targets: []string{"unset", "optin", "disabled"},
 		}},
 	}
@@ -1664,65 +1663,62 @@ func (s *S) TestSelectTargets(c *C) {
 func (s *S) TestParseAndMergeLogTargets(c *C) {
 	tests := []struct {
 		base, override string
-		res            plan.LogTargets
+		res            *plan.LogTargets
 	}{{
 		base: "[tgt1]", override: "[tgt3]",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1", "tgt3"},
 		},
 	}, {
 		base: "[tgt1]", override: "!replace [tgt3]",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Targets: []string{"tgt3"},
-			Replace: true,
 		},
 	}, {
 		base: "default", override: "all",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Keyword: plan.AllLogTargets,
 		},
 	}, {
 		base: "[tgt1]", override: "default",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Keyword: plan.DefaultLogTargets,
 		},
 	}, {
 		base: "[tgt1]", override: "!replace default",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Keyword: plan.DefaultLogTargets,
-			Replace: true,
 		},
 	}, {
 		base: "[tgt1]", override: "none",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Keyword: plan.NoLogTargets,
 		},
 	}, {
 		base: "[tgt1]", override: "!replace none",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Keyword: plan.NoLogTargets,
-			Replace: true,
 		},
 	}, {
 		base: "default", override: "[tgt1]",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
 	}, {
 		base: "all", override: "[tgt1]",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
 	}, {
 		base: "none", override: "[tgt1]",
-		res: plan.LogTargets{
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
 	}}
 
-	parseLogTargets := func(raw string) plan.LogTargets {
-		parsed := plan.LogTargets{}
-		err := yaml.Unmarshal([]byte(raw), &parsed)
+	parseLogTargets := func(raw string) *plan.LogTargets {
+		parsed := &plan.LogTargets{}
+		err := yaml.Unmarshal([]byte(raw), parsed)
 		c.Assert(err, IsNil)
 		return parsed
 	}
@@ -1730,7 +1726,7 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 	for _, t := range tests {
 		base := parseLogTargets(t.base)
 		override := parseLogTargets(t.override)
-		merged := plan.MergeLogTargets(base, override)
-		c.Check(merged, DeepEquals, t.res, Commentf("merge %s <- %s", t.base, t.override))
+		base.Merge(override)
+		c.Check(base, DeepEquals, t.res, Commentf("merge %s <- %s", t.base, t.override))
 	}
 }

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -806,7 +806,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1"},
+				},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -816,7 +818,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1", "tgt2"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -894,18 +898,22 @@ var planTests = []planTest{{
 		Order: 0,
 		Services: map[string]*plan.Service{
 			"svc1": {
-				Name:       "svc1",
-				Command:    "foo",
-				Override:   plan.MergeOverride,
-				Startup:    plan.StartupEnabled,
-				LogTargets: []string{"tgt1"},
+				Name:     "svc1",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				Startup:  plan.StartupEnabled,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1"},
+				},
 			},
 			"svc2": {
-				Name:       "svc2",
-				Command:    "bar",
-				Override:   plan.MergeOverride,
-				Startup:    plan.StartupEnabled,
-				LogTargets: []string{"tgt1", "tgt2"},
+				Name:     "svc2",
+				Command:  "bar",
+				Override: plan.MergeOverride,
+				Startup:  plan.StartupEnabled,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -928,17 +936,21 @@ var planTests = []planTest{{
 		Order: 1,
 		Services: map[string]*plan.Service{
 			"svc1": {
-				Name:       "svc1",
-				Command:    "foo",
-				Override:   plan.MergeOverride,
-				LogTargets: []string{"tgt3"},
+				Name:     "svc1",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+				},
 			},
 			"svc2": {
-				Name:       "svc2",
-				Command:    "bar",
-				Override:   plan.ReplaceOverride,
-				Startup:    plan.StartupEnabled,
-				LogTargets: []string{"tgt3"},
+				Name:     "svc2",
+				Command:  "bar",
+				Override: plan.ReplaceOverride,
+				Startup:  plan.StartupEnabled,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -972,7 +984,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1", "tgt3"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt3"},
+				},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -982,7 +996,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt3"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -1331,13 +1347,27 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "disabled", Selection: plan.DisabledSelection},
 	}
 	services := []*plan.Service{
-		{Name: "svc1", LogTargets: nil},
-		{Name: "svc2", LogTargets: []string{}},
-		{Name: "svc3", LogTargets: []string{"unset"}},
-		{Name: "svc4", LogTargets: []string{"optout"}},
-		{Name: "svc5", LogTargets: []string{"optin"}},
-		{Name: "svc6", LogTargets: []string{"disabled"}},
-		{Name: "svc7", LogTargets: []string{"unset", "optin", "disabled"}},
+		{Name: "svc1", LogTargets: plan.LogTargets{
+			Targets: nil,
+		}},
+		{Name: "svc2", LogTargets: plan.LogTargets{
+			Targets: []string{},
+		}},
+		{Name: "svc3", LogTargets: plan.LogTargets{
+			Targets: []string{"unset"},
+		}},
+		{Name: "svc4", LogTargets: plan.LogTargets{
+			Targets: []string{"optout"},
+		}},
+		{Name: "svc5", LogTargets: plan.LogTargets{
+			Targets: []string{"optin"},
+		}},
+		{Name: "svc6", LogTargets: plan.LogTargets{
+			Targets: []string{"disabled"},
+		}},
+		{Name: "svc7", LogTargets: plan.LogTargets{
+			Targets: []string{"unset", "optin", "disabled"},
+		}},
 	}
 
 	// Use pointers to bools so the test will fail if we forget to set a value
@@ -1359,5 +1389,26 @@ func (s *S) TestSelectTargets(c *C) {
 			c.Check(service.LogsTo(target), Equals, *exp,
 				Commentf("unexpected value for %s.LogsTo(%s)", service.Name, target.Name))
 		}
+	}
+}
+
+func (s *S) TestMergeLogTargets(c *C) {
+	tests := []struct {
+		t1, t2, res plan.LogTargets
+	}{{
+		t1: plan.LogTargets{
+			Targets: []string{"tgt1"},
+		},
+		t2: plan.LogTargets{
+			Targets: []string{"tgt3"},
+		},
+		res: plan.LogTargets{
+			Targets: []string{"tgt1", "tgt3"},
+		},
+	}}
+
+	for _, t := range tests {
+		merged := plan.MergeLogTargets(t.t1, t.t2)
+		c.Check(merged, DeepEquals, t.res)
 	}
 }


### PR DESCRIPTION
Alternative to #223.

### Context

#209 and #217 have included extensive discussion of the configuration and merging of log targets specified in a service definition. Two issues have been identified when it comes to merging the `log-targets` field:

1. It is hard to restore the default behaviour provided when `log-targets` is not specified. The issue is that specifying a null value
   ```yaml
   svc1:
     command: foo
     log-targets: ~ # or null
   ```
   parses identically to not specifying a value at all:
   ```yaml
   svc1:
     command: foo
   ```

2. It is hard to remove a log target which was previously specified. If your base layer contains
   ```yaml
   svc1:
     log-targets: [a,b]
   ```
   and you merge the following layer on top of it:
   ```yaml
   svc1:
     log-targets: [c]
     override: merge
   ```
   it will yield `log-targets: [a,b,c]`.

As it stands, the only way to get around either issue is to replace the entire service - which is a real usability issue. This PR proposes one solution to the problem.

### The solution

To solve (1), we need an **explicit value** to represent the default behaviour. We can't use `null` in a merge, as when this is parsed, it is indistinguishable from an unspecified value. To this end, I have added a `default` keyword which can be specified as the value of `log-targets` to restore the default behaviour:
```yaml
svc1:
  log-targets: default
```

To solve the issue raised by Gustavo [here](https://github.com/canonical/pebble/pull/209#discussion_r1155712205), I have also added a `none` keyword which a service can use to entirely opt-out of log forwarding. Personally I feel this is a safer approach than what I've proposed in #217. Distinguishing between `[]string(nil)` and `[]string{}` in Go is fiddly and error-prone, and it's bound to cause issues down the road when merging and passing structs around.

Finally, I've added an `all` keyword - this is not strictly necessary, but could be convenient if a user has a large number of log targets.

To solve (2), I've added a `!replace` tag, which a service can use during a merge to indicate that the value of `log-targets` should be replaced, not merged. i.e. merging
```yaml
svc1:
  log-targets: !replace [c]
  override: merge
```
on top of another layer will overwrite the value of `log-targets`, yielding just `log-targets: [c]`.

So, the full schema for the `log-targets` field is now:
```
log-targets: [!replace] default | none | all | <list of log targets>
```

I've implemented a custom type `LogTargets` with a custom `UnmarshalYAML` method to handle all this.

### Merging rules

These are the rules I decided on for merging `log-targets` - see the `MergeLogTargets` function. Open to discussing the details here.

1. Merging `anything1` <- `!replace anything2` yields `anything2`. In particular, merging `list1` <- `!replace list2` yields `list2`.
2. Merging `list1` <- `list2` will combine the two lists.
3. Merging `list` <- `keyword` yields `keyword`.
4. Merging `keyword1` <- `keyword2` yields `keyword2`
5. Merging `keyword` <- `list` yields `list` (if the list is nonempty).

Essentially, the `!replace` directive is only needed when wanting to replace a list with another list.
