### PR TITLE
Add "service context" support for exec and health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,13 @@ checks:
             # directly, not interpreted by a shell.
             command: <commmand>
 
+            # (Optional) Run the command in the context of the given service,
+            # that is, inherit its environment variables, user/group settings,
+            # and working directory. The check's context (the settings below)
+            # will override the service's; the check's environment map will be
+            # merged on top of the service's.
+            context: <service-name>
+
             # (Optional) A list of key/value pairs defining environment
             # variables that should be set when running the command.
             environment:

--- a/README.md
+++ b/README.md
@@ -523,6 +523,10 @@ services:
         # group and group-id are specified, the group's GID must match group-id.
         group-id: <gid>
 
+        # (Optional) Working directory to run command in. By default, the
+        # command is run in the service manager's current directory.
+        working-dir: <directory>
+
         # (Optional) Defines what happens when the service exits with a zero
         # exit code. Possible values are: "restart" (default) which restarts
         # the service after the backoff delay, "shutdown" which shuts down and
@@ -653,7 +657,8 @@ checks:
             # match group-id.
             group-id: <gid>
 
-            # (Optional) Working directory to run command in.
+            # (Optional) Working directory to run command in. By default, the
+            # command is run in the service manager's current directory.
             working-dir: <directory>
 ```
 

--- a/client/exec.go
+++ b/client/exec.go
@@ -30,6 +30,12 @@ type ExecOptions struct {
 	// Required: command and arguments (first element is the executable).
 	Command []string
 
+	// Optional service name to run the command in the context of this service,
+	// that is, inherit its environment variables, user/group settings,
+	// and working directory. The other options in this struct will override
+	// the service context; Environment will be merged on top of the service's.
+	Context string
+
 	// Optional environment variables.
 	Environment map[string]string
 
@@ -75,6 +81,7 @@ type ExecOptions struct {
 
 type execPayload struct {
 	Command     []string          `json:"command"`
+	Context     string            `json:"context,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	WorkingDir  string            `json:"working-dir,omitempty"`
 	Timeout     string            `json:"timeout,omitempty"`
@@ -123,6 +130,7 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	}
 	payload := execPayload{
 		Command:     opts.Command,
+		Context:     opts.Context,
 		Environment: opts.Environment,
 		WorkingDir:  opts.WorkingDir,
 		Timeout:     timeoutStr,

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -39,6 +39,7 @@ type cmdExec struct {
 	GroupID        *int          `long:"gid"`
 	Group          string        `long:"group"`
 	Timeout        time.Duration `long:"timeout"`
+	Context        string        `long:"context"`
 	Terminal       bool          `short:"t"`
 	NoTerminal     bool          `short:"T"`
 	Interactive    bool          `short:"i"`
@@ -56,6 +57,7 @@ var execDescs = map[string]string{
 	"gid":     "Group ID to run command as",
 	"group":   "Group name to run command as (group's GID must match gid if both present)",
 	"timeout": "Timeout after which to terminate command",
+	"context": "Run the command in the context of this service (overridden by -w, --env, --user, --uid, --group, --gid)",
 	"t":       "Allocate remote pseudo-terminal and connect stdout to it (default if stdout is a TTY)",
 	"T":       "Disable remote pseudo-terminal allocation",
 	"i":       "Interactive mode: connect stdin to the pseudo-terminal (default if stdin and stdout are TTYs)",
@@ -144,6 +146,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 
 	opts := &client.ExecOptions{
 		Command:     command,
+		Context:     cmd.Context,
 		Environment: env,
 		WorkingDir:  cmd.WorkingDir,
 		Timeout:     cmd.Timeout,

--- a/internals/daemon/api_exec.go
+++ b/internals/daemon/api_exec.go
@@ -24,10 +24,12 @@ import (
 	"github.com/canonical/pebble/internals/osutil"
 	"github.com/canonical/pebble/internals/overlord/cmdstate"
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/plan"
 )
 
 type execPayload struct {
 	Command     []string          `json:"command"`
+	Context     string            `json:"context"`
 	Environment map[string]string `json:"environment"`
 	WorkingDir  string            `json:"working-dir"`
 	Timeout     string            `json:"timeout"`
@@ -67,8 +69,25 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 		return statusBadRequest("%v", err)
 	}
 
+	p, err := c.d.overlord.ServiceManager().Plan()
+	if err != nil {
+		return statusBadRequest("%v", err)
+	}
+	overrides := plan.ContextOptions{
+		Environment: payload.Environment,
+		UserID:      payload.UserID,
+		User:        payload.User,
+		GroupID:     payload.GroupID,
+		Group:       payload.Group,
+		WorkingDir:  payload.WorkingDir,
+	}
+	merged, err := plan.MergeServiceContext(p, payload.Context, overrides)
+	if err != nil {
+		return statusBadRequest("%v", err)
+	}
+
 	// Convert User/UserID and Group/GroupID combinations into raw uid/gid.
-	uid, gid, err := osutil.NormalizeUidGid(payload.UserID, payload.GroupID, payload.User, payload.Group)
+	uid, gid, err := osutil.NormalizeUidGid(merged.UserID, merged.GroupID, merged.User, merged.Group)
 	if err != nil {
 		return statusBadRequest("%v", err)
 	}
@@ -79,8 +98,8 @@ func v1PostExec(c *Command, req *http.Request, _ *userState) Response {
 
 	args := &cmdstate.ExecArgs{
 		Command:     payload.Command,
-		Environment: payload.Environment,
-		WorkingDir:  payload.WorkingDir,
+		Environment: merged.Environment,
+		WorkingDir:  merged.WorkingDir,
 		Timeout:     timeout,
 		UserID:      uid,
 		GroupID:     gid,

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -291,7 +291,7 @@ func (s *CheckersSuite) TestNewChecker(c *C) {
 			URL:     "https://example.com/foo",
 			Headers: map[string]string{"k": "v"},
 		},
-	})
+	}, nil)
 	http, ok := chk.(*httpChecker)
 	c.Assert(ok, Equals, true)
 	c.Check(http.name, Equals, "http")
@@ -304,7 +304,7 @@ func (s *CheckersSuite) TestNewChecker(c *C) {
 			Port: 80,
 			Host: "localhost",
 		},
-	})
+	}, nil)
 	tcp, ok := chk.(*tcpChecker)
 	c.Assert(ok, Equals, true)
 	c.Check(tcp.name, Equals, "tcp")
@@ -323,7 +323,7 @@ func (s *CheckersSuite) TestNewChecker(c *C) {
 			Group:       "group",
 			WorkingDir:  "/working/dir",
 		},
-	})
+	}, nil)
 	exec, ok := chk.(*execChecker)
 	c.Assert(ok, Equals, true)
 	c.Assert(exec.name, Equals, "exec")
@@ -333,4 +333,71 @@ func (s *CheckersSuite) TestNewChecker(c *C) {
 	c.Assert(exec.user, Equals, "user")
 	c.Assert(exec.groupID, Equals, &groupID)
 	c.Assert(exec.workingDir, Equals, "/working/dir")
+}
+
+func (s *CheckersSuite) TestExecContextNoOverride(c *C) {
+	svcUserID, svcGroupID := 10, 20
+	chk := newChecker(&plan.Check{
+		Name: "exec",
+		Exec: &plan.ExecCheck{
+			Command: "sleep 1",
+			Context: "svc1",
+		},
+	}, &plan.Plan{Services: map[string]*plan.Service{
+		"svc1": {
+			Name:        "svc1",
+			Environment: map[string]string{"k": "x", "a": "1"},
+			UserID:      &svcUserID,
+			User:        "svcuser",
+			GroupID:     &svcGroupID,
+			Group:       "svcgroup",
+			WorkingDir:  "/working/svc",
+		},
+	}})
+	exec, ok := chk.(*execChecker)
+	c.Assert(ok, Equals, true)
+	c.Check(exec.name, Equals, "exec")
+	c.Check(exec.command, Equals, "sleep 1")
+	c.Check(exec.environment, DeepEquals, map[string]string{"k": "x", "a": "1"})
+	c.Check(exec.userID, Equals, &svcUserID)
+	c.Check(exec.user, Equals, "svcuser")
+	c.Check(exec.groupID, Equals, &svcGroupID)
+	c.Check(exec.workingDir, Equals, "/working/svc")
+}
+
+func (s *CheckersSuite) TestExecContextOverride(c *C) {
+	userID, groupID := 100, 200
+	svcUserID, svcGroupID := 10, 20
+	chk := newChecker(&plan.Check{
+		Name: "exec",
+		Exec: &plan.ExecCheck{
+			Command:     "sleep 1",
+			Context:     "svc1",
+			Environment: map[string]string{"k": "v"},
+			UserID:      &userID,
+			User:        "user",
+			GroupID:     &groupID,
+			Group:       "group",
+			WorkingDir:  "/working/dir",
+		},
+	}, &plan.Plan{Services: map[string]*plan.Service{
+		"svc1": {
+			Name:        "svc1",
+			Environment: map[string]string{"k": "x", "a": "1"},
+			UserID:      &svcUserID,
+			User:        "svcuser",
+			GroupID:     &svcGroupID,
+			Group:       "svcgroup",
+			WorkingDir:  "/working/svc",
+		},
+	}})
+	exec, ok := chk.(*execChecker)
+	c.Assert(ok, Equals, true)
+	c.Check(exec.name, Equals, "exec")
+	c.Check(exec.command, Equals, "sleep 1")
+	c.Check(exec.environment, DeepEquals, map[string]string{"k": "v", "a": "1"})
+	c.Check(exec.userID, Equals, &userID)
+	c.Check(exec.user, Equals, "user")
+	c.Check(exec.groupID, Equals, &groupID)
+	c.Check(exec.workingDir, Equals, "/working/dir")
 }

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -359,9 +359,9 @@ func (s *CheckersSuite) TestExecContextNoOverride(c *C) {
 	c.Check(exec.name, Equals, "exec")
 	c.Check(exec.command, Equals, "sleep 1")
 	c.Check(exec.environment, DeepEquals, map[string]string{"k": "x", "a": "1"})
-	c.Check(exec.userID, Equals, &svcUserID)
+	c.Check(exec.userID, DeepEquals, &svcUserID)
 	c.Check(exec.user, Equals, "svcuser")
-	c.Check(exec.groupID, Equals, &svcGroupID)
+	c.Check(exec.groupID, DeepEquals, &svcGroupID)
 	c.Check(exec.workingDir, Equals, "/working/svc")
 }
 
@@ -396,8 +396,8 @@ func (s *CheckersSuite) TestExecContextOverride(c *C) {
 	c.Check(exec.name, Equals, "exec")
 	c.Check(exec.command, Equals, "sleep 1")
 	c.Check(exec.environment, DeepEquals, map[string]string{"k": "v", "a": "1"})
-	c.Check(exec.userID, Equals, &userID)
+	c.Check(exec.userID, DeepEquals, &userID)
 	c.Check(exec.user, Equals, "user")
-	c.Check(exec.groupID, Equals, &groupID)
+	c.Check(exec.groupID, DeepEquals, &groupID)
 	c.Check(exec.workingDir, Equals, "/working/dir")
 }

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -347,6 +347,8 @@ func (s *serviceData) startInternal() error {
 		environment[k] = v
 	}
 
+	s.cmd.Dir = s.config.WorkingDir
+
 	// Start as another user if specified in plan.
 	uid, gid, err := osutil.NormalizeUidGid(s.config.UserID, s.config.GroupID, s.config.User, s.config.Group)
 	if err != nil {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -79,6 +79,7 @@ type Service struct {
 	User        string            `yaml:"user,omitempty"`
 	GroupID     *int              `yaml:"group-id,omitempty"`
 	Group       string            `yaml:"group,omitempty"`
+	WorkingDir  string            `yaml:"working-dir,omitempty"`
 
 	// Auto-restart and backoff functionality
 	OnSuccess      ServiceAction            `yaml:"on-success,omitempty"`
@@ -153,6 +154,9 @@ func (s *Service) Merge(other *Service) {
 	}
 	if other.Group != "" {
 		s.Group = other.Group
+	}
+	if other.WorkingDir != "" {
+		s.WorkingDir = other.WorkingDir
 	}
 	s.After = append(s.After, other.After...)
 	s.Before = append(s.Before, other.Before...)

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1142,9 +1142,15 @@ func MergeServiceContext(p *Plan, serviceName string, overrides ContextOptions) 
 	for k, v := range service.Environment {
 		merged.Environment[k] = v
 	}
-	merged.UserID = service.UserID
+	if service.UserID != nil {
+		copied := *service.UserID
+		merged.UserID = &copied
+	}
 	merged.User = service.User
-	merged.GroupID = service.GroupID
+	if service.GroupID != nil {
+		copied := *service.GroupID
+		merged.GroupID = &copied
+	}
 	merged.Group = service.Group
 	merged.WorkingDir = service.WorkingDir
 
@@ -1153,13 +1159,15 @@ func MergeServiceContext(p *Plan, serviceName string, overrides ContextOptions) 
 		merged.Environment[k] = v
 	}
 	if overrides.UserID != nil {
-		merged.UserID = overrides.UserID
+		userID := *overrides.UserID
+		merged.UserID = &userID
 	}
 	if overrides.User != "" {
 		merged.User = overrides.User
 	}
 	if overrides.GroupID != nil {
-		merged.GroupID = overrides.GroupID
+		groupID := *overrides.GroupID
+		merged.GroupID = &groupID
 	}
 	if overrides.Group != "" {
 		merged.Group = overrides.Group

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -817,6 +817,17 @@ var planTests = []planTest{{
 					command: foo '
 	`},
 }, {
+	summary: `Invalid exec check context`,
+	error:   `plan check "chk1" context "nosvc" is not a service name`,
+	input: []string{`
+		checks:
+			chk1:
+				override: replace
+				exec:
+					command: foo
+					context: nosvc
+	`},
+}, {
 	summary: "Simple layer with log targets",
 	input: []string{`
 		services:


### PR DESCRIPTION
This adds the ability to run exec commands (one-shot commands) and exec-based health checks using the context from an existing service, specifically, reusing its environment variables, user/group, and working directory. Any options in the exec command or health check, if present, override the service context (and the environment variables are merged).

Note that #245 -- support for `working-dir` in the service configuration -- should be merged first.

This is based on spec [OP034](https://docs.google.com/document/d/1hdzrbvrsQomK04FCUTW-pueAG9F3dvrxyISGL5rzM0g/edit).