### PR TITLE
ci: promote snap to candidate on every release

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,13 @@
 name: Pebble snap
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [master]
+  release:
+    types: [published]
+
+env:
+  SNAP_NAME: pebble
 
 jobs:
   build:
@@ -27,6 +34,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [build]
+    outputs:
+      pebble-version: ${{ steps.install-pebble.outputs.version }}
 
     steps:
       - uses: actions/download-artifact@v3
@@ -34,12 +43,58 @@ jobs:
           name: ${{ needs.build.outputs.pebble-snap }}
 
       - name: Install the Pebble snap
+        id: install-pebble
         run: |
+          set -ex
           # Install the Pebble snap from the artifact built in the previous job
           sudo snap install --dangerous --classic ${{ needs.build.outputs.pebble-snap }}
 
           # Make sure Pebble is installed
-          pebble version
+          echo "version=$(pebble version --client)" >> "$GITHUB_OUTPUT"
 
       - name: Run smoke test
-        run: pebble enter exec echo Hello | grep Hello
+        run: pebble enter --create-dirs exec echo Hello | grep Hello
+
+  promote:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs: [test]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64, ppc64el, armhf, s390x]
+    env:
+      TRACK: latest
+      DEFAULT_RISK: edge
+      TO_RISK: candidate
+    steps:
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --classic
+      
+      - name: Wait for ${{ needs.test.outputs.pebble-version }} to be released
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          while ! `snapcraft status ${{ env.SNAP_NAME }} --track ${{ env.TRACK }} --arch ${{ matrix.arch }} \
+              | grep "${{ env.DEFAULT_RISK }}" \
+              | awk -F' ' '{print $2}' \
+              | grep -Fxq "${{ needs.test.outputs.pebble-version }}"`; do
+            echo "[${{ matrix.arch }}] Waiting for ${{ needs.test.outputs.pebble-version }} \
+          to be released to ${{ env.TRACK }}/${{ env.DEFAULT_RISK }}..."
+            sleep 10
+          done
+
+      # It would be easier to use `snapcraft promote`, but there's an error when trying
+      # to avoid the prompt with the "--yes" option: 
+      # > 'latest/edge' is not a valid set value for --from-channel when using --yes.
+      - name: Promote ${{ needs.test.outputs.pebble-version }} (${{ matrix.arch }}) to ${{ env.TO_RISK }}
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          revision="$(snapcraft status ${{ env.SNAP_NAME }} \
+            --track ${{ env.TRACK }} --arch ${{ matrix.arch }} \
+            | grep "${{ env.DEFAULT_RISK }}" | awk -F' ' '{print $3}')"
+
+          snapcraft release ${{ env.SNAP_NAME }} \
+            $revision \
+            ${{ env.TRACK }}/${{ env.TO_RISK }}


### PR DESCRIPTION
closes https://github.com/canonical/pebble/issues/241

**BEFORE MERGING:** This new job requires a secret for letting Snapcraft authenticate with the Snap Store. I'm still in the process of getting a Pebble-specific bot account for this, so **before merging**, please double-check the current status with me so that I can also share said secret privately. 

#### Context

This PR is built on top of https://github.com/canonical/pebble/pull/179, allowing us to automatically promote the Pebble snap to `latest/candidate` every time there is a new Pebble release on GitHub.

#### Summary of changes

 - this workflow is now also triggered on every GH release
 - during the snap tests, the Pebble client version is inferred so that it can be used for promoting the right snap version
 - on release, we wait for the Store to finish the snap builds for every architecture
 - once the store has built and released the respective snap into `latest/edge`, we then promote it to `latest/candidate`

---

Example of a successful build: https://github.com/cjdcordeiro/pebble/actions/runs/5475322209