### PR TITLE
[JUJU-3777] Multiplex services to log targets using only a `log-target.services` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ my-target:
     services: [-svc1]
     override: merge
 ```
-then in the merged layer, `my-target` will collect logs from only `svc2`. You can also use `-all` to remove all services from the list.
+then in the merged layer, the `services` list will be merged to `[svc1, svc2, -svc1]`, which evaluates left to right as simply `[svc2]`. So `my-target` will collect logs from only `svc2`. You can also use `-all` to remove all services from the list.
 -->
 
 ## Container usage

--- a/README.md
+++ b/README.md
@@ -403,6 +403,45 @@ $ pebble run --verbose
 ...
 ```
 
+<!--
+TODO: uncomment this section once log forwarding is fully implemented
+TODO: add log targets to the Pebble layer spec below
+
+#### Log forwarding
+
+Pebble supports forwarding its services' logs to a remote Loki server or syslog receiver (via UDP/TCP). In the `log-targets` section of the plan, you can specify destinations for log forwarding, for example:
+```yaml
+log-targets:
+    loki-example:
+        override: merge
+        type: loki
+        location: http://10.1.77.205:3100/loki/api/v1/push
+        services: [all]
+    syslog-example:
+        override: merge
+        type: syslog
+        location: tcp://192.168.10.241:1514
+        services: [svc1, svc2]
+```
+
+For each log target, use the `services` key to specify a list of services to collect logs from. In the above example, the `syslog-example` target will collect logs from `svc1` and `svc2`.
+
+Use the special keyword `all` to match all services. In the above example, `loki-example` will collect logs from all services.
+
+To remove a service from a log target when merging, prefix the service name with a minus `-`. For example, if we have a base layer with
+```yaml
+my-target:
+    services: [svc1, svc2]
+```
+and override layer with
+```yaml
+my-target:
+    services: [-svc1]
+    override: merge
+```
+then in the merged layer, `my-target` will collect logs from only `svc2`. You can also use `-all` to remove all services from the list.
+-->
+
 ## Container usage
 
 Pebble works well as a local service manager, but if running Pebble in a separate container, you can use the exec and file management APIs to coordinate with the remote system over the shared unix socket.

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ log-targets:
 
 For each log target, use the `services` key to specify a list of services to collect logs from. In the above example, the `syslog-example` target will collect logs from `svc1` and `svc2`.
 
-Use the special keyword `all` to match all services. In the above example, `loki-example` will collect logs from all services.
+Use the special keyword `all` to match all services, including services that might be added in future layers. In the above example, `loki-example` will collect logs from all services.
 
 To remove a service from a log target when merging, prefix the service name with a minus `-`. For example, if we have a base layer with
 ```yaml
@@ -439,7 +439,22 @@ my-target:
     services: [-svc1]
     override: merge
 ```
-then in the merged layer, the `services` list will be merged to `[svc1, svc2, -svc1]`, which evaluates left to right as simply `[svc2]`. So `my-target` will collect logs from only `svc2`. You can also use `-all` to remove all services from the list.
+then in the merged layer, the `services` list will be merged to `[svc1, svc2, -svc1]`, which evaluates left to right as simply `[svc2]`. So `my-target` will collect logs from only `svc2`.
+
+You can also use `-all` to remove all services from the list. For example, adding an override layer with
+```yaml
+my-target:
+    services: [-all]
+    override: merge
+```
+would remove all services from `my-target`, effectively disabling `my-target`. Meanwhile, adding an override layer with
+```yaml
+my-target:
+    services: [-all, svc1]
+    override: merge
+```
+would remove all services and then add `svc1`, so `my-target` would receive logs from only `svc1`.
+
 -->
 
 ## Container usage

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -780,7 +780,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 		}
 
-		if target.Location == "" && len(target.Services) > 0 {
+		if target.Location == "" {
 			return nil, &FormatError{
 				Message: fmt.Sprintf(`plan must define "location" for log target %q`, name),
 			}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -523,8 +523,6 @@ func (t *LogTarget) Merge(other *LogTarget) {
 	if other.Location != "" {
 		t.Location = other.Location
 	}
-	// TODO: reduce log targets?
-	// e.g. [..., all, -svc1] -> [all, -svc1]
 	t.Services = append(t.Services, other.Services...)
 }
 
@@ -774,6 +772,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			if _, ok := combined.Services[serviceName]; ok {
 				continue
 			}
+			// Check if this is `-svc`
 			serviceName = strings.TrimPrefix(serviceName, "-")
 			if _, ok := combined.Services[serviceName]; ok {
 				continue

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -255,7 +255,21 @@ func CommandString(base, extra []string) string {
 
 // LogsTo returns true if the logs from s should be forwarded to target t.
 func (s *Service) LogsTo(t *LogTarget) bool {
-	// TODO: implement
+	// Iterate backwards through t.Services until we find something matching
+	// s.Name.
+	for i := len(t.Services) - 1; i >= 0; i++ {
+		switch t.Services[i] {
+		case s.Name:
+			return true
+		case ("-" + s.Name):
+			return false
+		case "all":
+			return true
+		case "-all":
+			return false
+		}
+	}
+	// Nothing matching the service name, so it was not specified.
 	return false
 }
 
@@ -480,6 +494,7 @@ type LogTarget struct {
 	Name     string        `yaml:"-"`
 	Type     LogTargetType `yaml:"type"`
 	Location string        `yaml:"location"`
+	Services []string      `yaml:"services"`
 	Override Override      `yaml:"override,omitempty"`
 }
 
@@ -495,6 +510,7 @@ const (
 // Copy returns a deep copy of the log target configuration.
 func (t *LogTarget) Copy() *LogTarget {
 	copied := *t
+	copied.Services = append([]string(nil), t.Services...)
 	return &copied
 }
 
@@ -506,6 +522,7 @@ func (t *LogTarget) Merge(other *LogTarget) {
 	if other.Location != "" {
 		t.Location = other.Location
 	}
+	t.Services = append(t.Services, other.Services...)
 }
 
 // FormatError is the error returned when a layer has a format error, such as

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/x-go/strutil/shlex"
 	"gopkg.in/yaml.v3"
 
@@ -927,6 +928,10 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 			return nil, &FormatError{
 				Message: fmt.Sprintf("cannot use reserved service name %q", name),
 			}
+		}
+		// Deprecated service names
+		if name == "all" || name == "default" || name == "none" {
+			logger.Noticef("WARNING: using %q as service name is deprecated", name)
 		}
 		if service == nil {
 			return nil, &FormatError{

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/x-go/strutil/shlex"
 	"gopkg.in/yaml.v3"
 
+	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/osutil"
 )
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -767,9 +767,13 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 		// Validate service names specified in log target
 		for _, serviceName := range target.Services {
-			if serviceName == "all" {
+			if serviceName == "all" || serviceName == "-all" {
 				continue
 			}
+			if _, ok := combined.Services[serviceName]; ok {
+				continue
+			}
+			serviceName = strings.TrimPrefix(serviceName, "-")
 			if _, ok := combined.Services[serviceName]; ok {
 				continue
 			}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -769,10 +769,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			if serviceName == "all" || serviceName == "-all" {
 				continue
 			}
-			if _, ok := combined.Services[serviceName]; ok {
-				continue
-			}
-			// Check if this is `-svc`
+			// This could be `-svc` - try to trim a preceding
 			serviceName = strings.TrimPrefix(serviceName, "-")
 			if _, ok := combined.Services[serviceName]; ok {
 				continue
@@ -931,6 +928,11 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		// Deprecated service names
 		if name == "all" || name == "default" || name == "none" {
 			logger.Noticef("WARNING: using %q as service name is deprecated", name)
+		}
+		if strings.HasPrefix(name, "-") {
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`cannot use service name %q: starting with "-" not allowed`, name),
+			}
 		}
 		if service == nil {
 			return nil, &FormatError{

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -477,11 +477,10 @@ func (c *ExecCheck) Merge(other *ExecCheck) {
 
 // LogTarget specifies a remote server to forward logs to.
 type LogTarget struct {
-	Name      string        `yaml:"-"`
-	Type      LogTargetType `yaml:"type"`
-	Location  string        `yaml:"location"`
-	Selection Selection     `yaml:"selection,omitempty"`
-	Override  Override      `yaml:"override,omitempty"`
+	Name     string        `yaml:"-"`
+	Type     LogTargetType `yaml:"type"`
+	Location string        `yaml:"location"`
+	Override Override      `yaml:"override,omitempty"`
 }
 
 // LogTargetType defines the protocol to use to forward logs.
@@ -491,16 +490,6 @@ const (
 	LokiTarget     LogTargetType = "loki"
 	SyslogTarget   LogTargetType = "syslog"
 	UnsetLogTarget LogTargetType = ""
-)
-
-// Selection describes which services' logs will be forwarded to this target.
-type Selection string
-
-const (
-	OptOutSelection   Selection = "opt-out"
-	OptInSelection    Selection = "opt-in"
-	DisabledSelection Selection = "disabled"
-	UnsetSelection    Selection = ""
 )
 
 // Copy returns a deep copy of the log target configuration.
@@ -516,9 +505,6 @@ func (t *LogTarget) Merge(other *LogTarget) {
 	}
 	if other.Location != "" {
 		t.Location = other.Location
-	}
-	if other.Selection != "" {
-		t.Selection = other.Selection
 	}
 }
 
@@ -760,17 +746,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 		}
 
-		switch target.Selection {
-		case OptOutSelection, OptInSelection, DisabledSelection, UnsetSelection:
-			// valid, continue
-		default:
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`log target %q has invalid selection %q, must be %q, %q or %q`,
-					name, target.Selection, OptOutSelection, OptInSelection, DisabledSelection),
-			}
-		}
-
-		if target.Location == "" && target.Selection != DisabledSelection {
+		if target.Location == "" {
 			return nil, &FormatError{
 				Message: fmt.Sprintf(`plan must define "location" for log target %q`, name),
 			}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -766,11 +766,10 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 		// Validate service names specified in log target
 		for _, serviceName := range target.Services {
-			if serviceName == "all" || serviceName == "-all" {
+			serviceName = strings.TrimPrefix(serviceName, "-")
+			if serviceName == "all" {
 				continue
 			}
-			// This could be `-svc` - try to trim a preceding
-			serviceName = strings.TrimPrefix(serviceName, "-")
 			if _, ok := combined.Services[serviceName]; ok {
 				continue
 			}
@@ -927,7 +926,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		}
 		// Deprecated service names
 		if name == "all" || name == "default" || name == "none" {
-			logger.Noticef("WARNING: using %q as service name is deprecated", name)
+			logger.Noticef("Using keyword %q as a service name is deprecated", name)
 		}
 		if strings.HasPrefix(name, "-") {
 			return nil, &FormatError{

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -258,7 +258,7 @@ func CommandString(base, extra []string) string {
 func (s *Service) LogsTo(t *LogTarget) bool {
 	// Iterate backwards through t.Services until we find something matching
 	// s.Name.
-	for i := len(t.Services) - 1; i >= 0; i++ {
+	for i := len(t.Services) - 1; i >= 0; i-- {
 		switch t.Services[i] {
 		case s.Name:
 			return true

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1102,6 +1102,15 @@ var planTests = []planTest{{
 				services: [nonexistent]
 				override: merge
 `},
+}, {
+	summary: `Service name can't start with "-"`,
+	error:   `cannot use service name "-svc1": starting with "-" not allowed`,
+	input: []string{`
+		services:
+			-svc1:
+				command: foo
+				override: merge
+`},
 }}
 
 func (s *S) TestParseLayer(c *C) {

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -918,11 +918,10 @@ var planTests = []planTest{{
 		log-targets:
 			tgt1:
 				override: merge
-				selection: opt-in
 			tgt2:
 				type: syslog
+				location: foo
 				override: replace
-				selection: disabled
 			tgt3:
 				type: loki
 				location: http://10.1.77.206:3100/loki/api/v1/push
@@ -979,15 +978,14 @@ var planTests = []planTest{{
 		Checks: map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
-				Name:      "tgt1",
-				Override:  plan.MergeOverride,
-				Selection: plan.OptInSelection,
+				Name:     "tgt1",
+				Override: plan.MergeOverride,
 			},
 			"tgt2": {
-				Name:      "tgt2",
-				Type:      plan.SyslogTarget,
-				Override:  plan.ReplaceOverride,
-				Selection: plan.DisabledSelection,
+				Name:     "tgt2",
+				Type:     plan.SyslogTarget,
+				Location: "foo",
+				Override: plan.ReplaceOverride,
 			},
 			"tgt3": {
 				Name:     "tgt3",
@@ -1021,17 +1019,16 @@ var planTests = []planTest{{
 		Checks: map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
-				Name:      "tgt1",
-				Type:      plan.LokiTarget,
-				Location:  "http://10.1.77.196:3100/loki/api/v1/push",
-				Override:  plan.MergeOverride,
-				Selection: plan.OptInSelection,
+				Name:     "tgt1",
+				Type:     plan.LokiTarget,
+				Location: "http://10.1.77.196:3100/loki/api/v1/push",
+				Override: plan.MergeOverride,
 			},
 			"tgt2": {
-				Name:      "tgt2",
-				Type:      plan.SyslogTarget,
-				Override:  plan.ReplaceOverride,
-				Selection: plan.DisabledSelection,
+				Name:     "tgt2",
+				Type:     plan.SyslogTarget,
+				Location: "foo",
+				Override: plan.ReplaceOverride,
 			},
 			"tgt3": {
 				Name:     "tgt3",
@@ -1067,17 +1064,6 @@ var planTests = []planTest{{
 				type: foobar
 				location: http://10.1.77.196:3100/loki/api/v1/push
 				override: merge
-`},
-}, {
-	summary: "Invalid selection for log target",
-	error:   `log target "tgt1" has invalid selection "foobar", must be "opt-out", "opt-in" or "disabled"`,
-	input: []string{`
-		log-targets:
-			tgt1:
-				type: loki
-				location: http://10.1.77.196:3100/loki/api/v1/push
-				override: merge
-				selection: foobar
 `},
 }}
 

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -932,6 +932,7 @@ var planTests = []planTest{{
 				override: merge
 			tgt2:
 				type: syslog
+				location: udp://1.2.3.4:514
 				services: []
 				override: replace
 			tgt3:
@@ -1007,6 +1008,7 @@ var planTests = []planTest{{
 			"tgt2": {
 				Name:     "tgt2",
 				Type:     plan.SyslogTarget,
+				Location: "udp://1.2.3.4:514",
 				Services: []string{},
 				Override: plan.ReplaceOverride,
 			},
@@ -1052,6 +1054,7 @@ var planTests = []planTest{{
 			"tgt2": {
 				Name:     "tgt2",
 				Type:     plan.SyslogTarget,
+				Location: "udp://1.2.3.4:514",
 				Override: plan.ReplaceOverride,
 			},
 			"tgt3": {

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -840,10 +840,12 @@ var planTests = []planTest{{
 			tgt1:
 				type: loki
 				location: http://10.1.77.196:3100/loki/api/v1/push
+				services: [all]
 				override: merge
 			tgt2:
 				type: syslog
 				location: udp://0.0.0.0:514
+				services: [svc2]
 				override: merge
 `},
 	result: &plan.Layer{
@@ -873,12 +875,14 @@ var planTests = []planTest{{
 				Name:     "tgt1",
 				Type:     plan.LokiTarget,
 				Location: "http://10.1.77.196:3100/loki/api/v1/push",
+				Services: []string{"all"},
 				Override: plan.MergeOverride,
 			},
 			"tgt2": {
 				Name:     "tgt2",
 				Type:     plan.SyslogTarget,
 				Location: "udp://0.0.0.0:514",
+				Services: []string{"svc2"},
 				Override: plan.MergeOverride,
 			},
 		},
@@ -900,10 +904,12 @@ var planTests = []planTest{{
 			tgt1:
 				type: loki
 				location: http://10.1.77.196:3100/loki/api/v1/push
+				services: [all]
 				override: merge
 			tgt2:
 				type: syslog
 				location: udp://0.0.0.0:514
+				services: [svc2]
 				override: merge
 `, `
 		services:
@@ -917,14 +923,16 @@ var planTests = []planTest{{
 		
 		log-targets:
 			tgt1:
+				services: [-all, svc1]
 				override: merge
 			tgt2:
 				type: syslog
-				location: foo
+				services: []
 				override: replace
 			tgt3:
 				type: loki
 				location: http://10.1.77.206:3100/loki/api/v1/push
+				services: [all]
 				override: merge
 `},
 	layers: []*plan.Layer{{
@@ -950,12 +958,14 @@ var planTests = []planTest{{
 				Name:     "tgt1",
 				Type:     plan.LokiTarget,
 				Location: "http://10.1.77.196:3100/loki/api/v1/push",
+				Services: []string{"all"},
 				Override: plan.MergeOverride,
 			},
 			"tgt2": {
 				Name:     "tgt2",
 				Type:     plan.SyslogTarget,
 				Location: "udp://0.0.0.0:514",
+				Services: []string{"svc2"},
 				Override: plan.MergeOverride,
 			},
 		},
@@ -979,18 +989,20 @@ var planTests = []planTest{{
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
+				Services: []string{"-all", "svc1"},
 				Override: plan.MergeOverride,
 			},
 			"tgt2": {
 				Name:     "tgt2",
 				Type:     plan.SyslogTarget,
-				Location: "foo",
+				Services: []string{},
 				Override: plan.ReplaceOverride,
 			},
 			"tgt3": {
 				Name:     "tgt3",
 				Type:     plan.LokiTarget,
 				Location: "http://10.1.77.206:3100/loki/api/v1/push",
+				Services: []string{"all"},
 				Override: plan.MergeOverride,
 			},
 		},
@@ -1022,18 +1034,19 @@ var planTests = []planTest{{
 				Name:     "tgt1",
 				Type:     plan.LokiTarget,
 				Location: "http://10.1.77.196:3100/loki/api/v1/push",
+				Services: []string{"all", "-all", "svc1"},
 				Override: plan.MergeOverride,
 			},
 			"tgt2": {
 				Name:     "tgt2",
 				Type:     plan.SyslogTarget,
-				Location: "foo",
 				Override: plan.ReplaceOverride,
 			},
 			"tgt3": {
 				Name:     "tgt3",
 				Type:     plan.LokiTarget,
 				Location: "http://10.1.77.206:3100/loki/api/v1/push",
+				Services: []string{"all"},
 				Override: plan.MergeOverride,
 			},
 		},
@@ -1054,6 +1067,7 @@ var planTests = []planTest{{
 		log-targets:
 			tgt1:
 				type: loki
+				services: [all]
 				override: merge
 `}}, {
 	summary: "Unsupported log target type",
@@ -1063,6 +1077,17 @@ var planTests = []planTest{{
 			tgt1:
 				type: foobar
 				location: http://10.1.77.196:3100/loki/api/v1/push
+				override: merge
+`},
+}, {
+	summary: "Log target specifies invalid service",
+	error:   `log target "tgt1" specifies unknown service "nonexistent"`,
+	input: []string{`
+		log-targets:
+			tgt1:
+				type: loki
+				location: http://10.1.77.196:3100/loki/api/v1/push
+				services: [nonexistent]
 				override: merge
 `},
 }}
@@ -1409,3 +1434,5 @@ func (s *S) TestParseCommand(c *C) {
 		c.Assert(extra, DeepEquals, test.cmdArgs)
 	}
 }
+
+func (s *S) TestLogsTo(c *C) {}


### PR DESCRIPTION
#223 was proving too complex, so we've come up with an alternative way to specify which services each log target should collect logs from.

The log target spec now has a `services` field, which accepts a list of services to collect log targets from.
```yaml
log-targets:
  tgt1:
    services: [svc1, svc2]
```

This replaces the old `log-target.selection` field, which has now been removed. The `services` field is also much more expressive than `selection`, so it also removes the need for the `service.log-targets` field. **Effectively, `log-target.services` is now the only place to specify which services' logs go to which log targets.**

Some bonus features:
- Use the `all` keyword to match all services (including future services):
  ```yaml
  tgt1:
    services: [all]
  ```

- Use `-svc` to remove a service from the list. This is especially useful when merging or after using `all`.
  ```yaml
  tgt1:
    services: [all, -svc1, -svc3]
  ```
  matches all services except `svc1` and `svc3`.

- Use `-all` to remove all service from the list. Again, useful when merging or after using `all`.
  ```yaml
  tgt1:
    services: [all, -svc3, -all]
  ```
  matches no services.

The `services` field is simply appended when merging. In combination with the above special syntaxes, this allows "replace" behaviour in a merge:
- To remove service(s) specified in a lower layer, you can just merge on top
  ```yaml
  tgt1:
    services: [-svc2, -svc4]
    override: merge
  ```

- To remove all services for a log target (i.e. opting out of log forwarding entirely), just merge on top
  ```yaml
  tgt1:
    services: [-all]
    override: merge
  ```

### Context / links

- Original log forwarding PR (closed w/o merging): #165
- Original log forwarding spec (not yet updated): [JU052](https://docs.google.com/document/d/12tJFhIbVIlOcblG6l9_u-K5bCib78lojRJ-hdGBxSsw/edit)
- Merged PR containing plan changes for log forwarding: #209
  - This PR essentially is a slight modification / follow-up to that PR.
- Rejected PRs trying to solve similar problems:
  - #217
  - #221
  - #223