### PR TITLE
randutil: allow pseudo rng seeding by caller

### DIFF
--- a/internal/osutil/export_test.go
+++ b/internal/osutil/export_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/canonical/pebble/internal/osutil/sys"
 )
 
+var AtomicFilePrng = atomicFilePrng
+
 func FakeUserCurrent(f func() (*user.User, error)) func() {
 	realUserCurrent := userCurrent
 	userCurrent = f

--- a/internal/osutil/io.go
+++ b/internal/osutil/io.go
@@ -43,6 +43,8 @@ const (
 // all unit tests in general.
 var unsafeIO bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") && os.Getenv("UNSAFE_IO") == "1"
 
+var atomicFilePrng = randutil.NewPseudoRand(nil)
+
 // An AtomicFile is similar to an os.File but it has an additional
 // Commit() method that does whatever needs to be done so the
 // modification is "atomic": an AtomicFile will do its best to leave
@@ -92,7 +94,7 @@ func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, ui
 	// aa-enforce. Tools from this package enumerate all profiles by loading
 	// parsing any file found in /etc/apparmor.d/, skipping only very specific
 	// suffixes, such as the one we selected below.
-	tmp := filename + "." + randutil.RandomString(12) + "~"
+	tmp := filename + "." + atomicFilePrng.RandomString(12) + "~"
 
 	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
 	if err != nil {

--- a/internal/osutil/io_test.go
+++ b/internal/osutil/io_test.go
@@ -22,12 +22,10 @@ package osutil_test
 import (
 	"errors"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"syscall"
 
-	"github.com/canonical/x-go/randutil"
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internal/osutil"
@@ -169,10 +167,10 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteRelativeSymlink(c *C
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) {
 	tmpdir := c.MkDir()
 	// ensure we always get the same result
-	rand.Seed(1)
-	expectedRandomness := randutil.RandomString(12) + "~"
+	osutil.AtomicFilePrng.Reseed(1)
+	expectedRandomness := osutil.AtomicFilePrng.RandomString(12) + "~"
 	// ensure we always get the same result
-	rand.Seed(1)
+	osutil.AtomicFilePrng.Reseed(1)
 
 	p := filepath.Join(tmpdir, "foo")
 	err := ioutil.WriteFile(p+"."+expectedRandomness, []byte(""), 0644)

--- a/internal/timeutil/schedule.go
+++ b/internal/timeutil/schedule.go
@@ -28,6 +28,12 @@ import (
 // Match 0:00-24:00, where 24:00 means the later end of the day.
 var validTime = regexp.MustCompile(`^([0-9]|0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$|^24:00$`)
 
+// Action scheduling can impact server load so we need to use a seed
+// that is not only based on time and PID, but contains
+// additional variance introduced by device specific details such
+// as hostname and MAC.
+var schedulePrng = randutil.NewPseudoRand(randutil.SeedDatePidHostMac)
+
 // Clock represents a hour:minute time within a day.
 type Clock struct {
 	Hour   int
@@ -387,12 +393,10 @@ func randDur(a, b time.Time) time.Duration {
 		dur -= 5 * time.Minute
 	}
 
-	if dur <= 0 {
-		// avoid panic'ing (even if things are probably messed up)
-		return 0
-	}
-
-	return randutil.RandomDuration(dur)
+	// RandomDuration returns a positive random duration in the half-open
+	// positive interval [0,d). Any zero or negative input duration results
+	// in a return of zero duration.
+	return schedulePrng.RandomDuration(dur)
 }
 
 var (


### PR DESCRIPTION
The randutil package was promoted to the x-go library because it provides helper functions needed by multiple projects.

Feedback from https://github.com/canonical/x-go/pull/17 highlighted the need for seeding of the pseudo random dependent functions to be left to the user of randutil (the crypto/rand functions are unaffected). The reason is simply that the seeding requirements differ between use cases (and projects), and it should be the responsibility of the caller to supply the seed.

Example Usage:

prng := randutil.NewPseudoRand(nil)
:
tmpfile := prng.RandomString(12)
:
wait := prng.RandomDuration(time.Hour)

Apply the changes required to make Pebble use the new randutil api.