### PR TITLE
Allow non-root user to specify current user/group when running commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ The Go client is used primarily by the CLI, but is importable and can be used by
 
 We try to never change the underlying HTTP API in a backwards-incompatible way, however, in rare cases we may change the Go client in a backwards-incompatible way.
 
-In addition to the Go client, there's also a [Python client](https://github.com/canonical/operator/blob/master/ops/pebble.py) for the Pebble API that's part of the Python Operator Framework used by Juju charms ([documentation here](https://juju.is/docs/sdk/interact-with-pebble)).
+In addition to the Go client, there's also a [Python client](https://github.com/canonical/operator/blob/master/ops/pebble.py) for the Pebble API that's part of the [`ops` library](https://github.com/canonical/operator) used by Juju charms ([documentation here](https://juju.is/docs/sdk/interact-with-pebble)).
 
 ## Roadmap / TODO
 

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -164,6 +164,21 @@ func (s *execSuite) TestTimeout(c *C) {
 	c.Check(stderr, Equals, "")
 }
 
+func (s *execSuite) TestCurrentUserGroup(c *C) {
+	current, err := user.Current()
+	c.Assert(err, IsNil)
+	group, err := user.LookupGroupId(current.Gid)
+	c.Assert(err, IsNil)
+	stdout, stderr, waitErr := s.exec(c, "", &client.ExecOptions{
+		Command: []string{"/bin/sh", "-c", "id -n -u && id -n -g"},
+		User:    current.Username,
+		Group:   group.Name,
+	})
+	c.Assert(waitErr, IsNil)
+	c.Check(stdout, Equals, current.Username+"\n"+group.Name+"\n")
+	c.Check(stderr, Equals, "")
+}
+
 // See .github/workflows/tests.yml for how to run this test as root.
 func (s *execSuite) TestUserGroup(c *C) {
 	if os.Getuid() != 0 {

--- a/internals/osutil/user.go
+++ b/internals/osutil/user.go
@@ -124,3 +124,21 @@ func NormalizeUidGid(uid, gid *int, username, group string) (*int, *int, error) 
 	}
 	return uid, gid, nil
 }
+
+// IsCurrent reports whether the given user ID and group ID are those of the
+// current user.
+func IsCurrent(uid, gid int) (bool, error) {
+	current, err := userCurrent()
+	if err != nil {
+		return false, err
+	}
+	currentUid, err := strconv.Atoi(current.Uid)
+	if err != nil {
+		return false, err
+	}
+	currentGid, err := strconv.Atoi(current.Gid)
+	if err != nil {
+		return false, err
+	}
+	return uid == currentUid && gid == currentGid, nil
+}

--- a/internals/overlord/checkstate/checkers.go
+++ b/internals/overlord/checkstate/checkers.go
@@ -148,9 +148,16 @@ func (c *execChecker) check(ctx context.Context) error {
 		return err
 	}
 	if uid != nil && gid != nil {
-		cmd.SysProcAttr.Credential = &syscall.Credential{
-			Uid: uint32(*uid),
-			Gid: uint32(*gid),
+		isCurrent, err := osutil.IsCurrent(*uid, *gid)
+		if err != nil {
+			logger.Debugf("Cannot determine if uid %d gid %d is current user", *uid, *gid)
+		}
+		if !isCurrent {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+			cmd.SysProcAttr.Credential = &syscall.Credential{
+				Uid: uint32(*uid),
+				Gid: uint32(*gid),
+			}
 		}
 	}
 

--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -32,6 +32,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"github.com/canonical/pebble/internals/logger"
+	"github.com/canonical/pebble/internals/osutil"
 	"github.com/canonical/pebble/internals/overlord/state"
 	"github.com/canonical/pebble/internals/ptyutil"
 	"github.com/canonical/pebble/internals/reaper"
@@ -345,9 +346,15 @@ func (e *execution) do(ctx context.Context, task *state.Task) error {
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	if e.userID != nil && e.groupID != nil {
-		cmd.SysProcAttr.Credential = &syscall.Credential{
-			Uid: uint32(*e.userID),
-			Gid: uint32(*e.groupID),
+		isCurrent, err := osutil.IsCurrent(*e.userID, *e.groupID)
+		if err != nil {
+			logger.Debugf("Cannot determine if uid %d gid %d is current user", *e.userID, *e.groupID)
+		}
+		if !isCurrent {
+			cmd.SysProcAttr.Credential = &syscall.Credential{
+				Uid: uint32(*e.userID),
+				Gid: uint32(*e.groupID),
+			}
 		}
 	}
 

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -353,10 +353,16 @@ func (s *serviceData) startInternal() error {
 		return err
 	}
 	if uid != nil && gid != nil {
-		setCmdCredential(s.cmd, &syscall.Credential{
-			Uid: uint32(*uid),
-			Gid: uint32(*gid),
-		})
+		isCurrent, err := osutil.IsCurrent(*uid, *gid)
+		if err != nil {
+			logger.Debugf("Cannot determine if uid %d gid %d is current user", *uid, *gid)
+		}
+		if !isCurrent {
+			setCmdCredential(s.cmd, &syscall.Credential{
+				Uid: uint32(*uid),
+				Gid: uint32(*gid),
+			})
+		}
 
 		// Also set HOME and USER if not explicitly specified in config.
 		if environment["HOME"] == "" || environment["USER"] == "" {

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -505,7 +505,7 @@ func (s *S) TestStartBadCommand(c *C) {
 	c.Assert(svc.Current, Equals, servstate.StatusInactive)
 }
 
-func (s *S) TestUserGroup(c *C) {
+func (s *S) TestCurrentUserGroup(c *C) {
 	current, err := user.Current()
 	c.Assert(err, IsNil)
 	group, err := user.LookupGroupId(current.Gid)
@@ -573,7 +573,7 @@ func (s *S) TestUserGroupFails(c *C) {
 }
 
 // See .github/workflows/tests.yml for how to run this test as root.
-func (s *S) TestUserGroupRoot(c *C) {
+func (s *S) TestUserGroup(c *C) {
 	if os.Getuid() != 0 {
 		c.Skip("requires running as root")
 	}


### PR DESCRIPTION
When user and group (or user ID and group ID) options are given when running services and they're equal to the current user and group, avoid setting os/exec's `syscall.Credential` `Uid` and `Gid`, because they require root. In the case when they're explicitly asking to run the command as the current user, we can just run it directly, without requiring root.

This goes for services, exec (one-shot commands), and health checks of type "exec".

This PR also fixes a long-standing bug in the user/group options for "exec" health checks not working at all. This was due to not setting `cmd.SysProcAttr`, so the `cmd.SysProcAttr.Credential = ...` line would panic with a nil pointer error.

Also a drive-by fix to the README to update to the new terminology. See also https://github.com/canonical/operator/pull/950

Fixes #166