### PR TITLE
daemon: FakeCommand usage requires reaper.Start()

### DIFF
--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/canonical/pebble/internals/overlord/restart"
 	"github.com/canonical/pebble/internals/overlord/standby"
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/systemd"
 	"github.com/canonical/pebble/internals/testutil"
 )
@@ -58,6 +59,8 @@ type daemonSuite struct {
 var _ = Suite(&daemonSuite{})
 
 func (s *daemonSuite) SetUpTest(c *C) {
+	err := reaper.Start()
+	c.Assert(err, IsNil)
 	s.pebbleDir = c.MkDir()
 	s.statePath = filepath.Join(s.pebbleDir, ".pebble.state")
 	systemdSdNotify = func(notif string) error {
@@ -71,6 +74,8 @@ func (s *daemonSuite) TearDownTest(c *C) {
 	s.notified = nil
 	s.authorized = false
 	s.err = nil
+	err := reaper.Stop()
+	c.Assert(err, IsNil)
 }
 
 func (s *daemonSuite) newDaemon(c *C) *Daemon {


### PR DESCRIPTION
The usage of testutil.FakeCommand requires the test environment to start and stop the reaper in the case where the reaper option is enabled.

For example, in internals/daemon/daemon_test.go:

:
cmd := testutil.FakeCommand(c, "shutdown", "", true) :

However, in daemon_test.go, the code is currently relying on the service manager, provided by the overlord, to start the reaper. This is not a safe solution as not all test implementations may actually run the real overlord code, and even if they do, we have a potential race condition.

daemon.Init() -> overlord.New() -> servstate.NewManager() -> reaper.Start()

The following changes are introduced:

- Add reaper.Start() and reaper.Stop() to the daemon test setup and teardown.

- Add a reaper based test for testutil.FakeCommand().