### PR TITLE
Public CLI API

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,3 +24,9 @@ func MockVersion(version string) (restore func()) {
 	Version = version
 	return func() { Version = old }
 }
+
+// Personality holds the binary and display names for the application.
+var Personality = struct {
+	ProgramName string
+	DisplayName string
+}{"pebble", "Pebble"}

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/logger"
 )
 
@@ -179,7 +180,7 @@ func Parser(cli *client.Client) *flags.Parser {
 	}
 	flagopts := flags.Options(flags.PassDoubleDash)
 	parser := flags.NewParser(&optionsData, flagopts)
-	parser.ShortDescription = "Tool to interact with pebble"
+	parser.ShortDescription = fmt.Sprintf("Tool to interact with %s", cmd.Personality.DisplayName)
 	parser.LongDescription = longPebbleDescription
 	// hide the unhelpful "[OPTIONS]" from help output
 	parser.Usage = ""
@@ -333,7 +334,7 @@ func Run() error {
 		}
 	}()
 
-	logger.SetLogger(logger.New(os.Stderr, "[pebble] "))
+	logger.SetLogger(logger.New(os.Stderr, fmt.Sprintf("[%s] ", cmd.Personality.ProgramName)))
 
 	_, clientConfig.Socket = getEnvPaths()
 
@@ -355,11 +356,11 @@ func Run() error {
 				return nil
 			case flags.ErrUnknownCommand:
 				sub := os.Args[1]
-				sug := "pebble help"
+				sug := cmd.Personality.ProgramName + " help"
 				if len(xtra) > 0 {
 					sub = xtra[0]
 					if x := parser.Command.Active; x != nil && x.Name != "help" {
-						sug = "pebble help " + x.Name
+						sug = cmd.Personality.ProgramName + " help " + x.Name
 					}
 				}
 				return fmt.Errorf("unknown command %q, see '%s'.", sub, sug)
@@ -403,7 +404,7 @@ func errorToMessage(e error) (normalMessage string, err error) {
 		}
 	case client.ErrorKindSystemRestart:
 		isError = false
-		msg = "pebble is about to reboot the system"
+		msg = cmd.Personality.DisplayName + " is about to reboot the system"
 	case client.ErrorKindNoDefaultServices:
 		msg = "no default services"
 	default:

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -80,9 +80,9 @@ var commands []*cmdInfo
 // debugCommands holds information about all debug commands.
 var debugCommands []*cmdInfo
 
-// addCommand replaces parser.addCommand() in a way that is compatible with
+// AddCommand replaces parser.AddCommand() in a way that is compatible with
 // re-constructing a pristine parser.
-func addCommand(name, shortHelp, longHelp string, builder func() flags.Commander, optDescs map[string]string, argDescs []argDesc) *cmdInfo {
+func AddCommand(name, shortHelp, longHelp string, builder func() flags.Commander, optDescs map[string]string, argDescs []argDesc) *cmdInfo {
 	info := &cmdInfo{
 		name:      name,
 		shortHelp: shortHelp,

--- a/internals/cli/cmd_add.go
+++ b/internals/cli/cmd_add.go
@@ -67,5 +67,5 @@ func (cmd *cmdAdd) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("add", shortAddHelp, longAddHelp, func() flags.Commander { return &cmdAdd{} }, addDescs, nil)
+	AddCommand("add", shortAddHelp, longAddHelp, func() flags.Commander { return &cmdAdd{} }, addDescs, nil)
 }

--- a/internals/cli/cmd_autostart.go
+++ b/internals/cli/cmd_autostart.go
@@ -31,7 +31,7 @@ type cmdAutoStart struct {
 }
 
 func init() {
-	addCommand("autostart", shortAutoStartHelp, longAutoStartHelp, func() flags.Commander { return &cmdAutoStart{} }, waitDescs, nil)
+	AddCommand("autostart", shortAutoStartHelp, longAutoStartHelp, func() flags.Commander { return &cmdAutoStart{} }, waitDescs, nil)
 }
 
 func (cmd cmdAutoStart) Execute(args []string) error {

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -48,9 +48,9 @@ type cmdTasks struct {
 }
 
 func init() {
-	addCommand("changes", shortChangesHelp, longChangesHelp,
+	AddCommand("changes", shortChangesHelp, longChangesHelp,
 		func() flags.Commander { return &cmdChanges{} }, timeDescs, nil)
-	addCommand("tasks", shortTasksHelp, longTasksHelp,
+	AddCommand("tasks", shortTasksHelp, longTasksHelp,
 		func() flags.Commander { return &cmdTasks{} },
 		merge(changeIDMixinOptDesc, timeDescs),
 		changeIDMixinArgDesc)

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -177,7 +177,7 @@ func (s *PebbleSuite) TestChangeSimpleRebooting(c *check.C) {
 
 	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "42"})
 	c.Assert(err, check.IsNil)
-	c.Check(s.Stderr(), check.Equals, "WARNING: pebble is about to reboot the system\n")
+	c.Check(s.Stderr(), check.Equals, "WARNING: Pebble is about to reboot the system\n")
 }
 
 func (s *PebbleSuite) TestChangeSimpleUnknownMaintenance(c *check.C) {

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -79,5 +79,5 @@ func (cmd *cmdChecks) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("checks", shortChecksHelp, longChecksHelp, func() flags.Commander { return &cmdChecks{} }, checksDescs, nil)
+	AddCommand("checks", shortChecksHelp, longChecksHelp, func() flags.Commander { return &cmdChecks{} }, checksDescs, nil)
 }

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -58,7 +58,7 @@ func init() {
 	for k, v := range sharedRunEnterOptsHelp {
 		optsHelp[k] = v
 	}
-	cmdInfo := addCommand("enter", shortEnterHelp, longEnterHelp, func() flags.Commander { return &cmdEnter{} }, optsHelp, nil)
+	cmdInfo := AddCommand("enter", shortEnterHelp, longEnterHelp, func() flags.Commander { return &cmdEnter{} }, optsHelp, nil)
 	cmdInfo.extra = func(cmd *flags.Command) {
 		cmd.PassAfterNonOption = true
 	}

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/canonical/go-flags"
 
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/logger"
 )
 
-const shortEnterHelp = "Run subcommand under a container environment"
-const longEnterHelp = `
-The enter command facilitates the use of Pebble as an entrypoint for containers.
+var shortEnterHelp = "Run subcommand under a container environment"
+var longEnterHelp = fmt.Sprintf(`
+The enter command facilitates the use of %s as an entrypoint for containers.
 When used without a subcommand it mimics the behavior of the run command
 alone, while if used with a subcommand it runs that subcommand in the most
 appropriate environment taking into account its purpose.
@@ -29,7 +30,8 @@ These subcommands are currently supported:
 (1) Services are not started.
 (2) No logs on stdout unless -v is used.
 (3) Services continue running after the subcommand succeeds.
-`
+`,
+	cmd.Personality.ProgramName)
 
 type enterFlags int
 
@@ -160,7 +162,7 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	case runStop = <-runReadyCh:
 	case runPanic := <-runResultCh:
 		if runPanic == nil {
-			panic("internal error: pebble daemon stopped early")
+			panic("internal error: daemon stopped early")
 		}
 		panic(runPanic)
 	}

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/ptyutil"
 )
@@ -63,7 +64,7 @@ var execDescs = map[string]string{
 }
 
 var shortExecHelp = "Execute a remote command and wait for it to finish"
-var longExecHelp = `
+var longExecHelp = fmt.Sprintf(`
 The exec command runs a remote command and waits for it to finish. The local
 stdin is sent as the input to the remote process, while the remote stdout and
 stderr are output locally.
@@ -71,8 +72,9 @@ stderr are output locally.
 To avoid confusion, exec options may be separated from the command and its
 arguments using "--", for example:
 
-pebble exec --timeout 10s -- echo -n foo bar
-`
+%s exec --timeout 10s -- echo -n foo bar
+`,
+	cmd.Personality.ProgramName)
 
 func (cmd *cmdExec) Execute(args []string) error {
 	if cmd.Terminal && cmd.NoTerminal {

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -264,7 +264,7 @@ func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan 
 }
 
 func init() {
-	info := addCommand("exec", shortExecHelp, longExecHelp, func() flags.Commander { return &cmdExec{} }, execDescs, nil)
+	info := AddCommand("exec", shortExecHelp, longExecHelp, func() flags.Commander { return &cmdExec{} }, execDescs, nil)
 	info.extra = func(cmd *flags.Command) {
 		cmd.PassAfterNonOption = true
 	}

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -79,7 +79,7 @@ type cmdHelp struct {
 }
 
 func init() {
-	addCommand("help", shortHelpHelp, longHelpHelp, func() flags.Commander { return &cmdHelp{} },
+	AddCommand("help", shortHelpHelp, longHelpHelp, func() flags.Commander { return &cmdHelp{} },
 		map[string]string{
 			"all": "Show a short summary of all commands",
 			"man": "Generate the manpage",

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -158,14 +158,14 @@ func (cmd cmdHelp) Execute(args []string) error {
 	return &flags.Error{Type: flags.ErrCommandRequired}
 }
 
-type helpCategory struct {
+type HelpCategory struct {
 	Label       string
 	Description string
 	Commands    []string
 }
 
 // helpCategories helps us by grouping commands
-var helpCategories = []helpCategory{{
+var helpCategories = []HelpCategory{{
 	Label:       "Run",
 	Description: "run pebble",
 	Commands:    []string{"run", "help", "version"},
@@ -190,6 +190,11 @@ var helpCategories = []helpCategory{{
 	Description: "manage warnings",
 	Commands:    []string{"warnings", "okay"},
 }}
+
+// AddHelpCategory appends an existing help category to the Pebble help manual.
+func AddHelpCategory(categ HelpCategory) {
+	helpCategories = append(helpCategories, categ)
+}
 
 var (
 	longPebbleDescription = strings.TrimSpace(`

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -23,6 +23,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/canonical/go-flags"
+	"github.com/canonical/pebble/cmd"
 )
 
 var shortHelpHelp = "Show help about a command"
@@ -167,7 +168,7 @@ type HelpCategory struct {
 // helpCategories helps us by grouping commands
 var helpCategories = []HelpCategory{{
 	Label:       "Run",
-	Description: "run pebble",
+	Description: "run " + cmd.Personality.DisplayName,
 	Commands:    []string{"run", "help", "version"},
 }, {
 	Label:       "Plan",
@@ -197,18 +198,23 @@ func AddHelpCategory(categ HelpCategory) {
 }
 
 var (
-	longPebbleDescription = strings.TrimSpace(`
-Pebble lets you control services and perform management actions on
+	longPebbleDescription = strings.TrimSpace(fmt.Sprintf(`
+%s lets you control services and perform management actions on
 the system that is running them.
-`)
-	pebbleUsage               = "Usage: pebble <command> [<options>...]"
+`, cmd.Personality.DisplayName))
+	pebbleUsage               = fmt.Sprintf("Usage: %s <command> [<options>...]", cmd.Personality.ProgramName)
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
-	pebbleHelpAllFooter       = "Set the PEBBLE environment variable to override the configuration directory \n" +
-		"(which defaults to " + defaultPebbleDir + "). Set PEBBLE_SOCKET to override \n" +
-		"the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).\n" +
-		"\n" +
-		"For more information about a command, run 'pebble help <command>'."
-	pebbleHelpFooter = "For a short summary of all commands, run 'pebble help --all'."
+	pebbleHelpAllFooter       = strings.TrimSpace(fmt.Sprintf(`
+Set the PEBBLE environment variable to override the configuration directory 
+(which defaults to %s). Set PEBBLE_SOCKET to override 
+the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
+
+For more information about a command, run '%s help <command>'.
+`, defaultPebbleDir, cmd.Personality.ProgramName))
+	pebbleHelpFooter = fmt.Sprintf(
+		"For a short summary of all commands, run '%s help --all'.",
+		cmd.Personality.ProgramName,
+	)
 )
 
 func printHelpHeader() {

--- a/internals/cli/cmd_help_test.go
+++ b/internals/cli/cmd_help_test.go
@@ -56,7 +56,7 @@ func (s *PebbleSuite) TestHelpMan(c *C) {
 
 	err := cli.RunMain()
 	c.Assert(err, Equals, nil)
-	c.Check(s.Stdout(), Matches, `(?s)\.TH.*\.SH NAME.*pebble \\- Tool to interact with pebble.*`)
+	c.Check(s.Stdout(), Matches, `(?s)\.TH.*\.SH NAME.*pebble \\- Tool to interact with Pebble.*`)
 	c.Check(s.Stderr(), Equals, "")
 }
 

--- a/internals/cli/cmd_help_test.go
+++ b/internals/cli/cmd_help_test.go
@@ -109,3 +109,20 @@ func (s *PebbleSuite) TestCommandWithHelpOption(c *C) {
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
 }
+
+func (s *PebbleSuite) TestAddHelpCategory(c *C) {
+	restore := fakeArgs("pebble")
+	defer restore()
+
+	cli.AddHelpCategory(cli.HelpCategory{
+		Label:       "Test category",
+		Description: "Test description",
+		Commands:    []string{"run", "logs"},
+	})
+
+	err := cli.RunMain()
+	c.Assert(err, Equals, nil)
+
+	c.Check(s.Stdout(), Matches, "(?s).*Test category: run, logs\n.*")
+	c.Check(s.Stderr(), Equals, "")
+}

--- a/internals/cli/cmd_logs.go
+++ b/internals/cli/cmd_logs.go
@@ -121,5 +121,5 @@ func notifyContext(parent context.Context, signals ...os.Signal) context.Context
 }
 
 func init() {
-	addCommand("logs", shortLogsHelp, longLogsHelp, func() flags.Commander { return &cmdLogs{} }, logsDescs, nil)
+	AddCommand("logs", shortLogsHelp, longLogsHelp, func() flags.Commander { return &cmdLogs{} }, logsDescs, nil)
 }

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -103,5 +103,5 @@ func parseGlob(path string) (parsedPath, parsedPattern string, err error) {
 }
 
 func init() {
-	addCommand("ls", shortLsHelp, longLsHelp, func() flags.Commander { return &cmdLs{} }, merge(lsDescs, timeDescs), nil)
+	AddCommand("ls", shortLsHelp, longLsHelp, func() flags.Commander { return &cmdLs{} }, merge(lsDescs, timeDescs), nil)
 }

--- a/internals/cli/cmd_mkdir.go
+++ b/internals/cli/cmd_mkdir.go
@@ -79,5 +79,5 @@ func (cmd *cmdMkdir) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("mkdir", shortMkdirHelp, longMkdirHelp, func() flags.Commander { return &cmdMkdir{} }, mkdirDescs, nil)
+	AddCommand("mkdir", shortMkdirHelp, longMkdirHelp, func() flags.Commander { return &cmdMkdir{} }, mkdirDescs, nil)
 }

--- a/internals/cli/cmd_plan.go
+++ b/internals/cli/cmd_plan.go
@@ -43,5 +43,5 @@ func (cmd *cmdPlan) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("plan", shortPlanHelp, longPlanHelp, func() flags.Commander { return &cmdPlan{} }, nil, nil)
+	AddCommand("plan", shortPlanHelp, longPlanHelp, func() flags.Commander { return &cmdPlan{} }, nil, nil)
 }

--- a/internals/cli/cmd_plan.go
+++ b/internals/cli/cmd_plan.go
@@ -15,9 +15,12 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/canonical/go-flags"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/cmd"
 )
 
 type cmdPlan struct {
@@ -25,10 +28,11 @@ type cmdPlan struct {
 }
 
 var shortPlanHelp = "Show the plan with layers combined"
-var longPlanHelp = `
-The plan command prints out the effective configuration of pebble in YAML
+var longPlanHelp = fmt.Sprintf(`
+The plan command prints out the effective configuration of %s in YAML
 format. Layers are combined according to the override rules defined in them.
-`
+`,
+	cmd.Personality.DisplayName)
 
 func (cmd *cmdPlan) Execute(args []string) error {
 	if len(args) > 0 {

--- a/internals/cli/cmd_replan.go
+++ b/internals/cli/cmd_replan.go
@@ -32,7 +32,7 @@ type cmdReplan struct {
 }
 
 func init() {
-	addCommand("replan", shortReplanHelp, longReplanHelp, func() flags.Commander { return &cmdReplan{} }, waitDescs, nil)
+	AddCommand("replan", shortReplanHelp, longReplanHelp, func() flags.Commander { return &cmdReplan{} }, waitDescs, nil)
 }
 
 func (cmd cmdReplan) Execute(args []string) error {

--- a/internals/cli/cmd_restart.go
+++ b/internals/cli/cmd_restart.go
@@ -33,7 +33,7 @@ type cmdRestart struct {
 }
 
 func init() {
-	addCommand("restart", shortRestartHelp, longRestartHelp, func() flags.Commander { return &cmdRestart{} }, waitDescs, nil)
+	AddCommand("restart", shortRestartHelp, longRestartHelp, func() flags.Commander { return &cmdRestart{} }, waitDescs, nil)
 }
 
 func (cmd cmdRestart) Execute(args []string) error {

--- a/internals/cli/cmd_rm.go
+++ b/internals/cli/cmd_rm.go
@@ -51,5 +51,5 @@ func (cmd *cmdRm) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("rm", shortRmHelp, longRmHelp, func() flags.Commander { return &cmdRm{} }, rmDescs, nil)
+	AddCommand("rm", shortRmHelp, longRmHelp, func() flags.Commander { return &cmdRm{} }, rmDescs, nil)
 }

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -31,17 +31,19 @@ import (
 	"github.com/canonical/pebble/internals/systemd"
 )
 
-var shortRunHelp = "Run the pebble environment"
-var longRunHelp = `
-The run command starts pebble and runs the configured environment.
+var shortRunHelp = fmt.Sprintf("Run the %s environment", cmd.Personality.DisplayName)
+var longRunHelp = fmt.Sprintf(`
+The run command starts %[1]s and runs the configured environment.
 
 Additional arguments may be provided to the service command with the --args option, which
-must be terminated with ";" unless there are no further Pebble options.  These arguments
+must be terminated with ";" unless there are no further %[2]s options.  These arguments
 are appended to the end of the service command, and replace any default arguments defined
 in the service plan. For example:
 
-    $ pebble run --args myservice --port 8080 \; --hold
-`
+    $ %[1]s run --args myservice --port 8080 \; --hold
+`,
+	cmd.Personality.DisplayName, cmd.Personality.ProgramName,
+)
 
 type sharedRunEnterOpts struct {
 	CreateDirs bool       `long:"create-dirs"`
@@ -52,7 +54,7 @@ type sharedRunEnterOpts struct {
 }
 
 var sharedRunEnterOptsHelp = map[string]string{
-	"create-dirs": "Create pebble directory on startup if it doesn't exist",
+	"create-dirs": fmt.Sprintf("Create %s directory on startup if it doesn't exist", cmd.Personality.DisplayName),
 	"hold":        "Do not start default services automatically",
 	"http":        `Start HTTP API listening on this address (e.g., ":4000")`,
 	"verbose":     "Log all output from services to stdout",

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -65,7 +65,7 @@ type cmdRun struct {
 }
 
 func init() {
-	addCommand("run", shortRunHelp, longRunHelp, func() flags.Commander { return &cmdRun{} },
+	AddCommand("run", shortRunHelp, longRunHelp, func() flags.Commander { return &cmdRun{} },
 		sharedRunEnterOptsHelp, nil)
 }
 

--- a/internals/cli/cmd_services.go
+++ b/internals/cli/cmd_services.go
@@ -73,7 +73,7 @@ func (cmd *cmdServices) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("services", shortServicesHelp, longServicesHelp,
+	AddCommand("services", shortServicesHelp, longServicesHelp,
 		func() flags.Commander { return &cmdServices{} },
 		timeDescs, nil)
 }

--- a/internals/cli/cmd_signal.go
+++ b/internals/cli/cmd_signal.go
@@ -21,6 +21,7 @@ import (
 	"github.com/canonical/go-flags"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/cmd"
 )
 
 type cmdSignal struct {
@@ -32,12 +33,13 @@ type cmdSignal struct {
 }
 
 var shortSignalHelp = "Send a signal to one or more running services"
-var longSignalHelp = `
+var longSignalHelp = fmt.Sprintf(`
 The signal command sends a signal to one or more running services. The signal
 name must be uppercase, for example:
 
-pebble signal HUP mysql nginx
-`
+%s signal HUP mysql nginx
+`,
+	cmd.Personality.ProgramName)
 
 func (cmd *cmdSignal) Execute(args []string) error {
 	if strings.ToUpper(cmd.Positional.Signal) != cmd.Positional.Signal {

--- a/internals/cli/cmd_signal.go
+++ b/internals/cli/cmd_signal.go
@@ -58,5 +58,5 @@ func (cmd *cmdSignal) Execute(args []string) error {
 }
 
 func init() {
-	addCommand("signal", shortSignalHelp, longSignalHelp, func() flags.Commander { return &cmdSignal{} }, nil, nil)
+	AddCommand("signal", shortSignalHelp, longSignalHelp, func() flags.Commander { return &cmdSignal{} }, nil, nil)
 }

--- a/internals/cli/cmd_start.go
+++ b/internals/cli/cmd_start.go
@@ -34,7 +34,7 @@ type cmdStart struct {
 }
 
 func init() {
-	addCommand("start", shortStartHelp, longStartHelp, func() flags.Commander { return &cmdStart{} }, waitDescs, nil)
+	AddCommand("start", shortStartHelp, longStartHelp, func() flags.Commander { return &cmdStart{} }, waitDescs, nil)
 }
 
 func (cmd cmdStart) Execute(args []string) error {

--- a/internals/cli/cmd_stop.go
+++ b/internals/cli/cmd_stop.go
@@ -34,7 +34,7 @@ type cmdStop struct {
 }
 
 func init() {
-	addCommand("stop", shortStopHelp, longStopHelp, func() flags.Commander { return &cmdStop{} }, waitDescs, nil)
+	AddCommand("stop", shortStopHelp, longStopHelp, func() flags.Commander { return &cmdStop{} }, waitDescs, nil)
 }
 
 func (cmd cmdStop) Execute(args []string) error {

--- a/internals/cli/cmd_version.go
+++ b/internals/cli/cmd_version.go
@@ -38,7 +38,7 @@ var versionDescs = map[string]string{
 }
 
 func init() {
-	addCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, versionDescs, nil)
+	AddCommand("version", shortVersionHelp, longVersionHelp, func() flags.Commander { return &cmdVersion{} }, versionDescs, nil)
 }
 
 func (cmd cmdVersion) Execute(args []string) error {

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -28,6 +28,7 @@ import (
 	"github.com/canonical/x-go/strutil/quantity"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/osutil"
 )
 
@@ -42,23 +43,25 @@ type cmdWarnings struct {
 type cmdOkay struct{ clientMixin }
 
 var shortWarningsHelp = "List warnings"
-var longWarningsHelp = `
+var longWarningsHelp = fmt.Sprintf(`
 The warnings command lists the warnings that have been reported to the system.
 
-Once warnings have been listed with 'pebble warnings', 'pebble okay' may be used to
+Once warnings have been listed with '%[1]s warnings', '%[1]s okay' may be used to
 silence them. A warning that's been silenced in this way will not be listed
 again unless it happens again, _and_ a cooldown time has passed.
 
 Warnings expire automatically, and once expired they are forgotten.
-`
+`,
+	cmd.Personality.ProgramName)
 
 var shortOkayHelp = "Acknowledge warnings"
-var longOkayHelp = `
-The okay command acknowledges the warnings listed with 'pebble warnings'.
+var longOkayHelp = fmt.Sprintf(`
+The okay command acknowledges the warnings listed with '%s warnings'.
 
 Once acknowledged, a warning won't appear again unless it reoccurs and
 sufficient time has passed.
-`
+`,
+	cmd.Personality.ProgramName)
 
 func init() {
 	AddCommand("warnings", shortWarningsHelp, longWarningsHelp, func() flags.Commander { return &cmdWarnings{} }, merge(timeDescs, unicodeDescs, map[string]string{
@@ -211,7 +214,7 @@ func lastWarningTimestamp() (time.Time, error) {
 	f, err := os.Open(warnFilename(user.HomeDir))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return time.Time{}, fmt.Errorf("you must have looked at the warnings before acknowledging them. Try 'pebble warnings'.")
+			return time.Time{}, fmt.Errorf("you must have looked at the warnings before acknowledging them. Try '%s warnings'.", cmd.Personality.ProgramName)
 		}
 		return time.Time{}, fmt.Errorf("cannot open timestamp file: %v", err)
 	}
@@ -235,9 +238,9 @@ func maybePresentWarnings(count int, timestamp time.Time) {
 		return
 	}
 
-	format := "WARNING: There are %d new warnings. See 'pebble warnings'.\n"
+	format := "WARNING: There are %d new warnings. See '%s warnings'.\n"
 	if count == 1 {
-		format = "WARNING: There is %d new warning. See 'pebble warnings'.\n"
+		format = "WARNING: There is %d new warning. See '%s warnings'.\n"
 	}
-	fmt.Fprintf(Stderr, format, count)
+	fmt.Fprintf(Stderr, format, count, cmd.Personality.ProgramName)
 }

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -61,11 +61,11 @@ sufficient time has passed.
 `
 
 func init() {
-	addCommand("warnings", shortWarningsHelp, longWarningsHelp, func() flags.Commander { return &cmdWarnings{} }, merge(timeDescs, unicodeDescs, map[string]string{
+	AddCommand("warnings", shortWarningsHelp, longWarningsHelp, func() flags.Commander { return &cmdWarnings{} }, merge(timeDescs, unicodeDescs, map[string]string{
 		"all":     "Show all warnings",
 		"verbose": "Show more information",
 	}), nil)
-	addCommand("okay", shortOkayHelp, longOkayHelp, func() flags.Commander { return &cmdOkay{} }, nil, nil)
+	AddCommand("okay", shortOkayHelp, longOkayHelp, func() flags.Commander { return &cmdOkay{} }, nil, nil)
 }
 
 func (cmd *cmdWarnings) Execute(args []string) error {


### PR DESCRIPTION
This PR evolves #226 and introduces:
 * a public `cli.AddCommand()` function so well-known Pebble-based applications can implement new commands on top of the basic ones in Pebble,
 * a public `cli.AddHelpCategory()` function that can append a category to the help manual, and
 * a public variable, `Personality`, which holds
   * one value that represents the name of the binary (e.g. *pebble*), and
   * one value that represents the display name of the application (e.g. *Pebble*).

This PR also introduces many changes to the help manual and hard-coded references to *pebble* and *Pebble* in order to replace them with the correct references to the `Personality` struct.