### PR TITLE
[JUJU-3777] Allow replacing in merge using `^log-targets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ services:
         log-targets: ['tgtA', 'tgtC']
     svc3:
         log-targets: ['tgtD']
+    svc4:
+        log-targets: []
 log-targets:
     tgtA:
         ...
@@ -450,9 +452,12 @@ log-targets:
         selection: disabled
 ```
 
-- `svc1` doesn't explicitly specify log-targets, so its logs will be forwarded to `tgtA` and `tgtB`.
+- `svc1` doesn't explicitly specify log-targets, so its logs will be forwarded to the opt-out targets: `tgtA` and `tgtB`.
 - `svc2` explicitly specifies `tgtA` and `tgtC`, so its logs will be sent to those targets. `svc2`'s logs will not be sent to `tgtB` or `tgtD`.
 - `svc3` explicitly specifies `tgtD`, but since this target is disabled, it will not receive any logs. Hence, `svc3`'s logs will not be sent anywhere.
+- `svc4` explicitly specifies an *empty list* of log targets. Hence, its logs will not be sent anywhere.
+
+TODO: document the replace key ^log-targets and default value
 -->
 
 ## Container usage

--- a/README.md
+++ b/README.md
@@ -403,6 +403,58 @@ $ pebble run --verbose
 ...
 ```
 
+<!--
+TODO: uncomment this section once log forwarding is fully implemented
+TODO: add log targets to the Pebble layer spec below
+
+#### Log forwarding
+
+Pebble supports forwarding its services' logs to a remote Loki server or syslog receiver (via UDP/TCP). In the `log-targets` section of the plan, you can specify destinations for log forwarding, for example:
+```yaml
+log-targets:
+    loki-example:
+        override: merge
+        type: loki
+        location: http://10.1.77.205:3100/loki/api/v1/push
+    syslog-example:
+        override: merge
+        type: syslog
+        location: tcp://192.168.10.241:1514
+```
+
+By default, all services' logs will be forwarded to these targets. For each log target, you can optionally specify the `selection` key, with the following possible values:
+
+* `opt-out`: each service which doesn't *explicitly specify* log targets will have its logs forwarded to this target. This is the default behaviour.
+* `opt-in`: a service must explicitly specify this log target to have its logs forwarded here.
+* `disabled`: no logs will be sent to this target. This can be used in combination with `override: replace` to disable a log target defined in an earlier layer.
+
+In the definition for each service, you can also specify a list `log-targets` of log targets to forward this service's logs to. The names in the list will be matched against targets defined in the `log-targets` section of the plan. If no targets are specified, the service's logs will be sent to all "opt-out" targets.
+
+For example, in the following (incomplete) plan:
+```yaml
+services:
+    svc1:
+        ...
+    svc2:
+        log-targets: ['tgtA', 'tgtC']
+    svc3:
+        log-targets: ['tgtD']
+log-targets:
+    tgtA:
+        ...
+    tgtB:
+        selection: opt-out
+    tgtC:
+        selection: opt-in
+    tgtD:
+        selection: disabled
+```
+
+- `svc1` doesn't explicitly specify log-targets, so its logs will be forwarded to `tgtA` and `tgtB`.
+- `svc2` explicitly specifies `tgtA` and `tgtC`, so its logs will be sent to those targets. `svc2`'s logs will not be sent to `tgtB` or `tgtD`.
+- `svc3` explicitly specifies `tgtD`, but since this target is disabled, it will not receive any logs. Hence, `svc3`'s logs will not be sent anywhere.
+-->
+
 ## Container usage
 
 Pebble works well as a local service manager, but if running Pebble in a separate container, you can use the exec and file management APIs to coordinate with the remote system over the shared unix socket.

--- a/README.md
+++ b/README.md
@@ -457,7 +457,47 @@ log-targets:
 - `svc3` explicitly specifies `tgtD`, but since this target is disabled, it will not receive any logs. Hence, `svc3`'s logs will not be sent anywhere.
 - `svc4` explicitly specifies an *empty list* of log targets. Hence, its logs will not be sent anywhere.
 
-TODO: document the replace key ^log-targets and default value
+When merging services, new `log-targets` specified in the override layer will be *appended* to the existing `log-targets` specified in the base layer. For example, with the (partial) base layer:
+```yaml
+svc1:
+    log-targets: [tgt1]
+```
+and override layer
+```yaml
+svc1:
+    log-targets: [tgt2]
+    override: merge
+```
+the resulting merged layer will be
+```yaml
+svc1:
+    log-targets: [tgt1, tgt2]
+```
+
+To remove existing `log-targets` specified by a service, use the special `^log-targets` key. This behaves like `log-targets` but has "replace" semantics, even in a merge. Taking the previous example, if we instead use the override layer
+```yaml
+svc1:
+    ^log-targets: [tgt2]
+    override: merge
+```
+the resulting merged layer will be
+```yaml
+svc1:
+  log-targets: [tgt2]
+```
+
+To restore the default unspecified behaviour for `log-targets` (i.e. forwarding logs to all opt-out targets), we can use the special `default` keyword for `^log-targets`. For example, using the following override layer
+```yaml
+svc1:
+    ^log-targets: default
+    override: merge
+```
+will result in
+```yaml
+svc1:
+    log-targets: ~
+```
+equivalent to if `svc1.log-targets` had never been specified at all.
 -->
 
 ## Container usage

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -919,7 +919,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		}
 
 		if logTargets != nil {
-			for _, targetName := range service.LogTargets.Targets {
+			for _, targetName := range logTargets.Targets {
 				_, ok := combined.LogTargets[targetName]
 				if !ok {
 					return nil, &FormatError{

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -355,6 +355,12 @@ func (t *LogTargets) Copy() *LogTargets {
 
 // Merge merges the fields from other into t.
 func (t *LogTargets) Merge(other *LogTargets) {
+	// anything <- keyword yields keyword
+	if other.Keyword != "" {
+		t.Keyword = other.Keyword
+		t.Targets = nil
+	}
+
 	// keyword <- [list] yields [list]
 	if t.Keyword != "" && len(other.Targets) > 0 {
 		t.Keyword = ""

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -880,7 +880,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		}
 
 		logTargets := service.LogTargets
-		if logTargets == nil {
+		if logTargets == nil && service.LogTargetsReplace != nil {
 			logTargets = service.LogTargetsReplace.Targets
 		}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -196,7 +196,7 @@ func (s *Service) Merge(other *Service) {
 		s.LogTargets = other.LogTargetsReplace.Copy()
 	} else if s.LogTargets != nil {
 		s.LogTargets.Merge(other.LogTargets)
-	} else {
+	} else if other.LogTargets != nil {
 		s.LogTargets = other.LogTargets.Copy()
 	}
 }

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -206,8 +206,6 @@ func (s *Service) Merge(other *Service) {
 // copyStrings returns a copy of the provided []string, in such a way that:
 //   - copyStrings(nil) returns nil;
 //   - copyStrings([]string{}) returns []string{}.
-//
-// TODO: move this function into canonical/x-go/strutil
 func copyStrings(s []string) []string {
 	if s == nil {
 		return nil
@@ -219,7 +217,6 @@ func copyStrings(s []string) []string {
 
 // appendUnique appends into a the elements from b which are not yet present
 // and returns the modified slice.
-// TODO: move this function into canonical/x-go/strutil
 func appendUnique(a []string, b ...string) []string {
 Outer:
 	for _, bn := range b {
@@ -354,10 +351,10 @@ type LogTargetsReplace struct {
 	Default bool
 }
 
-const LogTargetsReplaceDefaultKeyword = "default"
+const LogTargetsReplaceDefault = "default"
 
 func (t *LogTargetsReplace) UnmarshalYAML(value *yaml.Node) error {
-	if value.Kind == yaml.ScalarNode && value.Value == LogTargetsReplaceDefaultKeyword {
+	if value.Kind == yaml.ScalarNode && value.Value == LogTargetsReplaceDefault {
 		t.Default = true
 		return nil
 	}
@@ -368,7 +365,7 @@ func (t *LogTargetsReplace) UnmarshalYAML(value *yaml.Node) error {
 
 func (t *LogTargetsReplace) MarshalYAML() (interface{}, error) {
 	if t.Default {
-		return LogTargetsReplaceDefaultKeyword, nil
+		return LogTargetsReplaceDefault, nil
 	}
 	return t.Targets, nil
 }
@@ -886,13 +883,11 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			logTargets = service.LogTargetsReplace.Targets
 		}
 
-		if logTargets != nil {
-			for _, targetName := range logTargets {
-				_, ok := combined.LogTargets[targetName]
-				if !ok {
-					return nil, &FormatError{
-						Message: fmt.Sprintf(`unknown log target %q for service %q`, targetName, serviceName),
-					}
+		for _, targetName := range logTargets {
+			_, ok := combined.LogTargets[targetName]
+			if !ok {
+				return nil, &FormatError{
+					Message: fmt.Sprintf(`unknown log target %q for service %q`, targetName, serviceName),
 				}
 			}
 		}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -196,6 +196,8 @@ func (s *Service) Merge(other *Service) {
 		} else {
 			s.LogTargets = other.LogTargetsReplace.Targets
 		}
+	} else if s.LogTargets == nil {
+		s.LogTargets = copyStrings(other.LogTargets)
 	} else {
 		s.LogTargets = appendUnique(s.LogTargets, other.LogTargets...)
 	}
@@ -875,7 +877,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 	for serviceName, service := range combined.Services {
 		if service.LogTargets != nil && service.LogTargetsReplace != nil {
 			return nil, &FormatError{
-				Message: fmt.Sprintf(`service %q cannot define both "log-targets" and "^log-targets" keys'`, serviceName),
+				Message: fmt.Sprintf(`service %q cannot define both "log-targets" and "^log-targets" keys`, serviceName),
 			}
 		}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -355,21 +355,22 @@ func (t *LogTargets) Copy() *LogTargets {
 
 // Merge merges the fields from other into t.
 func (t *LogTargets) Merge(other *LogTargets) {
-	// anything <- keyword yields keyword
 	if other.Keyword != "" {
+		// anything <- keyword yields keyword
 		t.Keyword = other.Keyword
 		t.Targets = nil
-	}
 
-	// keyword <- [list] yields [list]
-	if t.Keyword != "" && len(other.Targets) > 0 {
-		t.Keyword = ""
-		t.Targets = append([]string(nil), other.Targets...)
-		return
-	}
+	} else {
+		if t.Keyword != "" {
+			// keyword <- [list] yields [list]
+			t.Keyword = ""
+			t.Targets = append([]string(nil), other.Targets...)
 
-	// [list] <- [list] - merge lists
-	t.Targets = appendUnique(t.Targets, other.Targets...)
+		} else {
+			// [list] <- [list] - merge lists
+			t.Targets = appendUnique(t.Targets, other.Targets...)
+		}
+	}
 }
 
 // LogsTo returns true if t specifies sending logs to tgt.

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -894,6 +894,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 	// Validate service log targets
 	for serviceName, service := range combined.Services {
+		if service.LogTargets != nil && service.LogTargetsReplace != nil {
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`service %q can't define both "log-targets" and "^log-targets" keys'`, serviceName),
+			}
+		}
+
 		if service.LogTargets != nil {
 			for _, targetName := range service.LogTargets.Targets {
 				_, ok := combined.LogTargets[targetName]

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -372,26 +372,24 @@ func (t *LogTargets) Merge(other *LogTargets) {
 	t.Targets = appendUnique(t.Targets, other.Targets...)
 }
 
+// LogsTo returns true if t specifies sending logs to tgt.
 func (t *LogTargets) LogsTo(tgt *LogTarget) bool {
-	// Handle keywords
-	switch t.Keyword {
-	case AllLogTargets:
-		return tgt.Selection != DisabledSelection
-	case DefaultLogTargets:
-		return tgt.Selection == OptOutSelection || tgt.Selection == UnsetSelection
-	case NoLogTargets:
+	// False if `log-targets: none` specified, or if target disabled
+	if t.Keyword == NoLogTargets || tgt.Selection == DisabledSelection {
 		return false
 	}
 
-	// No keyword
-	if tgt.Selection == DisabledSelection {
-		return false
+	// All log-targets selected
+	if t.Keyword == AllLogTargets {
+		return true // already handled the case tgt.Selection == "disabled"
 	}
-	if len(t.Targets) == 0 {
-		if tgt.Selection == UnsetSelection || tgt.Selection == OptOutSelection {
-			return true
-		}
+
+	// Default log-targets
+	if t.Keyword == DefaultLogTargets || len(t.Targets) == 0 {
+		return tgt.Selection == OptOutSelection || tgt.Selection == UnsetSelection
 	}
+
+	// No keyword - check if log target is specified
 	for _, targetName := range t.Targets {
 		if targetName == tgt.Name {
 			return true

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -352,6 +352,13 @@ func (t *LogTargets) UnmarshalYAML(value *yaml.Node) error {
 	return value.Decode(&t.Targets)
 }
 
+func (t *LogTargets) MarshalYAML() (interface{}, error) {
+	if t.Keyword != "" {
+		return t.Keyword, nil
+	}
+	return t.Targets, nil
+}
+
 // Copy returns a deep copy of this LogTargets struct.
 func (t *LogTargets) Copy() *LogTargets {
 	return &LogTargets{

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -906,18 +906,13 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 		}
 
-		if service.LogTargets != nil {
-			for _, targetName := range service.LogTargets.Targets {
-				_, ok := combined.LogTargets[targetName]
-				if !ok {
-					return nil, &FormatError{
-						Message: fmt.Sprintf(`unknown log target %q for service %q`, targetName, serviceName),
-					}
-				}
-			}
+		logTargets := service.LogTargets
+		if logTargets == nil {
+			logTargets = service.LogTargetsReplace
 		}
-		if service.LogTargetsReplace != nil {
-			for _, targetName := range service.LogTargetsReplace.Targets {
+
+		if logTargets != nil {
+			for _, targetName := range service.LogTargets.Targets {
 				_, ok := combined.LogTargets[targetName]
 				if !ok {
 					return nil, &FormatError{

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -312,9 +312,9 @@ type LogTargets struct {
 
 const (
 	// Valid keywords for LogTargets
-	defaultLogTargets = "default"
-	allLogTargets     = "all"
-	noLogTargets      = "none"
+	DefaultLogTargets = "default"
+	AllLogTargets     = "all"
+	NoLogTargets      = "none"
 
 	// Tag used to replace value (rather than append)
 	logTargetsReplaceTag = "!replace"
@@ -326,7 +326,7 @@ func (t *LogTargets) UnmarshalYAML(value *yaml.Node) error {
 
 	if value.Kind == yaml.ScalarNode {
 		switch value.Value {
-		case defaultLogTargets, allLogTargets, noLogTargets:
+		case DefaultLogTargets, AllLogTargets, NoLogTargets:
 			t.Keyword = value.Value
 			return nil
 		default:
@@ -349,27 +349,28 @@ func (t *LogTargets) Copy() LogTargets {
 
 // MergeLogTargets returns the result of merging other into t.
 func MergeLogTargets(t, other LogTargets) (res LogTargets) {
-	if other.Replace {
+	if other.Replace || other.Keyword != "" {
 		return other
 	}
 
-	res.Targets = appendUnique(t.Targets, other.Targets...)
-	if other.Keyword == "" {
-		res.Keyword = t.Keyword
-	} else {
-		res.Keyword = other.Keyword
+	// keyword <- [list] yields [list]
+	if t.Keyword != "" && len(other.Targets) > 0 {
+		return other
 	}
+
+	// [list] <- [list] - merge lists
+	res.Targets = appendUnique(t.Targets, other.Targets...)
 	return
 }
 
 func (t *LogTargets) LogsTo(tgt *LogTarget) bool {
 	// Handle keywords
 	switch t.Keyword {
-	case allLogTargets:
+	case AllLogTargets:
 		return tgt.Selection != DisabledSelection
-	case defaultLogTargets:
+	case DefaultLogTargets:
 		return tgt.Selection == OptOutSelection || tgt.Selection == UnsetSelection
-	case noLogTargets:
+	case NoLogTargets:
 		return false
 	}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -197,7 +197,7 @@ func (s *Service) Merge(other *Service) {
 	} else if s.LogTargets != nil {
 		s.LogTargets.Merge(other.LogTargets)
 	} else {
-		s.LogTargets = other.LogTargets
+		s.LogTargets = other.LogTargets.Copy()
 	}
 }
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -318,6 +318,8 @@ const (
 	ActionIgnore   ServiceAction = "ignore"
 )
 
+// LogTargets specifies which log targets should receive a service's logs.
+// It is either an explicit list of targets, or one of the below keywords.
 type LogTargets struct {
 	Targets []string
 	Keyword string
@@ -332,6 +334,7 @@ const (
 
 func (t *LogTargets) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind == yaml.ScalarNode {
+		// decode keyword
 		switch value.Value {
 		case DefaultLogTargets, AllLogTargets, NoLogTargets:
 			t.Keyword = value.Value

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1880,3 +1880,58 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 		c.Check(base.LogTargets, DeepEquals, t.res, Commentf("merge %q <- %q", t.base, t.override))
 	}
 }
+
+func (s *S) TestLogTargetsUnmarshalYAML(c *C) {
+	tests := []struct {
+		input    string
+		expected *plan.LogTargets
+		err      string
+	}{{
+		input:    "",
+		expected: &plan.LogTargets{},
+	}, {
+		input:    "~",
+		expected: &plan.LogTargets{},
+	}, {
+		input:    "null",
+		expected: &plan.LogTargets{},
+	}, {
+		input:    "[]",
+		expected: &plan.LogTargets{Targets: []string{}},
+	}, {
+		input:    "[tgt1]",
+		expected: &plan.LogTargets{Targets: []string{"tgt1"}},
+	}, {
+		input:    "[tgt1, tgt2, tgt3]",
+		expected: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+	}, {
+		input:    "all",
+		expected: &plan.LogTargets{Keyword: plan.AllLogTargets},
+	}, {
+		input:    "default",
+		expected: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
+	}, {
+		input:    "none",
+		expected: &plan.LogTargets{Keyword: plan.NoLogTargets},
+	}, {
+		input: "invalidkeyword",
+		err:   `invalid value "invalidkeyword" for LogTargets`,
+	}}
+
+	for _, t := range tests {
+		out := &plan.LogTargets{}
+		err := yaml.Unmarshal([]byte(t.input), out)
+
+		if t.err != "" {
+			c.Assert(err, ErrorMatches, t.err)
+			continue
+		}
+
+		c.Assert(err, IsNil)
+		c.Check(out, DeepEquals, t.expected)
+	}
+}
+
+func (s *S) TestLogTargetsMarshalYAML(c *C) {
+
+}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1969,3 +1969,27 @@ func (s *S) TestLogTargetsMarshalYAML(c *C) {
 		c.Check(string(out), DeepEquals, t.expected)
 	}
 }
+
+// Test that marshalling then unmarshalling yields the original value.
+func (s *S) TestLogTargetsYAMLRoundTrip(c *C) {
+	tests := []*plan.LogTargets{
+		// nil ends up as empty slice. We are treating these as equivalent.
+		// {},
+		{Targets: []string{}},
+		{Targets: []string{"tgt1"}},
+		{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+		{Keyword: plan.AllLogTargets},
+		{Keyword: plan.DefaultLogTargets},
+		{Keyword: plan.NoLogTargets},
+	}
+
+	for _, input := range tests {
+		marshalled, err := yaml.Marshal(input)
+		c.Assert(err, IsNil)
+
+		out := &plan.LogTargets{}
+		err = yaml.Unmarshal(marshalled, out)
+		c.Assert(err, IsNil)
+		c.Check(out, DeepEquals, input)
+	}
+}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -854,7 +854,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1"},
 				},
 			},
@@ -866,7 +866,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -950,7 +950,7 @@ var planTests = []planTest{{
 				Command:  "foo",
 				Override: plan.MergeOverride,
 				Startup:  plan.StartupEnabled,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1"},
 				},
 			},
@@ -959,7 +959,7 @@ var planTests = []planTest{{
 				Command:  "bar",
 				Override: plan.MergeOverride,
 				Startup:  plan.StartupEnabled,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -987,7 +987,7 @@ var planTests = []planTest{{
 				Name:     "svc1",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
 				},
 			},
@@ -996,7 +996,7 @@ var planTests = []planTest{{
 				Command:  "bar",
 				Override: plan.ReplaceOverride,
 				Startup:  plan.StartupEnabled,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
 				},
 			},
@@ -1032,7 +1032,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt3"},
 				},
 			},
@@ -1044,7 +1044,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
 				},
 			},
@@ -1149,19 +1149,19 @@ var planTests = []planTest{{
 			svc5:
 				command: foo
 				override: merge
-				log-targets: !replace default
+				^log-targets: default
 			svc6:
 				command: foo
 				override: merge
-				log-targets: !replace all
+				^log-targets: all
 			svc7:
 				command: foo
 				override: merge
-				log-targets: !replace none
+				^log-targets: none
 			svc8:
 				command: foo
 				override: merge
-				log-targets: !replace [tgt1, tgt2]
+				^log-targets: [tgt1, tgt2]
 
 		log-targets:
 			tgt1:
@@ -1181,7 +1181,7 @@ var planTests = []planTest{{
 				Name:     "svc1",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.DefaultLogTargets,
 				},
 			},
@@ -1189,7 +1189,7 @@ var planTests = []planTest{{
 				Name:     "svc2",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.AllLogTargets,
 				},
 			},
@@ -1197,7 +1197,7 @@ var planTests = []planTest{{
 				Name:     "svc3",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.NoLogTargets,
 				},
 			},
@@ -1205,7 +1205,7 @@ var planTests = []planTest{{
 				Name:     "svc4",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -1213,36 +1213,32 @@ var planTests = []planTest{{
 				Name:     "svc5",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargetsReplace: &plan.LogTargets{
 					Keyword: plan.DefaultLogTargets,
-					Replace: true,
 				},
 			},
 			"svc6": {
 				Name:     "svc6",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargetsReplace: &plan.LogTargets{
 					Keyword: plan.AllLogTargets,
-					Replace: true,
 				},
 			},
 			"svc7": {
 				Name:     "svc7",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargetsReplace: &plan.LogTargets{
 					Keyword: plan.NoLogTargets,
-					Replace: true,
 				},
 			},
 			"svc8": {
 				Name:     "svc8",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: plan.LogTargets{
+				LogTargetsReplace: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
-					Replace: true,
 				},
 			},
 		},
@@ -1301,7 +1297,7 @@ var planTests = []planTest{{
 			svc2:
 				command: foo
 				override: merge
-				log-targets: !replace [tgt3]
+				^log-targets: [tgt3]
 			svc3:
 				command: foo
 				override: merge
@@ -1334,7 +1330,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2", "tgt3"},
 				},
 			},
@@ -1345,9 +1341,8 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt3"},
-					Replace: true,
 				},
 			},
 			"svc3": {
@@ -1357,7 +1352,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Keyword: plan.DefaultLogTargets,
 				},
 			},
@@ -1368,7 +1363,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: plan.LogTargets{
+				LogTargets: &plan.LogTargets{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -1748,25 +1743,25 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "disabled", Selection: plan.DisabledSelection},
 	}
 	services := []*plan.Service{
-		{Name: "svc1", LogTargets: plan.LogTargets{
+		{Name: "svc1", LogTargets: &plan.LogTargets{
 			Targets: nil,
 		}},
-		{Name: "svc2", LogTargets: plan.LogTargets{
+		{Name: "svc2", LogTargets: &plan.LogTargets{
 			Targets: []string{},
 		}},
-		{Name: "svc3", LogTargets: plan.LogTargets{
+		{Name: "svc3", LogTargets: &plan.LogTargets{
 			Targets: []string{"unset"},
 		}},
-		{Name: "svc4", LogTargets: plan.LogTargets{
+		{Name: "svc4", LogTargets: &plan.LogTargets{
 			Targets: []string{"optout"},
 		}},
-		{Name: "svc5", LogTargets: plan.LogTargets{
+		{Name: "svc5", LogTargets: &plan.LogTargets{
 			Targets: []string{"optin"},
 		}},
-		{Name: "svc6", LogTargets: plan.LogTargets{
+		{Name: "svc6", LogTargets: &plan.LogTargets{
 			Targets: []string{"disabled"},
 		}},
-		{Name: "svc7", LogTargets: plan.LogTargets{
+		{Name: "svc7", LogTargets: &plan.LogTargets{
 			Targets: []string{"unset", "optin", "disabled"},
 		}},
 	}
@@ -1796,73 +1791,80 @@ func (s *S) TestSelectTargets(c *C) {
 func (s *S) TestParseAndMergeLogTargets(c *C) {
 	tests := []struct {
 		base, override string
-		res            plan.LogTargets
+		res            *plan.LogTargets
 	}{{
-		base: "[tgt1]", override: "[tgt3]",
-		res: plan.LogTargets{
+		base:     "log-targets: [tgt1]",
+		override: "log-targets: [tgt3]",
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1", "tgt3"},
 		},
 	}, {
-		base: "[tgt1]", override: "!replace [tgt3]",
-		res: plan.LogTargets{
+		base:     "log-targets: [tgt1]",
+		override: "^log-targets: [tgt3]",
+		res: &plan.LogTargets{
 			Targets: []string{"tgt3"},
-			Replace: true,
 		},
 	}, {
-		base: "default", override: "all",
-		res: plan.LogTargets{
+		base:     "log-targets: default",
+		override: "log-targets: all",
+		res: &plan.LogTargets{
 			Keyword: plan.AllLogTargets,
 		},
 	}, {
-		base: "[tgt1]", override: "default",
-		res: plan.LogTargets{
+		base:     "log-targets: [tgt1]",
+		override: "log-targets: default",
+		res: &plan.LogTargets{
 			Keyword: plan.DefaultLogTargets,
 		},
 	}, {
-		base: "[tgt1]", override: "!replace default",
-		res: plan.LogTargets{
+		base:     "log-targets: [tgt1]",
+		override: "^log-targets: default",
+		res: &plan.LogTargets{
 			Keyword: plan.DefaultLogTargets,
-			Replace: true,
 		},
 	}, {
-		base: "[tgt1]", override: "none",
-		res: plan.LogTargets{
+		base:     "log-targets: [tgt1]",
+		override: "log-targets: none",
+		res: &plan.LogTargets{
 			Keyword: plan.NoLogTargets,
 		},
 	}, {
-		base: "[tgt1]", override: "!replace none",
-		res: plan.LogTargets{
+		base:     "log-targets: [tgt1]",
+		override: "^log-targets: none",
+		res: &plan.LogTargets{
 			Keyword: plan.NoLogTargets,
-			Replace: true,
 		},
 	}, {
-		base: "default", override: "[tgt1]",
-		res: plan.LogTargets{
+		base:     "log-targets: default",
+		override: "log-targets: [tgt1]",
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
 	}, {
-		base: "all", override: "[tgt1]",
-		res: plan.LogTargets{
+		base:     "log-targets: all",
+		override: "log-targets: [tgt1]",
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
 	}, {
-		base: "none", override: "[tgt1]",
-		res: plan.LogTargets{
+		base:     "log-targets: none",
+		override: "log-targets: [tgt1]",
+		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
 	}}
 
-	parseLogTargets := func(raw string) plan.LogTargets {
-		parsed := plan.LogTargets{}
-		err := yaml.Unmarshal([]byte(raw), &parsed)
+	parseService := func(raw string) *plan.Service {
+		parsed := &plan.Service{}
+		err := yaml.Unmarshal([]byte(raw), parsed)
 		c.Assert(err, IsNil)
 		return parsed
 	}
 
 	for _, t := range tests {
-		base := parseLogTargets(t.base)
-		override := parseLogTargets(t.override)
-		merged := plan.MergeLogTargets(base, override)
-		c.Check(merged, DeepEquals, t.res, Commentf("merge %s <- %s", t.base, t.override))
+		base := parseService(t.base)
+		override := parseService(t.override)
+		base.Merge(override)
+		c.Check(base.LogTargets, DeepEquals, t.res, Commentf("merge %q <- %q", t.base, t.override))
 	}
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1126,6 +1126,275 @@ var planTests = []planTest{{
 				location: http://10.1.77.196:3100/loki/api/v1/push
 				override: merge
 `},
+}, {
+	summary: "LogTargets parsing",
+	input: []string{`
+		services:
+			svc1:
+				command: foo
+				override: merge
+				log-targets: default
+			svc2:
+				command: foo
+				override: merge
+				log-targets: all
+			svc3:
+				command: foo
+				override: merge
+				log-targets: none
+			svc4:
+				command: foo
+				override: merge
+				log-targets: [tgt1, tgt2]
+			svc5:
+				command: foo
+				override: merge
+				log-targets: !replace default
+			svc6:
+				command: foo
+				override: merge
+				log-targets: !replace all
+			svc7:
+				command: foo
+				override: merge
+				log-targets: !replace none
+			svc8:
+				command: foo
+				override: merge
+				log-targets: !replace [tgt1, tgt2]
+
+		log-targets:
+			tgt1:
+				type: loki
+				selection: disabled
+				override: merge
+			tgt2:
+				type: loki
+				selection: disabled
+				override: merge
+`},
+	layers: []*plan.Layer{{
+		Label: "layer-0",
+		Order: 0,
+		Services: map[string]*plan.Service{
+			"svc1": {
+				Name:     "svc1",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Keyword: plan.DefaultLogTargets,
+				},
+			},
+			"svc2": {
+				Name:     "svc2",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Keyword: plan.AllLogTargets,
+				},
+			},
+			"svc3": {
+				Name:     "svc3",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Keyword: plan.NoLogTargets,
+				},
+			},
+			"svc4": {
+				Name:     "svc4",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+				},
+			},
+			"svc5": {
+				Name:     "svc5",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Keyword: plan.DefaultLogTargets,
+					Replace: true,
+				},
+			},
+			"svc6": {
+				Name:     "svc6",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Keyword: plan.AllLogTargets,
+					Replace: true,
+				},
+			},
+			"svc7": {
+				Name:     "svc7",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Keyword: plan.NoLogTargets,
+					Replace: true,
+				},
+			},
+			"svc8": {
+				Name:     "svc8",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+					Replace: true,
+				},
+			},
+		},
+		Checks: map[string]*plan.Check{},
+		LogTargets: map[string]*plan.LogTarget{
+			"tgt1": {
+				Name:      "tgt1",
+				Type:      plan.LokiTarget,
+				Selection: plan.DisabledSelection,
+				Override:  plan.MergeOverride,
+			},
+			"tgt2": {
+				Name:      "tgt2",
+				Type:      plan.LokiTarget,
+				Selection: plan.DisabledSelection,
+				Override:  plan.MergeOverride,
+			},
+		},
+	}},
+}, {
+	summary: "Replacing LogTargets in merge",
+	input: []string{`
+		services:
+			svc1:
+				command: foo
+				override: merge
+				log-targets: [tgt1, tgt2]
+			svc2:
+				command: foo
+				override: merge
+				log-targets: [tgt1, tgt2]
+			svc3:
+				command: foo
+				override: merge
+				log-targets: [tgt1, tgt2]
+			svc4:
+				command: foo
+				override: merge
+				log-targets: none
+
+		log-targets:
+			tgt1:
+				type: loki
+				selection: disabled
+				override: merge
+			tgt2:
+				type: loki
+				selection: disabled
+				override: merge
+`, `
+		services:
+			svc1:
+				command: foo
+				override: merge
+				log-targets: [tgt3]
+			svc2:
+				command: foo
+				override: merge
+				log-targets: !replace [tgt3]
+			svc3:
+				command: foo
+				override: merge
+				log-targets: default
+			svc4:
+				command: foo
+				override: merge
+				log-targets: [tgt1, tgt2]
+
+		log-targets:
+			tgt1:
+				type: loki
+				selection: disabled
+				override: merge
+			tgt2:
+				type: loki
+				selection: disabled
+				override: merge
+			tgt3:
+				type: loki
+				selection: disabled
+				override: merge
+`},
+	result: &plan.Layer{
+		Services: map[string]*plan.Service{
+			"svc1": {
+				Name:          "svc1",
+				Command:       "foo",
+				Override:      plan.MergeOverride,
+				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
+				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
+				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2", "tgt3"},
+				},
+			},
+			"svc2": {
+				Name:          "svc2",
+				Command:       "foo",
+				Override:      plan.MergeOverride,
+				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
+				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
+				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+					Replace: true,
+				},
+			},
+			"svc3": {
+				Name:          "svc3",
+				Command:       "foo",
+				Override:      plan.MergeOverride,
+				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
+				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
+				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
+				LogTargets: plan.LogTargets{
+					Keyword: plan.DefaultLogTargets,
+				},
+			},
+			"svc4": {
+				Name:          "svc4",
+				Command:       "foo",
+				Override:      plan.MergeOverride,
+				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
+				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
+				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+				},
+			},
+		},
+		Checks: map[string]*plan.Check{},
+		LogTargets: map[string]*plan.LogTarget{
+			"tgt1": {
+				Name:      "tgt1",
+				Type:      plan.LokiTarget,
+				Selection: plan.DisabledSelection,
+				Override:  plan.MergeOverride,
+			},
+			"tgt2": {
+				Name:      "tgt2",
+				Type:      plan.LokiTarget,
+				Selection: plan.DisabledSelection,
+				Override:  plan.MergeOverride,
+			},
+			"tgt3": {
+				Name:      "tgt3",
+				Type:      plan.LokiTarget,
+				Selection: plan.DisabledSelection,
+				Override:  plan.MergeOverride,
+			},
+		},
+	},
 }}
 
 func (s *S) TestParseLayer(c *C) {
@@ -1524,23 +1793,76 @@ func (s *S) TestSelectTargets(c *C) {
 	}
 }
 
-func (s *S) TestMergeLogTargets(c *C) {
+func (s *S) TestParseAndMergeLogTargets(c *C) {
 	tests := []struct {
-		t1, t2, res plan.LogTargets
+		base, override string
+		res            plan.LogTargets
 	}{{
-		t1: plan.LogTargets{
-			Targets: []string{"tgt1"},
-		},
-		t2: plan.LogTargets{
-			Targets: []string{"tgt3"},
-		},
+		base: "[tgt1]", override: "[tgt3]",
 		res: plan.LogTargets{
 			Targets: []string{"tgt1", "tgt3"},
 		},
+	}, {
+		base: "[tgt1]", override: "!replace [tgt3]",
+		res: plan.LogTargets{
+			Targets: []string{"tgt3"},
+			Replace: true,
+		},
+	}, {
+		base: "default", override: "all",
+		res: plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base: "[tgt1]", override: "default",
+		res: plan.LogTargets{
+			Keyword: plan.DefaultLogTargets,
+		},
+	}, {
+		base: "[tgt1]", override: "!replace default",
+		res: plan.LogTargets{
+			Keyword: plan.DefaultLogTargets,
+			Replace: true,
+		},
+	}, {
+		base: "[tgt1]", override: "none",
+		res: plan.LogTargets{
+			Keyword: plan.NoLogTargets,
+		},
+	}, {
+		base: "[tgt1]", override: "!replace none",
+		res: plan.LogTargets{
+			Keyword: plan.NoLogTargets,
+			Replace: true,
+		},
+	}, {
+		base: "default", override: "[tgt1]",
+		res: plan.LogTargets{
+			Targets: []string{"tgt1"},
+		},
+	}, {
+		base: "all", override: "[tgt1]",
+		res: plan.LogTargets{
+			Targets: []string{"tgt1"},
+		},
+	}, {
+		base: "none", override: "[tgt1]",
+		res: plan.LogTargets{
+			Targets: []string{"tgt1"},
+		},
 	}}
 
+	parseLogTargets := func(raw string) plan.LogTargets {
+		parsed := plan.LogTargets{}
+		err := yaml.Unmarshal([]byte(raw), &parsed)
+		c.Assert(err, IsNil)
+		return parsed
+	}
+
 	for _, t := range tests {
-		merged := plan.MergeLogTargets(t.t1, t.t2)
-		c.Check(merged, DeepEquals, t.res)
+		base := parseLogTargets(t.base)
+		override := parseLogTargets(t.override)
+		merged := plan.MergeLogTargets(base, override)
+		c.Check(merged, DeepEquals, t.res, Commentf("merge %s <- %s", t.base, t.override))
 	}
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1111,243 +1111,32 @@ var planTests = []planTest{{
 				override: merge
 `},
 }, {
-	summary: "LogTargets parsing",
+	summary: `Service specifies unknown log target in "^log-targets"`,
+	error:   `unknown log target "tgt2" for service "svc1"`,
 	input: []string{`
 		services:
 			svc1:
 				command: foo
 				override: merge
-				log-targets: default
-			svc2:
-				command: foo
-				override: merge
-				log-targets: all
-			svc3:
-				command: foo
-				override: merge
-				log-targets: none
-			svc4:
-				command: foo
-				override: merge
-				log-targets: [tgt1, tgt2]
-			svc5:
-				command: foo
-				override: merge
-				^log-targets: default
-			svc6:
-				command: foo
-				override: merge
-				^log-targets: all
-			svc7:
-				command: foo
-				override: merge
-				^log-targets: none
-			svc8:
-				command: foo
-				override: merge
-				^log-targets: [tgt1, tgt2]
-
+				^log-targets:
+					- tgt2
 		log-targets:
 			tgt1:
 				type: loki
-				selection: disabled
-				override: merge
-			tgt2:
-				type: loki
-				selection: disabled
+				location: http://10.1.77.196:3100/loki/api/v1/push
 				override: merge
 `},
-	layers: []*plan.Layer{{
-		Label: "layer-0",
-		Order: 0,
-		Services: map[string]*plan.Service{
-			"svc1": {
-				Name:     "svc1",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-			},
-			"svc2": {
-				Name:     "svc2",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-			},
-			"svc3": {
-				Name:     "svc3",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-			},
-			"svc4": {
-				Name:       "svc4",
-				Command:    "foo",
-				Override:   plan.MergeOverride,
-				LogTargets: []string{"tgt1", "tgt2"},
-			},
-			"svc5": {
-				Name:     "svc5",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-				LogTargetsReplace: &plan.LogTargetsReplace{
-					Default: true,
-				},
-			},
-			"svc6": {
-				Name:     "svc6",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-			},
-			"svc7": {
-				Name:     "svc7",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-			},
-			"svc8": {
-				Name:     "svc8",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-				LogTargetsReplace: &plan.LogTargetsReplace{
-					Targets: []string{"tgt1", "tgt2"},
-				},
-			},
-		},
-		Checks: map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{
-			"tgt1": {
-				Name:      "tgt1",
-				Type:      plan.LokiTarget,
-				Selection: plan.DisabledSelection,
-				Override:  plan.MergeOverride,
-			},
-			"tgt2": {
-				Name:      "tgt2",
-				Type:      plan.LokiTarget,
-				Selection: plan.DisabledSelection,
-				Override:  plan.MergeOverride,
-			},
-		},
-	}},
 }, {
-	summary: "Replacing LogTargets in merge",
+	summary: `Service defines both "log-targets" and "^log-targets"`,
+	error:   `service "svc1" cannot define both "log-targets" and "\^log-targets" keys`,
 	input: []string{`
 		services:
 			svc1:
 				command: foo
 				override: merge
-				log-targets: [tgt1, tgt2]
-			svc2:
-				command: foo
-				override: merge
-				log-targets: [tgt1, tgt2]
-			svc3:
-				command: foo
-				override: merge
-				log-targets: [tgt1, tgt2]
-			svc4:
-				command: foo
-				override: merge
-				log-targets: none
-
-		log-targets:
-			tgt1:
-				type: loki
-				selection: disabled
-				override: merge
-			tgt2:
-				type: loki
-				selection: disabled
-				override: merge
-`, `
-		services:
-			svc1:
-				command: foo
-				override: merge
-				log-targets: [tgt3]
-			svc2:
-				command: foo
-				override: merge
-				^log-targets: [tgt3]
-			svc3:
-				command: foo
-				override: merge
-				log-targets: default
-			svc4:
-				command: foo
-				override: merge
-				log-targets: [tgt1, tgt2]
-
-		log-targets:
-			tgt1:
-				type: loki
-				selection: disabled
-				override: merge
-			tgt2:
-				type: loki
-				selection: disabled
-				override: merge
-			tgt3:
-				type: loki
-				selection: disabled
-				override: merge
+				log-targets: [tgt1]
+				^log-targets: [tgt2]
 `},
-	result: &plan.Layer{
-		Services: map[string]*plan.Service{
-			"svc1": {
-				Name:          "svc1",
-				Command:       "foo",
-				Override:      plan.MergeOverride,
-				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
-				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
-				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1", "tgt2", "tgt3"},
-			},
-			"svc2": {
-				Name:          "svc2",
-				Command:       "foo",
-				Override:      plan.MergeOverride,
-				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
-				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
-				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt3"},
-			},
-			"svc3": {
-				Name:          "svc3",
-				Command:       "foo",
-				Override:      plan.MergeOverride,
-				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
-				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
-				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-			},
-			"svc4": {
-				Name:          "svc4",
-				Command:       "foo",
-				Override:      plan.MergeOverride,
-				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
-				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
-				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1", "tgt2"},
-			},
-		},
-		Checks: map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{
-			"tgt1": {
-				Name:      "tgt1",
-				Type:      plan.LokiTarget,
-				Selection: plan.DisabledSelection,
-				Override:  plan.MergeOverride,
-			},
-			"tgt2": {
-				Name:      "tgt2",
-				Type:      plan.LokiTarget,
-				Selection: plan.DisabledSelection,
-				Override:  plan.MergeOverride,
-			},
-			"tgt3": {
-				Name:      "tgt3",
-				Type:      plan.LokiTarget,
-				Selection: plan.DisabledSelection,
-				Override:  plan.MergeOverride,
-			},
-		},
-	},
 }}
 
 func (s *S) TestParseLayer(c *C) {
@@ -1701,51 +1490,25 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "disabled", Selection: plan.DisabledSelection},
 	}
 	services := []*plan.Service{
-		//	{Name: "svc1", LogTargets: &plan.LogTargets{
-		//		Targets: nil,
-		//	}},
-		//	{Name: "svc2", LogTargets: &plan.LogTargets{
-		//		Targets: []string{},
-		//	}},
-		//	{Name: "svc3", LogTargets: &plan.LogTargets{
-		//		Targets: []string{"unset"},
-		//	}},
-		//	{Name: "svc4", LogTargets: &plan.LogTargets{
-		//		Targets: []string{"optout"},
-		//	}},
-		//	{Name: "svc5", LogTargets: &plan.LogTargets{
-		//		Targets: []string{"optin"},
-		//	}},
-		//	{Name: "svc6", LogTargets: &plan.LogTargets{
-		//		Targets: []string{"disabled"},
-		//	}},
-		//	{Name: "svc7", LogTargets: &plan.LogTargets{
-		//		Targets: []string{"unset", "optin", "disabled"},
-		//	}},
-		//	{Name: "svc8", LogTargets: &plan.LogTargets{
-		//		Keyword: plan.DefaultLogTargets,
-		//	}},
-		//	{Name: "svc9", LogTargets: &plan.LogTargets{
-		//		Keyword: plan.AllLogTargets,
-		//	}},
-		//	{Name: "svc10", LogTargets: &plan.LogTargets{
-		//		Keyword: plan.NoLogTargets,
-		//	}},
+		{Name: "svc1", LogTargets: nil},
+		{Name: "svc2", LogTargets: []string{}},
+		{Name: "svc3", LogTargets: []string{"unset"}},
+		{Name: "svc4", LogTargets: []string{"optout"}},
+		{Name: "svc5", LogTargets: []string{"optin"}},
+		{Name: "svc6", LogTargets: []string{"disabled"}},
+		{Name: "svc7", LogTargets: []string{"unset", "optin", "disabled"}},
 	}
 
 	// Use pointers to bools so the test will fail if we forget to set a value
 	t, f := true, false
 	expected := map[string]map[string]*bool{
-		"svc1":  {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
-		"svc2":  {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
-		"svc3":  {"unset": &t, "optout": &f, "optin": &f, "disabled": &f},
-		"svc4":  {"unset": &f, "optout": &t, "optin": &f, "disabled": &f},
-		"svc5":  {"unset": &f, "optout": &f, "optin": &t, "disabled": &f},
-		"svc6":  {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
-		"svc7":  {"unset": &t, "optout": &f, "optin": &t, "disabled": &f},
-		"svc8":  {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
-		"svc9":  {"unset": &t, "optout": &t, "optin": &t, "disabled": &f},
-		"svc10": {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
+		"svc1": {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
+		"svc2": {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
+		"svc3": {"unset": &t, "optout": &f, "optin": &f, "disabled": &f},
+		"svc4": {"unset": &f, "optout": &t, "optin": &f, "disabled": &f},
+		"svc5": {"unset": &f, "optout": &f, "optin": &t, "disabled": &f},
+		"svc6": {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
+		"svc7": {"unset": &t, "optout": &f, "optin": &t, "disabled": &f},
 	}
 
 	for _, service := range services {
@@ -1766,6 +1529,54 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 		base:       "log-targets: ~",
 		override:   "log-targets: ~",
 		logTargets: nil,
+	}, {
+		base:       "log-targets: ~",
+		override:   "log-targets: []",
+		logTargets: []string{},
+	}, {
+		base:       "log-targets: ~",
+		override:   "log-targets: [tgt1, tgt2]",
+		logTargets: []string{"tgt1", "tgt2"},
+	}, {
+		base:       "log-targets: []",
+		override:   "log-targets: ~",
+		logTargets: []string{},
+	}, {
+		base:       "log-targets: []",
+		override:   "^log-targets: ~",
+		logTargets: []string{},
+	}, {
+		base:       "log-targets: []",
+		override:   "^log-targets: default",
+		logTargets: nil,
+	}, {
+		base:       "log-targets: ~",
+		override:   "^log-targets: default",
+		logTargets: nil,
+	}, {
+		base:       "log-targets: [tgt1, tgt2]",
+		override:   "^log-targets: default",
+		logTargets: nil,
+	}, {
+		base:       "log-targets: [tgt1]",
+		override:   "log-targets: [tgt2]",
+		logTargets: []string{"tgt1", "tgt2"},
+	}, {
+		base:       "log-targets: [tgt1]",
+		override:   "^log-targets: [tgt2]",
+		logTargets: []string{"tgt2"},
+	}, {
+		base:       "log-targets: [tgt1, tgt2, tgt3]",
+		override:   "log-targets: [tgt2]",
+		logTargets: []string{"tgt1", "tgt2", "tgt3"},
+	}, {
+		base:       "log-targets: [tgt1, tgt2, tgt3]",
+		override:   "^log-targets: [tgt2]",
+		logTargets: []string{"tgt2"},
+	}, {
+		base:       "log-targets: [tgt1, tgt2, tgt3]",
+		override:   "^log-targets: default",
+		logTargets: nil,
 	}}
 
 	parseService := func(raw string) *plan.Service {
@@ -1783,116 +1594,91 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 	}
 }
 
-//
-//func (s *S) TestLogTargetsUnmarshalYAML(c *C) {
-//	tests := []struct {
-//		input    string
-//		expected *plan.LogTargets
-//		err      string
-//	}{{
-//		input:    "",
-//		expected: &plan.LogTargets{},
-//	}, {
-//		input:    "~",
-//		expected: &plan.LogTargets{},
-//	}, {
-//		input:    "null",
-//		expected: &plan.LogTargets{},
-//	}, {
-//		input:    "[]",
-//		expected: &plan.LogTargets{Targets: []string{}},
-//	}, {
-//		input:    "[tgt1]",
-//		expected: &plan.LogTargets{Targets: []string{"tgt1"}},
-//	}, {
-//		input:    "[tgt1, tgt2, tgt3]",
-//		expected: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
-//	}, {
-//		input:    "all",
-//		expected: &plan.LogTargets{Keyword: plan.AllLogTargets},
-//	}, {
-//		input:    "default",
-//		expected: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
-//	}, {
-//		input:    "none",
-//		expected: &plan.LogTargets{Keyword: plan.NoLogTargets},
-//	}, {
-//		input: "invalidkeyword",
-//		err:   `invalid value "invalidkeyword" for LogTargets`,
-//	}}
-//
-//	for _, t := range tests {
-//		out := &plan.LogTargets{}
-//		err := yaml.Unmarshal([]byte(t.input), out)
-//
-//		if t.err != "" {
-//			c.Assert(err, ErrorMatches, t.err)
-//			continue
-//		}
-//
-//		c.Assert(err, IsNil)
-//		c.Check(out, DeepEquals, t.expected)
-//	}
-//}
-//
-//func (s *S) TestLogTargetsMarshalYAML(c *C) {
-//	tests := []struct {
-//		input    *plan.LogTargets
-//		expected string
-//	}{{
-//		input: &plan.LogTargets{},
-//		// nil slice unmarshals to []
-//		expected: `[]
-//`}, {
-//		input: &plan.LogTargets{Targets: []string{}},
-//		expected: `[]
-//`}, {
-//		input: &plan.LogTargets{Targets: []string{"tgt1"}},
-//		expected: `- tgt1
-//`}, {
-//		input: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
-//		expected: `
-//- tgt1
-//- tgt2
-//- tgt3
-//`[1:]}, {
-//		input: &plan.LogTargets{Keyword: plan.AllLogTargets},
-//		expected: `all
-//`}, {
-//		input: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
-//		expected: `default
-//`}, {
-//		input: &plan.LogTargets{Keyword: plan.NoLogTargets},
-//		expected: `none
-//`}}
-//
-//	for _, t := range tests {
-//		out, err := yaml.Marshal(t.input)
-//		c.Assert(err, IsNil)
-//		c.Check(string(out), DeepEquals, t.expected)
-//	}
-//}
-//
-//// Test that marshalling then unmarshalling yields the original value.
-//func (s *S) TestLogTargetsYAMLRoundTrip(c *C) {
-//	tests := []*plan.LogTargets{
-//		// nil ends up as empty slice. We are treating these as equivalent.
-//		// {},
-//		{Targets: []string{}},
-//		{Targets: []string{"tgt1"}},
-//		{Targets: []string{"tgt1", "tgt2", "tgt3"}},
-//		{Keyword: plan.AllLogTargets},
-//		{Keyword: plan.DefaultLogTargets},
-//		{Keyword: plan.NoLogTargets},
-//	}
-//
-//	for _, input := range tests {
-//		marshalled, err := yaml.Marshal(input)
-//		c.Assert(err, IsNil)
-//
-//		out := &plan.LogTargets{}
-//		err = yaml.Unmarshal(marshalled, out)
-//		c.Assert(err, IsNil)
-//		c.Check(out, DeepEquals, input)
-//	}
-//}
+func (s *S) TestLogTargetsReplaceUnmarshalYAML(c *C) {
+	tests := []struct {
+		input    string
+		expected *plan.LogTargetsReplace
+	}{{
+		input:    "",
+		expected: &plan.LogTargetsReplace{},
+	}, {
+		input:    "~",
+		expected: &plan.LogTargetsReplace{},
+	}, {
+		input:    "null",
+		expected: &plan.LogTargetsReplace{},
+	}, {
+		input:    "[]",
+		expected: &plan.LogTargetsReplace{Targets: []string{}},
+	}, {
+		input:    "[tgt1]",
+		expected: &plan.LogTargetsReplace{Targets: []string{"tgt1"}},
+	}, {
+		input:    "[tgt1, tgt2, tgt3]",
+		expected: &plan.LogTargetsReplace{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+	}, {
+		input:    "default",
+		expected: &plan.LogTargetsReplace{Default: true},
+	}}
+
+	for _, t := range tests {
+		out := &plan.LogTargetsReplace{}
+		err := yaml.Unmarshal([]byte(t.input), out)
+		c.Assert(err, IsNil)
+		c.Check(out, DeepEquals, t.expected)
+	}
+}
+
+func (s *S) TestLogTargetsReplaceMarshalYAML(c *C) {
+	tests := []struct {
+		input    *plan.LogTargetsReplace
+		expected string
+	}{{
+		input: &plan.LogTargetsReplace{},
+		// nil slice unmarshals to []
+		expected: `[]
+`}, {
+		input: &plan.LogTargetsReplace{Targets: []string{}},
+		expected: `[]
+`}, {
+		input: &plan.LogTargetsReplace{Targets: []string{"tgt1"}},
+		expected: `- tgt1
+`}, {
+		input: &plan.LogTargetsReplace{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+		expected: `
+- tgt1
+- tgt2
+- tgt3
+`[1:]}, {
+		input: &plan.LogTargetsReplace{Default: true},
+		expected: `default
+`}}
+
+	for _, t := range tests {
+		out, err := yaml.Marshal(t.input)
+		c.Assert(err, IsNil)
+		c.Check(string(out), DeepEquals, t.expected)
+	}
+}
+
+// Test that marshalling then unmarshalling yields the original value.
+func (s *S) TestLogTargetsReplaceYAMLRoundTrip(c *C) {
+	tests := []*plan.LogTargetsReplace{
+		// nil ends up as empty slice. We are treating these as equivalent.
+		// {},
+		{Targets: []string{}},
+		{Targets: []string{"tgt1"}},
+		{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+		{Default: true},
+	}
+
+	for _, input := range tests {
+		marshalled, err := yaml.Marshal(input)
+		c.Assert(err, IsNil)
+
+		out := &plan.LogTargetsReplace{}
+		err = yaml.Unmarshal(marshalled, out)
+		c.Assert(err, IsNil)
+		c.Check(out, DeepEquals, input)
+	}
+}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -854,9 +854,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1"},
-				},
+				LogTargets:    []string{"tgt1"},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -866,9 +864,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1", "tgt2"},
-				},
+				LogTargets:    []string{"tgt1", "tgt2"},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -946,22 +942,18 @@ var planTests = []planTest{{
 		Order: 0,
 		Services: map[string]*plan.Service{
 			"svc1": {
-				Name:     "svc1",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-				Startup:  plan.StartupEnabled,
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1"},
-				},
+				Name:       "svc1",
+				Command:    "foo",
+				Override:   plan.MergeOverride,
+				Startup:    plan.StartupEnabled,
+				LogTargets: []string{"tgt1"},
 			},
 			"svc2": {
-				Name:     "svc2",
-				Command:  "bar",
-				Override: plan.MergeOverride,
-				Startup:  plan.StartupEnabled,
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1", "tgt2"},
-				},
+				Name:       "svc2",
+				Command:    "bar",
+				Override:   plan.MergeOverride,
+				Startup:    plan.StartupEnabled,
+				LogTargets: []string{"tgt1", "tgt2"},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -984,21 +976,17 @@ var planTests = []planTest{{
 		Order: 1,
 		Services: map[string]*plan.Service{
 			"svc1": {
-				Name:     "svc1",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt3"},
-				},
+				Name:       "svc1",
+				Command:    "foo",
+				Override:   plan.MergeOverride,
+				LogTargets: []string{"tgt3"},
 			},
 			"svc2": {
-				Name:     "svc2",
-				Command:  "bar",
-				Override: plan.ReplaceOverride,
-				Startup:  plan.StartupEnabled,
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt3"},
-				},
+				Name:       "svc2",
+				Command:    "bar",
+				Override:   plan.ReplaceOverride,
+				Startup:    plan.StartupEnabled,
+				LogTargets: []string{"tgt3"},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -1032,9 +1020,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1", "tgt3"},
-				},
+				LogTargets:    []string{"tgt1", "tgt3"},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -1044,9 +1030,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt3"},
-				},
+				LogTargets:    []string{"tgt3"},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -1181,63 +1165,46 @@ var planTests = []planTest{{
 				Name:     "svc1",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: &plan.LogTargets{
-					Keyword: plan.DefaultLogTargets,
-				},
 			},
 			"svc2": {
 				Name:     "svc2",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: &plan.LogTargets{
-					Keyword: plan.AllLogTargets,
-				},
 			},
 			"svc3": {
 				Name:     "svc3",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargets: &plan.LogTargets{
-					Keyword: plan.NoLogTargets,
-				},
 			},
 			"svc4": {
-				Name:     "svc4",
-				Command:  "foo",
-				Override: plan.MergeOverride,
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1", "tgt2"},
-				},
+				Name:       "svc4",
+				Command:    "foo",
+				Override:   plan.MergeOverride,
+				LogTargets: []string{"tgt1", "tgt2"},
 			},
 			"svc5": {
 				Name:     "svc5",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargetsReplace: &plan.LogTargets{
-					Keyword: plan.DefaultLogTargets,
+				LogTargetsReplace: &plan.LogTargetsReplace{
+					Default: true,
 				},
 			},
 			"svc6": {
 				Name:     "svc6",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargetsReplace: &plan.LogTargets{
-					Keyword: plan.AllLogTargets,
-				},
 			},
 			"svc7": {
 				Name:     "svc7",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargetsReplace: &plan.LogTargets{
-					Keyword: plan.NoLogTargets,
-				},
 			},
 			"svc8": {
 				Name:     "svc8",
 				Command:  "foo",
 				Override: plan.MergeOverride,
-				LogTargetsReplace: &plan.LogTargets{
+				LogTargetsReplace: &plan.LogTargetsReplace{
 					Targets: []string{"tgt1", "tgt2"},
 				},
 			},
@@ -1330,9 +1297,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1", "tgt2", "tgt3"},
-				},
+				LogTargets:    []string{"tgt1", "tgt2", "tgt3"},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -1341,9 +1306,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt3"},
-				},
+				LogTargets:    []string{"tgt3"},
 			},
 			"svc3": {
 				Name:          "svc3",
@@ -1352,9 +1315,6 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Keyword: plan.DefaultLogTargets,
-				},
 			},
 			"svc4": {
 				Name:          "svc4",
@@ -1363,9 +1323,7 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets: &plan.LogTargets{
-					Targets: []string{"tgt1", "tgt2"},
-				},
+				LogTargets:    []string{"tgt1", "tgt2"},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -1743,36 +1701,36 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "disabled", Selection: plan.DisabledSelection},
 	}
 	services := []*plan.Service{
-		{Name: "svc1", LogTargets: &plan.LogTargets{
-			Targets: nil,
-		}},
-		{Name: "svc2", LogTargets: &plan.LogTargets{
-			Targets: []string{},
-		}},
-		{Name: "svc3", LogTargets: &plan.LogTargets{
-			Targets: []string{"unset"},
-		}},
-		{Name: "svc4", LogTargets: &plan.LogTargets{
-			Targets: []string{"optout"},
-		}},
-		{Name: "svc5", LogTargets: &plan.LogTargets{
-			Targets: []string{"optin"},
-		}},
-		{Name: "svc6", LogTargets: &plan.LogTargets{
-			Targets: []string{"disabled"},
-		}},
-		{Name: "svc7", LogTargets: &plan.LogTargets{
-			Targets: []string{"unset", "optin", "disabled"},
-		}},
-		{Name: "svc8", LogTargets: &plan.LogTargets{
-			Keyword: plan.DefaultLogTargets,
-		}},
-		{Name: "svc9", LogTargets: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		}},
-		{Name: "svc10", LogTargets: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		}},
+		//	{Name: "svc1", LogTargets: &plan.LogTargets{
+		//		Targets: nil,
+		//	}},
+		//	{Name: "svc2", LogTargets: &plan.LogTargets{
+		//		Targets: []string{},
+		//	}},
+		//	{Name: "svc3", LogTargets: &plan.LogTargets{
+		//		Targets: []string{"unset"},
+		//	}},
+		//	{Name: "svc4", LogTargets: &plan.LogTargets{
+		//		Targets: []string{"optout"},
+		//	}},
+		//	{Name: "svc5", LogTargets: &plan.LogTargets{
+		//		Targets: []string{"optin"},
+		//	}},
+		//	{Name: "svc6", LogTargets: &plan.LogTargets{
+		//		Targets: []string{"disabled"},
+		//	}},
+		//	{Name: "svc7", LogTargets: &plan.LogTargets{
+		//		Targets: []string{"unset", "optin", "disabled"},
+		//	}},
+		//	{Name: "svc8", LogTargets: &plan.LogTargets{
+		//		Keyword: plan.DefaultLogTargets,
+		//	}},
+		//	{Name: "svc9", LogTargets: &plan.LogTargets{
+		//		Keyword: plan.AllLogTargets,
+		//	}},
+		//	{Name: "svc10", LogTargets: &plan.LogTargets{
+		//		Keyword: plan.NoLogTargets,
+		//	}},
 	}
 
 	// Use pointers to bools so the test will fail if we forget to set a value
@@ -1803,192 +1761,11 @@ func (s *S) TestSelectTargets(c *C) {
 func (s *S) TestParseAndMergeLogTargets(c *C) {
 	tests := []struct {
 		base, override string
-		res            *plan.LogTargets
+		logTargets     []string
 	}{{
-		base:     "log-targets: ~",
-		override: "log-targets: ~",
-		res:      &plan.LogTargets{},
-	}, {
-		base:     "log-targets: ~",
-		override: "log-targets: default",
-		res: &plan.LogTargets{
-			Keyword: plan.DefaultLogTargets,
-		},
-	}, {
-		base:     "log-targets: ~",
-		override: "log-targets: none",
-		res: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		},
-	}, {
-		base:     "log-targets: ~",
-		override: "log-targets: all",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: ~",
-		override: "log-targets: [tgt1, tgt2]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		base:     "log-targets: default",
-		override: "log-targets: ~",
-		res: &plan.LogTargets{
-			Keyword: plan.DefaultLogTargets,
-		},
-	}, {
-		base:     "log-targets: default",
-		override: "log-targets: default",
-		res: &plan.LogTargets{
-			Keyword: plan.DefaultLogTargets,
-		},
-	}, {
-		// `default` should behave like an unspecified value.
-		// Merging `default` <- `anything` yields `anything`.
-		base:     "log-targets: default",
-		override: "log-targets: none",
-		res: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		},
-	}, {
-		base:     "log-targets: default",
-		override: "log-targets: all",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		// `default` should behave like an unspecified value.
-		// Merging `default` <- `anything` yields `anything`.
-		base:     "log-targets: default",
-		override: "log-targets: [tgt1, tgt2]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		base:     "log-targets: none",
-		override: "log-targets: ~",
-		res: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		},
-	}, {
-		// `default` should behave like an unspecified value.
-		// Merging `anything` <- `default` yields `anything`.
-		base:     "log-targets: none",
-		override: "log-targets: default",
-		res: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		},
-	}, {
-		base:     "log-targets: none",
-		override: "log-targets: none",
-		res: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		},
-	}, {
-		base:     "log-targets: none",
-		override: "log-targets: all",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: none",
-		override: "log-targets: [tgt1, tgt2]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		base:     "log-targets: all",
-		override: "log-targets: ~",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: all",
-		override: "log-targets: default",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: all",
-		override: "log-targets: none",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: all",
-		override: "log-targets: all",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: all",
-		override: "log-targets: [tgt1, tgt2]",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		base:     "log-targets: [tgt1, tgt2]",
-		override: "log-targets: ~",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		// `default` should behave like an unspecified value.
-		// Merging `anything` <- `default` yields `anything`.
-		base:     "log-targets: [tgt1, tgt2]",
-		override: "log-targets: default",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		base:     "log-targets: [tgt1, tgt2]",
-		override: "log-targets: none",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		base:     "log-targets: [tgt1, tgt2]",
-		override: "log-targets: all",
-		res: &plan.LogTargets{
-			Keyword: plan.AllLogTargets,
-		},
-	}, {
-		// A few tests merging lists
-		base:     "log-targets: [tgt1]",
-		override: "log-targets: [tgt2]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2"},
-		},
-	}, {
-		base:     "log-targets: [tgt1]",
-		override: "log-targets: [tgt1]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1"},
-		},
-	}, {
-		base:     "log-targets: [tgt1, tgt2, tgt3, tgt4]",
-		override: "log-targets: [tgt2, tgt4]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2", "tgt3", "tgt4"},
-		},
-	}, {
-		base:     "log-targets: [tgt1, tgt2]",
-		override: "log-targets: [tgt1, tgt3]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt2", "tgt3"},
-		},
-	}, {
-		// Replace should always replace
-		// TODO: add tests for `^log-targets`
-		base:     "log-targets: ",
-		override: "log-targets: ",
-		res:      &plan.LogTargets{},
-	}, {
-		base:     "log-targets: ",
-		override: "log-targets: ",
-		res:      &plan.LogTargets{},
+		base:       "log-targets: ~",
+		override:   "log-targets: ~",
+		logTargets: nil,
 	}}
 
 	parseService := func(raw string) *plan.Service {
@@ -2002,119 +1779,120 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 		base := parseService(t.base)
 		override := parseService(t.override)
 		base.Merge(override)
-		c.Check(base.LogTargets, DeepEquals, t.res, Commentf("merge %q <- %q", t.base, t.override))
+		c.Check(base.LogTargets, DeepEquals, t.logTargets, Commentf("merge %q <- %q", t.base, t.override))
 	}
 }
 
-func (s *S) TestLogTargetsUnmarshalYAML(c *C) {
-	tests := []struct {
-		input    string
-		expected *plan.LogTargets
-		err      string
-	}{{
-		input:    "",
-		expected: &plan.LogTargets{},
-	}, {
-		input:    "~",
-		expected: &plan.LogTargets{},
-	}, {
-		input:    "null",
-		expected: &plan.LogTargets{},
-	}, {
-		input:    "[]",
-		expected: &plan.LogTargets{Targets: []string{}},
-	}, {
-		input:    "[tgt1]",
-		expected: &plan.LogTargets{Targets: []string{"tgt1"}},
-	}, {
-		input:    "[tgt1, tgt2, tgt3]",
-		expected: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
-	}, {
-		input:    "all",
-		expected: &plan.LogTargets{Keyword: plan.AllLogTargets},
-	}, {
-		input:    "default",
-		expected: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
-	}, {
-		input:    "none",
-		expected: &plan.LogTargets{Keyword: plan.NoLogTargets},
-	}, {
-		input: "invalidkeyword",
-		err:   `invalid value "invalidkeyword" for LogTargets`,
-	}}
-
-	for _, t := range tests {
-		out := &plan.LogTargets{}
-		err := yaml.Unmarshal([]byte(t.input), out)
-
-		if t.err != "" {
-			c.Assert(err, ErrorMatches, t.err)
-			continue
-		}
-
-		c.Assert(err, IsNil)
-		c.Check(out, DeepEquals, t.expected)
-	}
-}
-
-func (s *S) TestLogTargetsMarshalYAML(c *C) {
-	tests := []struct {
-		input    *plan.LogTargets
-		expected string
-	}{{
-		input: &plan.LogTargets{},
-		// nil slice unmarshals to []
-		expected: `[]
-`}, {
-		input: &plan.LogTargets{Targets: []string{}},
-		expected: `[]
-`}, {
-		input: &plan.LogTargets{Targets: []string{"tgt1"}},
-		expected: `- tgt1
-`}, {
-		input: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
-		expected: `
-- tgt1
-- tgt2
-- tgt3
-`[1:]}, {
-		input: &plan.LogTargets{Keyword: plan.AllLogTargets},
-		expected: `all
-`}, {
-		input: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
-		expected: `default
-`}, {
-		input: &plan.LogTargets{Keyword: plan.NoLogTargets},
-		expected: `none
-`}}
-
-	for _, t := range tests {
-		out, err := yaml.Marshal(t.input)
-		c.Assert(err, IsNil)
-		c.Check(string(out), DeepEquals, t.expected)
-	}
-}
-
-// Test that marshalling then unmarshalling yields the original value.
-func (s *S) TestLogTargetsYAMLRoundTrip(c *C) {
-	tests := []*plan.LogTargets{
-		// nil ends up as empty slice. We are treating these as equivalent.
-		// {},
-		{Targets: []string{}},
-		{Targets: []string{"tgt1"}},
-		{Targets: []string{"tgt1", "tgt2", "tgt3"}},
-		{Keyword: plan.AllLogTargets},
-		{Keyword: plan.DefaultLogTargets},
-		{Keyword: plan.NoLogTargets},
-	}
-
-	for _, input := range tests {
-		marshalled, err := yaml.Marshal(input)
-		c.Assert(err, IsNil)
-
-		out := &plan.LogTargets{}
-		err = yaml.Unmarshal(marshalled, out)
-		c.Assert(err, IsNil)
-		c.Check(out, DeepEquals, input)
-	}
-}
+//
+//func (s *S) TestLogTargetsUnmarshalYAML(c *C) {
+//	tests := []struct {
+//		input    string
+//		expected *plan.LogTargets
+//		err      string
+//	}{{
+//		input:    "",
+//		expected: &plan.LogTargets{},
+//	}, {
+//		input:    "~",
+//		expected: &plan.LogTargets{},
+//	}, {
+//		input:    "null",
+//		expected: &plan.LogTargets{},
+//	}, {
+//		input:    "[]",
+//		expected: &plan.LogTargets{Targets: []string{}},
+//	}, {
+//		input:    "[tgt1]",
+//		expected: &plan.LogTargets{Targets: []string{"tgt1"}},
+//	}, {
+//		input:    "[tgt1, tgt2, tgt3]",
+//		expected: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+//	}, {
+//		input:    "all",
+//		expected: &plan.LogTargets{Keyword: plan.AllLogTargets},
+//	}, {
+//		input:    "default",
+//		expected: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
+//	}, {
+//		input:    "none",
+//		expected: &plan.LogTargets{Keyword: plan.NoLogTargets},
+//	}, {
+//		input: "invalidkeyword",
+//		err:   `invalid value "invalidkeyword" for LogTargets`,
+//	}}
+//
+//	for _, t := range tests {
+//		out := &plan.LogTargets{}
+//		err := yaml.Unmarshal([]byte(t.input), out)
+//
+//		if t.err != "" {
+//			c.Assert(err, ErrorMatches, t.err)
+//			continue
+//		}
+//
+//		c.Assert(err, IsNil)
+//		c.Check(out, DeepEquals, t.expected)
+//	}
+//}
+//
+//func (s *S) TestLogTargetsMarshalYAML(c *C) {
+//	tests := []struct {
+//		input    *plan.LogTargets
+//		expected string
+//	}{{
+//		input: &plan.LogTargets{},
+//		// nil slice unmarshals to []
+//		expected: `[]
+//`}, {
+//		input: &plan.LogTargets{Targets: []string{}},
+//		expected: `[]
+//`}, {
+//		input: &plan.LogTargets{Targets: []string{"tgt1"}},
+//		expected: `- tgt1
+//`}, {
+//		input: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+//		expected: `
+//- tgt1
+//- tgt2
+//- tgt3
+//`[1:]}, {
+//		input: &plan.LogTargets{Keyword: plan.AllLogTargets},
+//		expected: `all
+//`}, {
+//		input: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
+//		expected: `default
+//`}, {
+//		input: &plan.LogTargets{Keyword: plan.NoLogTargets},
+//		expected: `none
+//`}}
+//
+//	for _, t := range tests {
+//		out, err := yaml.Marshal(t.input)
+//		c.Assert(err, IsNil)
+//		c.Check(string(out), DeepEquals, t.expected)
+//	}
+//}
+//
+//// Test that marshalling then unmarshalling yields the original value.
+//func (s *S) TestLogTargetsYAMLRoundTrip(c *C) {
+//	tests := []*plan.LogTargets{
+//		// nil ends up as empty slice. We are treating these as equivalent.
+//		// {},
+//		{Targets: []string{}},
+//		{Targets: []string{"tgt1"}},
+//		{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+//		{Keyword: plan.AllLogTargets},
+//		{Keyword: plan.DefaultLogTargets},
+//		{Keyword: plan.NoLogTargets},
+//	}
+//
+//	for _, input := range tests {
+//		marshalled, err := yaml.Marshal(input)
+//		c.Assert(err, IsNil)
+//
+//		out := &plan.LogTargets{}
+//		err = yaml.Unmarshal(marshalled, out)
+//		c.Assert(err, IsNil)
+//		c.Check(out, DeepEquals, input)
+//	}
+//}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -854,7 +854,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1"},
+				},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -864,7 +866,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1", "tgt2"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -942,18 +946,22 @@ var planTests = []planTest{{
 		Order: 0,
 		Services: map[string]*plan.Service{
 			"svc1": {
-				Name:       "svc1",
-				Command:    "foo",
-				Override:   plan.MergeOverride,
-				Startup:    plan.StartupEnabled,
-				LogTargets: []string{"tgt1"},
+				Name:     "svc1",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				Startup:  plan.StartupEnabled,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1"},
+				},
 			},
 			"svc2": {
-				Name:       "svc2",
-				Command:    "bar",
-				Override:   plan.MergeOverride,
-				Startup:    plan.StartupEnabled,
-				LogTargets: []string{"tgt1", "tgt2"},
+				Name:     "svc2",
+				Command:  "bar",
+				Override: plan.MergeOverride,
+				Startup:  plan.StartupEnabled,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt2"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -976,17 +984,21 @@ var planTests = []planTest{{
 		Order: 1,
 		Services: map[string]*plan.Service{
 			"svc1": {
-				Name:       "svc1",
-				Command:    "foo",
-				Override:   plan.MergeOverride,
-				LogTargets: []string{"tgt3"},
+				Name:     "svc1",
+				Command:  "foo",
+				Override: plan.MergeOverride,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+				},
 			},
 			"svc2": {
-				Name:       "svc2",
-				Command:    "bar",
-				Override:   plan.ReplaceOverride,
-				Startup:    plan.StartupEnabled,
-				LogTargets: []string{"tgt3"},
+				Name:     "svc2",
+				Command:  "bar",
+				Override: plan.ReplaceOverride,
+				Startup:  plan.StartupEnabled,
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -1020,7 +1032,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt1", "tgt3"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt1", "tgt3"},
+				},
 			},
 			"svc2": {
 				Name:          "svc2",
@@ -1030,7 +1044,9 @@ var planTests = []planTest{{
 				BackoffDelay:  plan.OptionalDuration{Value: defaultBackoffDelay},
 				BackoffFactor: plan.OptionalFloat{Value: defaultBackoffFactor},
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
-				LogTargets:    []string{"tgt3"},
+				LogTargets: plan.LogTargets{
+					Targets: []string{"tgt3"},
+				},
 			},
 		},
 		Checks: map[string]*plan.Check{},
@@ -1463,13 +1479,27 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "disabled", Selection: plan.DisabledSelection},
 	}
 	services := []*plan.Service{
-		{Name: "svc1", LogTargets: nil},
-		{Name: "svc2", LogTargets: []string{}},
-		{Name: "svc3", LogTargets: []string{"unset"}},
-		{Name: "svc4", LogTargets: []string{"optout"}},
-		{Name: "svc5", LogTargets: []string{"optin"}},
-		{Name: "svc6", LogTargets: []string{"disabled"}},
-		{Name: "svc7", LogTargets: []string{"unset", "optin", "disabled"}},
+		{Name: "svc1", LogTargets: plan.LogTargets{
+			Targets: nil,
+		}},
+		{Name: "svc2", LogTargets: plan.LogTargets{
+			Targets: []string{},
+		}},
+		{Name: "svc3", LogTargets: plan.LogTargets{
+			Targets: []string{"unset"},
+		}},
+		{Name: "svc4", LogTargets: plan.LogTargets{
+			Targets: []string{"optout"},
+		}},
+		{Name: "svc5", LogTargets: plan.LogTargets{
+			Targets: []string{"optin"},
+		}},
+		{Name: "svc6", LogTargets: plan.LogTargets{
+			Targets: []string{"disabled"},
+		}},
+		{Name: "svc7", LogTargets: plan.LogTargets{
+			Targets: []string{"unset", "optin", "disabled"},
+		}},
 	}
 
 	// Use pointers to bools so the test will fail if we forget to set a value
@@ -1491,5 +1521,26 @@ func (s *S) TestSelectTargets(c *C) {
 			c.Check(service.LogsTo(target), Equals, *exp,
 				Commentf("unexpected value for %s.LogsTo(%s)", service.Name, target.Name))
 		}
+	}
+}
+
+func (s *S) TestMergeLogTargets(c *C) {
+	tests := []struct {
+		t1, t2, res plan.LogTargets
+	}{{
+		t1: plan.LogTargets{
+			Targets: []string{"tgt1"},
+		},
+		t2: plan.LogTargets{
+			Targets: []string{"tgt3"},
+		},
+		res: plan.LogTargets{
+			Targets: []string{"tgt1", "tgt3"},
+		},
+	}}
+
+	for _, t := range tests {
+		merged := plan.MergeLogTargets(t.t1, t.t2)
+		c.Check(merged, DeepEquals, t.res)
 	}
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1805,16 +1805,52 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 		base, override string
 		res            *plan.LogTargets
 	}{{
-		base:     "log-targets: [tgt1]",
-		override: "log-targets: [tgt3]",
+		base:     "log-targets: ~",
+		override: "log-targets: ~",
+		res:      &plan.LogTargets{},
+	}, {
+		base:     "log-targets: ~",
+		override: "log-targets: default",
 		res: &plan.LogTargets{
-			Targets: []string{"tgt1", "tgt3"},
+			Keyword: plan.DefaultLogTargets,
 		},
 	}, {
-		base:     "log-targets: [tgt1]",
-		override: "^log-targets: [tgt3]",
+		base:     "log-targets: ~",
+		override: "log-targets: none",
 		res: &plan.LogTargets{
-			Targets: []string{"tgt3"},
+			Keyword: plan.NoLogTargets,
+		},
+	}, {
+		base:     "log-targets: ~",
+		override: "log-targets: all",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base:     "log-targets: ~",
+		override: "log-targets: [tgt1, tgt2]",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		base:     "log-targets: default",
+		override: "log-targets: ~",
+		res: &plan.LogTargets{
+			Keyword: plan.DefaultLogTargets,
+		},
+	}, {
+		base:     "log-targets: default",
+		override: "log-targets: default",
+		res: &plan.LogTargets{
+			Keyword: plan.DefaultLogTargets,
+		},
+	}, {
+		// `default` should behave like an unspecified value.
+		// Merging `default` <- `anything` yields `anything`.
+		base:     "log-targets: default",
+		override: "log-targets: none",
+		res: &plan.LogTargets{
+			Keyword: plan.NoLogTargets,
 		},
 	}, {
 		base:     "log-targets: default",
@@ -1823,47 +1859,136 @@ func (s *S) TestParseAndMergeLogTargets(c *C) {
 			Keyword: plan.AllLogTargets,
 		},
 	}, {
-		base:     "log-targets: [tgt1]",
+		// `default` should behave like an unspecified value.
+		// Merging `default` <- `anything` yields `anything`.
+		base:     "log-targets: default",
+		override: "log-targets: [tgt1, tgt2]",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		base:     "log-targets: none",
+		override: "log-targets: ~",
+		res: &plan.LogTargets{
+			Keyword: plan.NoLogTargets,
+		},
+	}, {
+		// `default` should behave like an unspecified value.
+		// Merging `anything` <- `default` yields `anything`.
+		base:     "log-targets: none",
 		override: "log-targets: default",
 		res: &plan.LogTargets{
-			Keyword: plan.DefaultLogTargets,
+			Keyword: plan.NoLogTargets,
 		},
 	}, {
-		base:     "log-targets: [tgt1]",
-		override: "^log-targets: default",
-		res: &plan.LogTargets{
-			Keyword: plan.DefaultLogTargets,
-		},
-	}, {
-		base:     "log-targets: [tgt1]",
+		base:     "log-targets: none",
 		override: "log-targets: none",
 		res: &plan.LogTargets{
 			Keyword: plan.NoLogTargets,
 		},
 	}, {
-		base:     "log-targets: [tgt1]",
-		override: "^log-targets: none",
+		base:     "log-targets: none",
+		override: "log-targets: all",
 		res: &plan.LogTargets{
-			Keyword: plan.NoLogTargets,
-		},
-	}, {
-		base:     "log-targets: default",
-		override: "log-targets: [tgt1]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1"},
-		},
-	}, {
-		base:     "log-targets: all",
-		override: "log-targets: [tgt1]",
-		res: &plan.LogTargets{
-			Targets: []string{"tgt1"},
+			Keyword: plan.AllLogTargets,
 		},
 	}, {
 		base:     "log-targets: none",
+		override: "log-targets: [tgt1, tgt2]",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		base:     "log-targets: all",
+		override: "log-targets: ~",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base:     "log-targets: all",
+		override: "log-targets: default",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base:     "log-targets: all",
+		override: "log-targets: none",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base:     "log-targets: all",
+		override: "log-targets: all",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base:     "log-targets: all",
+		override: "log-targets: [tgt1, tgt2]",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		base:     "log-targets: [tgt1, tgt2]",
+		override: "log-targets: ~",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		// `default` should behave like an unspecified value.
+		// Merging `anything` <- `default` yields `anything`.
+		base:     "log-targets: [tgt1, tgt2]",
+		override: "log-targets: default",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		base:     "log-targets: [tgt1, tgt2]",
+		override: "log-targets: none",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		base:     "log-targets: [tgt1, tgt2]",
+		override: "log-targets: all",
+		res: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		},
+	}, {
+		// A few tests merging lists
+		base:     "log-targets: [tgt1]",
+		override: "log-targets: [tgt2]",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2"},
+		},
+	}, {
+		base:     "log-targets: [tgt1]",
 		override: "log-targets: [tgt1]",
 		res: &plan.LogTargets{
 			Targets: []string{"tgt1"},
 		},
+	}, {
+		base:     "log-targets: [tgt1, tgt2, tgt3, tgt4]",
+		override: "log-targets: [tgt2, tgt4]",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2", "tgt3", "tgt4"},
+		},
+	}, {
+		base:     "log-targets: [tgt1, tgt2]",
+		override: "log-targets: [tgt1, tgt3]",
+		res: &plan.LogTargets{
+			Targets: []string{"tgt1", "tgt2", "tgt3"},
+		},
+	}, {
+		// Replace should always replace
+		// TODO: add tests for `^log-targets`
+		base:     "log-targets: ",
+		override: "log-targets: ",
+		res:      &plan.LogTargets{},
+	}, {
+		base:     "log-targets: ",
+		override: "log-targets: ",
+		res:      &plan.LogTargets{},
 	}}
 
 	parseService := func(raw string) *plan.Service {

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1764,18 +1764,30 @@ func (s *S) TestSelectTargets(c *C) {
 		{Name: "svc7", LogTargets: &plan.LogTargets{
 			Targets: []string{"unset", "optin", "disabled"},
 		}},
+		{Name: "svc8", LogTargets: &plan.LogTargets{
+			Keyword: plan.DefaultLogTargets,
+		}},
+		{Name: "svc9", LogTargets: &plan.LogTargets{
+			Keyword: plan.AllLogTargets,
+		}},
+		{Name: "svc10", LogTargets: &plan.LogTargets{
+			Keyword: plan.NoLogTargets,
+		}},
 	}
 
 	// Use pointers to bools so the test will fail if we forget to set a value
 	t, f := true, false
 	expected := map[string]map[string]*bool{
-		"svc1": {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
-		"svc2": {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
-		"svc3": {"unset": &t, "optout": &f, "optin": &f, "disabled": &f},
-		"svc4": {"unset": &f, "optout": &t, "optin": &f, "disabled": &f},
-		"svc5": {"unset": &f, "optout": &f, "optin": &t, "disabled": &f},
-		"svc6": {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
-		"svc7": {"unset": &t, "optout": &f, "optin": &t, "disabled": &f},
+		"svc1":  {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
+		"svc2":  {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
+		"svc3":  {"unset": &t, "optout": &f, "optin": &f, "disabled": &f},
+		"svc4":  {"unset": &f, "optout": &t, "optin": &f, "disabled": &f},
+		"svc5":  {"unset": &f, "optout": &f, "optin": &t, "disabled": &f},
+		"svc6":  {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
+		"svc7":  {"unset": &t, "optout": &f, "optin": &t, "disabled": &f},
+		"svc8":  {"unset": &t, "optout": &t, "optin": &f, "disabled": &f},
+		"svc9":  {"unset": &t, "optout": &t, "optin": &t, "disabled": &f},
+		"svc10": {"unset": &f, "optout": &f, "optin": &f, "disabled": &f},
 	}
 
 	for _, service := range services {

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1933,5 +1933,39 @@ func (s *S) TestLogTargetsUnmarshalYAML(c *C) {
 }
 
 func (s *S) TestLogTargetsMarshalYAML(c *C) {
+	tests := []struct {
+		input    *plan.LogTargets
+		expected string
+	}{{
+		input: &plan.LogTargets{},
+		// nil slice unmarshals to []
+		expected: `[]
+`}, {
+		input: &plan.LogTargets{Targets: []string{}},
+		expected: `[]
+`}, {
+		input: &plan.LogTargets{Targets: []string{"tgt1"}},
+		expected: `- tgt1
+`}, {
+		input: &plan.LogTargets{Targets: []string{"tgt1", "tgt2", "tgt3"}},
+		expected: `
+- tgt1
+- tgt2
+- tgt3
+`[1:]}, {
+		input: &plan.LogTargets{Keyword: plan.AllLogTargets},
+		expected: `all
+`}, {
+		input: &plan.LogTargets{Keyword: plan.DefaultLogTargets},
+		expected: `default
+`}, {
+		input: &plan.LogTargets{Keyword: plan.NoLogTargets},
+		expected: `none
+`}}
 
+	for _, t := range tests {
+		out, err := yaml.Marshal(t.input)
+		c.Assert(err, IsNil)
+		c.Check(string(out), DeepEquals, t.expected)
+	}
 }


### PR DESCRIPTION
Replaces #217 and #221.

### Context

#209 and #217 have included extensive discussion of the configuration and merging of log targets specified in a service definition. Two issues have been identified when it comes to merging the `log-targets` field:

1. It is hard to restore the default behaviour provided when `log-targets` is not specified. The issue is that specifying a null value
   ```yaml
   svc1:
     command: foo
     log-targets: ~ # or null
   ```
   parses identically to not specifying a value at all:
   ```yaml
   svc1:
     command: foo
   ```

2. It is hard to remove a log target which was previously specified. If your base layer contains
   ```yaml
   svc1:
     log-targets: [a,b]
   ```
   and you merge the following layer on top of it:
   ```yaml
   svc1:
     log-targets: [c]
     override: merge
   ```
   it will yield `log-targets: [a,b,c]`.

As it stands, the only way to get around either issue is to replace the entire service - which is a real usability issue. This PR proposes one solution to the problem.

### The solution

To solve (2), I've added a new key `^log-targets`, which a service can use during a merge to indicate that the value of `log-targets` should be replaced, not merged. So merging
```yaml
svc1:
  ^log-targets: [c]
  override: merge
```
on top of another layer will overwrite the value of `log-targets`, yielding just `log-targets: [c]`.

To solve (1), we need an **explicit value** to represent the default behaviour. We can't use `null` in a merge, as when this is parsed, it is indistinguishable from an unspecified value. To enable this, the `^log-targets` key also accepts a `default` keyword which restores the default behaviour. So merging
```yaml
svc1:
  ^log-targets: default
```
on top of another layer will result in `log-targets: ~`, i.e. equivalent to if `log-targets` had never been specified at all.

I've also copied over the relevant code from #217 so that we correctly distinguish between
- `log-targets: null` (= unspecified = default behaviour = forward to all `opt-out` targets)
- `log-targets: []` (= explicitly specify empty list = opt-out = don't forward to any targets)

So, the relevant part of the service spec now looks like:
```yaml
<service name>:
  ...
  log-targets: <list of log targets>
  ^log-targets: <list of log targets> | default
```

I've implemented a custom type `LogTargetsReplace` with a custom `UnmarshalYAML` method to handle the new `^log-targets` field. The `Service` struct now has fields
```go
type Service struct {
  ...
  LogTargets        []string           `yaml:"log-targets,omitempty"`
  LogTargetsReplace *LogTargetsReplace `yaml:"^log-targets,omitempty"`
}
```
and the `LogTargetsReplace` field takes precedence in a merge.

I've also added documentation about all this to the README - which will remain commented out until log forwarding is fully implemented.

### Merging rules

The merge rules for `log-targets` and `^log-targets` are documented in `TestParseAndMergeLogTargets`. In short:
1. Merging `log-targets: [list1]` <- `log-targets: [list2]` yields `log-targets: [list1+list2]` (with any duplicates removed).
2. Merging `log-targets: [list1]` <- `^log-targets: [list2]` yields `log-targets: [list2]`.
3. Merging `log-targets: [list1]` <- `^log-targets: default` yields `log-targets: ~`.