### PR TITLE
client: public API

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -89,8 +89,10 @@ type changeAndData struct {
 // Change fetches information about a Change given its ID.
 func (client *Client) Change(id string) (*Change, error) {
 	var chgd changeAndData
-	_, err := client.doSync("GET", "/v1/changes/"+id, nil, nil, nil, &chgd)
-	if err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/changes/" + id,
+	}, &chgd); err != nil {
 		return nil, err
 	}
 
@@ -111,7 +113,11 @@ func (client *Client) Abort(id string) (*Change, error) {
 	}
 
 	var chg Change
-	if _, err := client.doSync("POST", "/v1/changes/"+id, nil, nil, &body, &chg); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/changes/" + id,
+		Body:   &body,
+	}, &chg); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +164,11 @@ func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	}
 
 	var chgds []changeAndData
-	_, err := client.doSync("GET", "/v1/changes", query, nil, nil, &chgds)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/changes",
+		Query:  query,
+	}, &chgds)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +200,11 @@ func (client *Client) WaitChange(id string, opts *WaitChangeOptions) (*Change, e
 		query.Set("timeout", opts.Timeout.String())
 	}
 
-	_, err := client.doSync("GET", "/v1/changes/"+id+"/wait", query, nil, nil, &chgd)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/changes/" + id + "/wait",
+		Query:  query,
+	}, &chgd)
 	if err != nil {
 		return nil, err
 	}

--- a/client/checks.go
+++ b/client/checks.go
@@ -79,7 +79,11 @@ func (client *Client) Checks(opts *ChecksOptions) ([]*CheckInfo, error) {
 		query["names"] = opts.Names
 	}
 	var checks []*CheckInfo
-	_, err := client.doSync("GET", "/v1/checks", query, nil, nil, &checks)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/checks",
+		Query:  query,
+	}, &checks)
 	if err != nil {
 		return nil, err
 	}

--- a/client/exec.go
+++ b/client/exec.go
@@ -152,7 +152,12 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	resultBytes, changeID, err := client.doAsyncFull("POST", "/v1/exec", nil, headers, &body)
+	resultBytes, changeID, err := client.DoAsyncFull(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/exec",
+		Headers: headers,
+		Body:    &body,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -34,7 +34,10 @@ func (client *Client) Do(method, path string, query url.Values, body io.Reader, 
 }
 
 func (client *Client) FakeAsyncRequest() (changeId string, err error) {
-	changeId, err = client.doAsync("GET", "/v1/async-test", nil, nil, nil)
+	changeId, err = client.DoAsync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/async-test",
+	})
 	if err != nil {
 		return "", fmt.Errorf("cannot do async test: %v", err)
 	}

--- a/client/files.go
+++ b/client/files.go
@@ -121,7 +121,11 @@ func (client *Client) ListFiles(opts *ListFilesOptions) ([]*FileInfo, error) {
 	}
 
 	var results []fileInfoResult
-	_, err := client.doSync("GET", "/v1/files", q, nil, nil, &results)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/files",
+		Query:  q,
+	}, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +284,12 @@ func (client *Client) MakeDir(opts *MakeDirOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.doSync("POST", "/v1/files", nil, headers, &body, &result); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/files",
+		Headers: headers,
+		Body:    &body,
+	}, &result); err != nil {
 		return err
 	}
 
@@ -347,7 +356,12 @@ func (client *Client) RemovePath(opts *RemovePathOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.doSync("POST", "/v1/files", nil, headers, &body, &result); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/files",
+		Headers: headers,
+		Body:    &body,
+	}, &result); err != nil {
 		return err
 	}
 

--- a/client/plan.go
+++ b/client/plan.go
@@ -52,7 +52,11 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	if err := json.NewEncoder(&body).Encode(&payload); err != nil {
 		return err
 	}
-	_, err := client.doSync("POST", "/v1/layers", nil, nil, &body, nil)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/layers",
+		Body:   &body,
+	}, nil)
 	return err
 }
 
@@ -64,7 +68,11 @@ func (client *Client) PlanBytes(_ *PlanOptions) (data []byte, err error) {
 		"format": []string{"yaml"},
 	}
 	var dataStr string
-	_, err = client.doSync("GET", "/v1/plan", query, nil, nil, &dataStr)
+	_, err = client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/plan",
+		Query:  query,
+	}, &dataStr)
 	if err != nil {
 		return nil, err
 	}

--- a/client/services.go
+++ b/client/services.go
@@ -77,7 +77,12 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	return client.doAsyncFull("POST", "/v1/services", nil, headers, bytes.NewBuffer(data))
+	return client.DoAsyncFull(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/services",
+		Headers: headers,
+		Body:    bytes.NewBuffer(data),
+	})
 }
 
 type ServicesOptions struct {
@@ -119,7 +124,11 @@ func (client *Client) Services(opts *ServicesOptions) ([]*ServiceInfo, error) {
 		"names": []string{strings.Join(opts.Names, ",")},
 	}
 	var services []*ServiceInfo
-	_, err := client.doSync("GET", "/v1/services", query, nil, nil, &services)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/services",
+		Query:  query,
+	}, &services)
 	if err != nil {
 		return nil, err
 	}

--- a/client/signals.go
+++ b/client/signals.go
@@ -36,7 +36,11 @@ func (client *Client) SendSignal(opts *SendSignalOptions) error {
 	if err != nil {
 		return fmt.Errorf("cannot encode JSON payload: %w", err)
 	}
-	_, err = client.doSync("POST", "/v1/signals", nil, nil, &body, nil)
+	_, err = client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/signals",
+		Body:   &body,
+	}, nil)
 	return err
 }
 

--- a/client/warnings.go
+++ b/client/warnings.go
@@ -52,7 +52,11 @@ func (client *Client) Warnings(opts WarningsOptions) ([]*Warning, error) {
 	if opts.All {
 		q.Add("select", "all")
 	}
-	_, err := client.doSync("GET", "/v1/warnings", q, nil, nil, &jws)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/warnings",
+		Query:  q,
+	}, &jws)
 
 	ws := make([]*Warning, len(jws))
 	for i, jw := range jws {
@@ -77,6 +81,10 @@ func (client *Client) Okay(t time.Time) error {
 	if err := json.NewEncoder(&body).Encode(op); err != nil {
 		return err
 	}
-	_, err := client.doSync("POST", "/v1/warnings", nil, nil, &body, nil)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/warnings",
+		Body:   &body,
+	}, nil)
 	return err
 }

--- a/internals/cli/cmd_add.go
+++ b/internals/cli/cmd_add.go
@@ -24,7 +24,7 @@ import (
 )
 
 type cmdAdd struct {
-	clientMixin
+	ClientMixin
 	Combine    bool `long:"combine"`
 	Positional struct {
 		Label     string `positional-arg-name:"<label>" required:"1"`
@@ -57,7 +57,7 @@ func (cmd *cmdAdd) Execute(args []string) error {
 		Label:     cmd.Positional.Label,
 		LayerData: data,
 	}
-	err = cmd.client.AddLayer(&opts)
+	err = cmd.Client().AddLayer(&opts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_autostart.go
+++ b/internals/cli/cmd_autostart.go
@@ -40,7 +40,7 @@ func (cmd cmdAutoStart) Execute(args []string) error {
 	}
 
 	servopts := client.ServiceOptions{}
-	changeID, err := cmd.client.AutoStart(&servopts)
+	changeID, err := cmd.Client().AutoStart(&servopts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -35,7 +35,7 @@ change that happened recently.
 `
 
 type cmdChanges struct {
-	clientMixin
+	ClientMixin
 	timeMixin
 	Positional struct {
 		Service string `positional-arg-name:"<service>"`
@@ -94,7 +94,7 @@ func (c *cmdChanges) Execute(args []string) error {
 		Selector:    client.ChangesAll,
 	}
 
-	changes, err := queryChanges(c.client, &opts)
+	changes, err := queryChanges(c.Client(), &opts)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func queryChange(cli *client.Client, chid string) (*client.Change, error) {
 }
 
 func (c *cmdTasks) showChange(chid string) error {
-	chg, err := queryChange(c.client, chid)
+	chg, err := queryChange(c.Client(), chid)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -23,7 +23,7 @@ import (
 )
 
 type cmdChecks struct {
-	clientMixin
+	ClientMixin
 	Level      string `long:"level"`
 	Positional struct {
 		Checks []string `positional-arg-name:"<check>"`
@@ -50,7 +50,7 @@ func (cmd *cmdChecks) Execute(args []string) error {
 		Level: client.CheckLevel(cmd.Level),
 		Names: cmd.Positional.Checks,
 	}
-	checks, err := cmd.client.Checks(&opts)
+	checks, err := cmd.Client().Checks(&opts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -42,7 +42,7 @@ const (
 )
 
 type cmdEnter struct {
-	clientMixin
+	ClientMixin
 	sharedRunEnterOpts
 	Run        bool `long:"run"`
 	Positional struct {
@@ -91,7 +91,7 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	runCmd := cmdRun{
 		sharedRunEnterOpts: cmd.sharedRunEnterOpts,
 	}
-	runCmd.setClient(cmd.client)
+	runCmd.SetClient(cmd.Client())
 
 	if len(cmd.Positional.Cmd) == 0 {
 		runCmd.run(nil)
@@ -105,7 +105,7 @@ func (cmd *cmdEnter) Execute(args []string) error {
 		extraArgs []string
 	)
 
-	parser := Parser(cmd.client)
+	parser := Parser(cmd.Client())
 	parser.CommandHandler = func(c flags.Commander, a []string) error {
 		commander = c
 		extraArgs = a

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -31,7 +31,7 @@ import (
 )
 
 type cmdExec struct {
-	clientMixin
+	ClientMixin
 	WorkingDir     string        `short:"w"`
 	Env            []string      `long:"env"`
 	UserID         *int          `long:"uid"`
@@ -174,7 +174,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 	}
 
 	// Start the command.
-	process, err := cmd.client.Exec(opts)
+	process, err := cmd.Client().Exec(opts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_logs.go
+++ b/internals/cli/cmd_logs.go
@@ -32,7 +32,7 @@ const (
 )
 
 type cmdLogs struct {
-	clientMixin
+	ClientMixin
 	Follow     bool   `short:"f" long:"follow"`
 	Format     string `long:"format"`
 	N          string `short:"n"`
@@ -97,9 +97,9 @@ func (cmd *cmdLogs) Execute(args []string) error {
 	if cmd.Follow {
 		// Stop following when Ctrl-C pressed (SIGINT).
 		ctx := notifyContext(context.Background(), os.Interrupt)
-		err = cmd.client.FollowLogs(ctx, &opts)
+		err = cmd.Client().FollowLogs(ctx, &opts)
 	} else {
-		err = cmd.client.Logs(&opts)
+		err = cmd.Client().Logs(&opts)
 	}
 	return err
 }

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -27,7 +27,7 @@ import (
 )
 
 type cmdLs struct {
-	clientMixin
+	ClientMixin
 	timeMixin
 
 	Directory  bool `short:"d"`
@@ -59,7 +59,7 @@ func (cmd *cmdLs) Execute(args []string) error {
 		return err
 	}
 
-	files, err := cmd.client.ListFiles(&client.ListFilesOptions{
+	files, err := cmd.Client().ListFiles(&client.ListFilesOptions{
 		Path:    path,
 		Pattern: pattern,
 		Itself:  cmd.Directory,

--- a/internals/cli/cmd_mkdir.go
+++ b/internals/cli/cmd_mkdir.go
@@ -25,7 +25,7 @@ import (
 )
 
 type cmdMkdir struct {
-	clientMixin
+	ClientMixin
 
 	MakeParents bool   `short:"p"`
 	Permissions string `short:"m"`
@@ -75,7 +75,7 @@ func (cmd *cmdMkdir) Execute(args []string) error {
 		opts.Permissions = os.FileMode(p)
 	}
 
-	return cmd.client.MakeDir(&opts)
+	return cmd.Client().MakeDir(&opts)
 }
 
 func init() {

--- a/internals/cli/cmd_plan.go
+++ b/internals/cli/cmd_plan.go
@@ -21,7 +21,7 @@ import (
 )
 
 type cmdPlan struct {
-	clientMixin
+	ClientMixin
 }
 
 var shortPlanHelp = "Show the plan with layers combined"
@@ -34,7 +34,7 @@ func (cmd *cmdPlan) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	planYAML, err := cmd.client.PlanBytes(&client.PlanOptions{})
+	planYAML, err := cmd.Client().PlanBytes(&client.PlanOptions{})
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_replan.go
+++ b/internals/cli/cmd_replan.go
@@ -41,7 +41,7 @@ func (cmd cmdReplan) Execute(args []string) error {
 	}
 
 	servopts := client.ServiceOptions{}
-	changeID, err := cmd.client.Replan(&servopts)
+	changeID, err := cmd.Client().Replan(&servopts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_restart.go
+++ b/internals/cli/cmd_restart.go
@@ -44,7 +44,7 @@ func (cmd cmdRestart) Execute(args []string) error {
 	servopts := client.ServiceOptions{
 		Names: cmd.Positional.Services,
 	}
-	changeID, err := cmd.client.Restart(&servopts)
+	changeID, err := cmd.Client().Restart(&servopts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_rm.go
+++ b/internals/cli/cmd_rm.go
@@ -21,7 +21,7 @@ import (
 )
 
 type cmdRm struct {
-	clientMixin
+	ClientMixin
 
 	Recursive bool `short:"r"`
 
@@ -44,7 +44,7 @@ func (cmd *cmdRm) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	return cmd.client.RemovePath(&client.RemovePathOptions{
+	return cmd.Client().RemovePath(&client.RemovePathOptions{
 		Path:      cmd.Positional.Path,
 		Recursive: cmd.Recursive,
 	})

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -60,7 +60,7 @@ var sharedRunEnterOptsHelp = map[string]string{
 }
 
 type cmdRun struct {
-	clientMixin
+	ClientMixin
 	sharedRunEnterOpts
 }
 
@@ -196,7 +196,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 
 	if !rcmd.Hold {
 		servopts := client.ServiceOptions{}
-		changeID, err := rcmd.client.AutoStart(&servopts)
+		changeID, err := rcmd.Client().AutoStart(&servopts)
 		if err != nil {
 			logger.Noticef("Cannot start default services: %v", err)
 		} else {
@@ -232,7 +232,7 @@ out:
 	}
 
 	// Close our own self-connection, otherwise it prevents fast and clean termination.
-	rcmd.client.CloseIdleConnections()
+	rcmd.Client().CloseIdleConnections()
 
 	return d.Stop(ch)
 }

--- a/internals/cli/cmd_services.go
+++ b/internals/cli/cmd_services.go
@@ -23,7 +23,7 @@ import (
 )
 
 type cmdServices struct {
-	clientMixin
+	ClientMixin
 	timeMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>"`
@@ -44,7 +44,7 @@ func (cmd *cmdServices) Execute(args []string) error {
 	opts := client.ServicesOptions{
 		Names: cmd.Positional.Services,
 	}
-	services, err := cmd.client.Services(&opts)
+	services, err := cmd.Client().Services(&opts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_signal.go
+++ b/internals/cli/cmd_signal.go
@@ -24,7 +24,7 @@ import (
 )
 
 type cmdSignal struct {
-	clientMixin
+	ClientMixin
 	Positional struct {
 		Signal   string   `positional-arg-name:"<SIGNAL>"`
 		Services []string `positional-arg-name:"<service>"`
@@ -50,7 +50,7 @@ func (cmd *cmdSignal) Execute(args []string) error {
 		Signal:   cmd.Positional.Signal,
 		Services: cmd.Positional.Services,
 	}
-	err := cmd.client.SendSignal(&opts)
+	err := cmd.Client().SendSignal(&opts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_start.go
+++ b/internals/cli/cmd_start.go
@@ -45,7 +45,7 @@ func (cmd cmdStart) Execute(args []string) error {
 	servopts := client.ServiceOptions{
 		Names: cmd.Positional.Services,
 	}
-	changeID, err := cmd.client.Start(&servopts)
+	changeID, err := cmd.Client().Start(&servopts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_stop.go
+++ b/internals/cli/cmd_stop.go
@@ -45,7 +45,7 @@ func (cmd cmdStop) Execute(args []string) error {
 	servopts := client.ServiceOptions{
 		Names: cmd.Positional.Services,
 	}
-	changeID, err := cmd.client.Stop(&servopts)
+	changeID, err := cmd.Client().Stop(&servopts)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_version.go
+++ b/internals/cli/cmd_version.go
@@ -29,7 +29,7 @@ The version command displays the versions of the running client and server.
 `
 
 type cmdVersion struct {
-	clientMixin
+	ClientMixin
 	ClientOnly bool `long:"client"`
 }
 
@@ -51,12 +51,12 @@ func (cmd cmdVersion) Execute(args []string) error {
 		return nil
 	}
 
-	return printVersions(cmd.client)
+	return printVersions(cmd.Client())
 }
 
-func printVersions(cli *client.Client) error {
+func printVersions(cg client.ClientGetter) error {
 	serverVersion := "-"
-	sysInfo, err := cli.SysInfo()
+	sysInfo, err := cg.Client().SysInfo()
 	if err == nil {
 		serverVersion = sysInfo.Version
 	}

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -32,14 +32,14 @@ import (
 )
 
 type cmdWarnings struct {
-	clientMixin
+	ClientMixin
 	timeMixin
 	unicodeMixin
 	All     bool `long:"all"`
 	Verbose bool `long:"verbose"`
 }
 
-type cmdOkay struct{ clientMixin }
+type cmdOkay struct{ ClientMixin }
 
 var shortWarningsHelp = "List warnings"
 var longWarningsHelp = `
@@ -74,7 +74,7 @@ func (cmd *cmdWarnings) Execute(args []string) error {
 	}
 	now := time.Now()
 
-	warnings, err := cmd.client.Warnings(client.WarningsOptions{All: cmd.All})
+	warnings, err := cmd.Client().Warnings(client.WarningsOptions{All: cmd.All})
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (cmd *cmdOkay) Execute(args []string) error {
 		return err
 	}
 
-	return cmd.client.Okay(last)
+	return cmd.Client().Okay(last)
 }
 
 const warnFileEnvKey = "PEBBLE_LAST_WARNING_TIMESTAMP_FILENAME"

--- a/internals/cli/last.go
+++ b/internals/cli/last.go
@@ -22,7 +22,7 @@ import (
 )
 
 type changeIDMixin struct {
-	clientMixin
+	ClientMixin
 	LastChangeType string `long:"last"`
 	Positional     struct {
 		ID string `positional-arg-name:"<id>"`
@@ -54,7 +54,7 @@ func (l *changeIDMixin) GetChangeID() (string, error) {
 		return string(l.Positional.ID), nil
 	}
 
-	cli := l.client
+	cli := l.Client()
 	// note that at this point we know l.LastChangeType != ""
 	kind := l.LastChangeType
 	optional := false

--- a/internals/cli/wait.go
+++ b/internals/cli/wait.go
@@ -31,7 +31,7 @@ var (
 )
 
 type waitMixin struct {
-	clientMixin
+	ClientMixin
 	NoWait    bool `long:"no-wait"`
 	skipAbort bool
 }
@@ -47,7 +47,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		fmt.Fprintf(Stdout, "%s\n", id)
 		return nil, noWait
 	}
-	cli := wmx.client
+	cli := wmx.Client()
 
 	// Intercept sigint
 	sigs := make(chan os.Signal, 2)
@@ -58,7 +58,7 @@ func (wmx waitMixin) wait(id string) (*client.Change, error) {
 		if sig == nil || wmx.skipAbort {
 			return
 		}
-		_, err := wmx.client.Abort(id)
+		_, err := wmx.Client().Abort(id)
 		if err != nil {
 			fmt.Fprintf(Stderr, err.Error()+"\n")
 		}


### PR DESCRIPTION
This patch, similar in spirit to #238, introduces a new public API for
extending the Pebble client. The basic idea behind this patch is the client mixin
struct embedded in commands' structs no longer holds an instance of the
Pebble-specific `client.Client` struct, but instead take a `ClientGetter` interface
that implements a `Client()` method. `ClientGetter.Client()` always returns a
Pebble-specific `client.Client` struct.

For applications that intend to extend Pebble, this means that either the Pebble
client or a new, application-specific client can be used. In the latter case,
the application-specific client must implement the `ClientGetter` interface so
that a Pebble-specific `client.Client` struct can always be derived by the
facilities consuming the `ClientGetter` interface. The easiest way to implement
this is to embed the Pebble client:

```go
type PebbleClient = client.Client
type MyClient struct {
    *PebbleClient
}
```

Since the Pebble-specific `client.Client` is embedded, and the `ClientGetter`
interface requires `Client()` to be implemented with a pointer receiver, the
snippet above suffices to implement a client based off the Pebble-supplied one
without much hassle, and that provides lower-level facilities for communicating
with the daemon, such as `DoSync()`, `DoAsync()` and `DoAsyncFull()`.