### PR TITLE
[RFC] shutdown/notify: allow for custom implementations

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -28,7 +28,6 @@ import (
 	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/daemon"
 	"github.com/canonical/pebble/internals/logger"
-	"github.com/canonical/pebble/internals/systemd"
 )
 
 var shortRunHelp = "Run the pebble environment"
@@ -114,7 +113,7 @@ func runWatchdog(d *daemon.Daemon) (*time.Ticker, error) {
 			case <-wt.C:
 				// TODO: poke the API here and only report WATCHDOG=1 if it
 				//       replies with valid data.
-				systemd.SdNotify("WATCHDOG=1")
+				daemon.Notify.Send("WATCHDOG=1")
 			case <-d.Dying():
 				return
 			}

--- a/internals/systemd/notify_test.go
+++ b/internals/systemd/notify_test.go
@@ -44,16 +44,16 @@ func (sd *sdNotifyTestSuite) TearDownTest(c *C) {
 
 func (sd *sdNotifyTestSuite) TestSocketAvailable(c *C) {
 	socketPath := filepath.Join(c.MkDir(), "notify.socket")
-	c.Assert(systemd.SocketAvailable(), Equals, false)
+	c.Assert(systemd.Notifier.Available(), Equals, false)
 	sd.env["NOTIFY_SOCKET"] = socketPath
-	c.Assert(systemd.SocketAvailable(), Equals, false)
+	c.Assert(systemd.Notifier.Available(), Equals, false)
 	f, _ := os.Create(socketPath)
 	f.Close()
-	c.Assert(systemd.SocketAvailable(), Equals, true)
+	c.Assert(systemd.Notifier.Available(), Equals, true)
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyMissingNotifyState(c *C) {
-	c.Check(systemd.SdNotify(""), ErrorMatches, "cannot use empty notify state")
+	c.Check(systemd.Notifier.Send(""), ErrorMatches, "cannot use empty notify state")
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyWrongNotifySocket(c *C) {
@@ -65,7 +65,7 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWrongNotifySocket(c *C) {
 		{"xxx", `cannot use \$NOTIFY_SOCKET value: "xxx"`},
 	} {
 		sd.env["NOTIFY_SOCKET"] = t.env
-		c.Check(systemd.SdNotify("something"), ErrorMatches, t.errStr)
+		c.Check(systemd.Notifier.Send("something"), ErrorMatches, t.errStr)
 	}
 }
 
@@ -91,7 +91,7 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 			ch <- string(buf[:n])
 		}()
 
-		err = systemd.SdNotify("something")
+		err = systemd.Notifier.Send("something")
 		c.Assert(err, IsNil)
 		c.Check(<-ch, Equals, "something")
 	}

--- a/internals/systemd/shutdown.go
+++ b/internals/systemd/shutdown.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package systemd
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/canonical/pebble/internals/osutil"
+)
+
+type shutdown struct{}
+
+var Shutdown = &shutdown{}
+
+// Reboot the system after a specified duration of time, optionally
+// displaying a wall message.
+func (s shutdown) Reboot(delay time.Duration, msg string) error {
+	if delay < 0 {
+		delay = 0
+	}
+	mins := int64(delay / time.Minute)
+	cmd := exec.Command("shutdown", "-r", fmt.Sprintf("+%d", mins), msg)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return osutil.OutputErr(out, err)
+	}
+	return nil
+}

--- a/internals/systemd/shutdown_test.go
+++ b/internals/systemd/shutdown_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2014-2020 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package systemd_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/reaper"
+	"github.com/canonical/pebble/internals/systemd"
+	"github.com/canonical/pebble/internals/testutil"
+)
+
+type shutdownTestSuite struct{}
+
+var _ = Suite(&shutdownTestSuite{})
+
+func (s *shutdownTestSuite) SetUpTest(c *C) {
+	// Needed for testutil.exec
+	reaper.Start()
+}
+
+func (s *shutdownTestSuite) TearDownTest(c *C) {
+	reaper.Stop()
+}
+
+// TestReboot checks that command construction match the
+// expectation of the systemd shutdown command.
+func (s *shutdownTestSuite) TestReboot(c *C) {
+	cmd := testutil.FakeCommand(c, "shutdown", "", true)
+	defer cmd.Restore()
+
+	tests := []struct {
+		delay    time.Duration
+		delayArg string
+		msg      string
+	}{
+		{0, "+0", ""},
+		{0, "+0", "some msg"},
+		{-1, "+0", "some msg"},
+		{time.Minute, "+1", "some msg"},
+		{10 * time.Minute, "+10", "some msg"},
+		{30 * time.Second, "+0", "some msg"},
+	}
+
+	for _, t := range tests {
+		err := systemd.Shutdown.Reboot(t.delay, t.msg)
+		c.Assert(err, IsNil)
+		c.Check(cmd.Calls(), DeepEquals, [][]string{
+			{"shutdown", "-r", t.delayArg, t.msg},
+		})
+
+		cmd.ForgetCalls()
+	}
+}


### PR DESCRIPTION
The current shutdown and notify logic in pebble is designed with the
assumption that it will run under systemd, or at least that some
systemd components, such as ```shutdown```, is installed.

Allow custom flavours of pebble to change the default assumptions.

- The daemon now defines a notification and shutdown interface, and
  configures the default implementation to use systemd.

- The shutdown logic (of which we currently only support reboot) is
  moved to the systemd package, as its based on systemd.

- Two globals daemon.Notify and daemon.Shutdown now provides a way
  to override the defaults.

This is an alternative approach to what we have in https://github.com/canonical/pebble/pull/197

An hypothetical derivative project based on Pebble can now supply its own shutdown and notification implementations before starting the daemon:

```
daemon.Notify = custom.Notifier 
daemon.Shutdown = custom.Shutdown
:
d, err := daemon.New(&dopts)
:
d.Start()
```