### PR TITLE
Change health checks of "exec" type to inherit the daemon's environment

### DIFF
--- a/internals/overlord/checkstate/checkers_test.go
+++ b/internals/overlord/checkstate/checkers_test.go
@@ -193,7 +193,7 @@ func (s *CheckersSuite) TestExec(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Assert(detailsErr.Details(), Equals, "Foo, meet Bar.")
 
-	// Does not inherit environment when no environment vars set
+	// Inherits environment when no environment vars set
 	os.Setenv("PEBBLE_TEST_CHECKERS_EXEC", "parent")
 	chk = &execChecker{
 		command: "/bin/sh -c 'echo $PEBBLE_TEST_CHECKERS_EXEC; exit 1'",
@@ -202,9 +202,9 @@ func (s *CheckersSuite) TestExec(c *C) {
 	c.Assert(err, ErrorMatches, "exit status 1")
 	detailsErr, ok = err.(*detailsError)
 	c.Assert(ok, Equals, true)
-	c.Assert(detailsErr.Details(), Equals, "")
+	c.Assert(detailsErr.Details(), Equals, "parent")
 
-	// Does not inherit environment when some environment vars set
+	// Inherits environment when some environment vars set
 	os.Setenv("PEBBLE_TEST_CHECKERS_EXEC", "parent")
 	chk = &execChecker{
 		command:     "/bin/sh -c 'echo FOO=$FOO test=$PEBBLE_TEST_CHECKERS_EXEC; exit 1'",
@@ -214,7 +214,7 @@ func (s *CheckersSuite) TestExec(c *C) {
 	c.Assert(err, ErrorMatches, "exit status 1")
 	detailsErr, ok = err.(*detailsError)
 	c.Assert(ok, Equals, true)
-	c.Assert(detailsErr.Details(), Equals, "FOO=foo test=")
+	c.Assert(detailsErr.Details(), Equals, "FOO=foo test=parent")
 
 	// Working directory is passed through
 	workingDir := c.MkDir()


### PR DESCRIPTION
Per discussion, we'd like to change command executions to inherit the Pebble daemon's environment. This PR implements that for exec-type health checks. See also #234, where the same change is being made for exec (one-shot commands). Services themselves have always inherited the environment.