### PR TITLE
Improve error messages with exec, especially if working dir missing

### DIFF
--- a/internals/daemon/api_exec.go
+++ b/internals/daemon/api_exec.go
@@ -64,7 +64,20 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 	// Check up-front that the executable exists.
 	_, err := exec.LookPath(payload.Command[0])
 	if err != nil {
-		return statusBadRequest("%v", err)
+		return statusBadRequest("cannot find executable %q", payload.Command[0])
+	}
+
+	// Also check that the working directory exists, to avoid a confusing
+	// error message later that implies the command doesn't exist:
+	//
+	//  fork/exec /usr/local/bin/realcommand: no such file or directory
+	//
+	// Note that this check still doesn't check that the permissions are
+	// correct to use it as a working directory, but this is a good start.
+	if payload.WorkingDir != "" {
+		if !osutil.IsDir(payload.WorkingDir) {
+			return statusBadRequest("cannot find working directory %q", payload.WorkingDir)
+		}
 	}
 
 	// Convert User/UserID and Group/GroupID combinations into raw uid/gid.

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -300,7 +300,7 @@ func (s *execSuite) TestCommandNotFound(c *C) {
 	c.Check(httpResp.StatusCode, Equals, http.StatusBadRequest)
 	c.Check(execResp.StatusCode, Equals, http.StatusBadRequest)
 	c.Check(execResp.Type, Equals, "error")
-	c.Check(execResp.Result["message"], Matches, ".*executable file not found.*")
+	c.Check(execResp.Result["message"], Matches, "cannot find executable .*")
 }
 
 func (s *execSuite) TestUserGroupError(c *C) {


### PR DESCRIPTION
This PR improves the error messages with `pebble exec` (at the API level), mainly so that if the working directory you specify doesn't exist, it's clear that the "no such file or directory" message is referring to the working dir and not the executable.

For example, the current error messages (shown below) looks like the `/usr/bin/echo` binary doesn't exist, when it's actually the `-w` working dir you've specified that doesn't exist:

```
$ pebble exec -w /noexist -- /usr/bin/echo foo
error: cannot perform the following tasks:
- exec command "/usr/bin/echo" (fork/exec /usr/bin/echo: no such file or directory)
```

This update isn't perfect, because it doesn't check the permissions of the working directory (I believe `x` is required), but definitely an improvement for the case at hand.

Fixes #235