### PR TITLE
Do not inherit HOME and USER env vars from pebble daemon environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,12 +46,12 @@ jobs:
     - name: Test
       run: |
         go test -c ./internals/daemon
-        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^execSuite\.TestUserGroup$
-        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^execSuite\.TestUserIDGroupID$
-        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^filesSuite\.TestWriteUserGroupReal$
-        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./daemon.test -check.v -check.f ^filesSuite\.TestMakeDirsUserGroupReal$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^execSuite\.TestUserGroup$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^execSuite\.TestUserIDGroupID$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^filesSuite\.TestWriteUserGroupReal$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^filesSuite\.TestMakeDirsUserGroupReal$
         go test -c ./internals/overlord/servstate/
-        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E ./servstate.test -check.v -check.f ^S.TestUserGroup$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./servstate.test -check.v -check.f ^S.TestUserGroup$
 
   format:
     runs-on: ubuntu-latest

--- a/internals/daemon/api_files_test.go
+++ b/internals/daemon/api_files_test.go
@@ -69,6 +69,9 @@ func (s *filesSuite) TestListFilesNonAbsPath(c *C) {
 }
 
 func (s *filesSuite) TestListFilesPermissionDenied(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	tmpDir := c.MkDir()
 	noAccessDir := filepath.Join(tmpDir, "noaccess")
 	c.Assert(os.Mkdir(noAccessDir, 0o775), IsNil)
@@ -301,6 +304,10 @@ func (s *filesSuite) TestReadMultiple(c *C) {
 }
 
 func (s *filesSuite) TestReadErrors(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	tmpDir := createTestFiles(c)
 	writeTempFile(c, tmpDir, "no-access", "x", 0)
 
@@ -1121,6 +1128,10 @@ nested user group
 }
 
 func (s *filesSuite) TestWriteErrors(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	tmpDir := c.MkDir()
 	c.Assert(os.Mkdir(tmpDir+"/permission-denied", 0), IsNil)
 	pathNoContent := tmpDir + "/no-content"

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -70,7 +70,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		return nil, ExecMetadata{}, errors.New("cannot use interactive mode without a terminal")
 	}
 
-	// Inherit the pebble daemon environment (execpt HOME and USER env vars)
+	// Inherit the pebble daemon environment (except HOME and USER env vars)
 	environment := osutil.Environ()
 	for _, k := range []string{"HOME", "USER"} {
 		if _, ok := environment[k]; ok {

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -70,8 +70,14 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		return nil, ExecMetadata{}, errors.New("cannot use interactive mode without a terminal")
 	}
 
-	// Inherit the pebble daemon environment.
+	// Inherit the pebble daemon environment (execpt HOME and USER env vars)
 	environment := osutil.Environ()
+	for _, k := range []string{"HOME", "USER"} {
+		if _, ok := environment[k]; ok {
+			delete(environment, k)
+		}
+	}
+
 	for k, v := range args.Environment {
 		// Requested environment takes precedence.
 		environment[k] = v

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -70,14 +70,13 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		return nil, ExecMetadata{}, errors.New("cannot use interactive mode without a terminal")
 	}
 
-	// Inherit the pebble daemon environment
-	// If the user is being changed, reset the HOME and USER env vars so that they
-	// can be set correctly later on in this method
+	// Inherit the pebble daemon environment.
+	// If the user is being changed, unset the HOME and USER env vars so that they
+	// can be set correctly later on in this method.
 	environment := osutil.Environ()
 	if args.UserID != nil && *args.UserID != os.Getuid() {
-		for _, k := range []string{"HOME", "USER"} {
-			delete(environment, k)
-		}
+		delete(environment, "HOME")
+		delete(environment, "USER")
 	}
 
 	for k, v := range args.Environment {

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -70,10 +70,12 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		return nil, ExecMetadata{}, errors.New("cannot use interactive mode without a terminal")
 	}
 
-	// Inherit the pebble daemon environment (except HOME and USER env vars)
+	// Inherit the pebble daemon environment
+	// If the user is being changed, reset the HOME and USER env vars so that they
+	// can be set correctly later on in this method
 	environment := osutil.Environ()
-	for _, k := range []string{"HOME", "USER"} {
-		if _, ok := environment[k]; ok {
+	if args.UserID != nil && *args.UserID != os.Getuid() {
+		for _, k := range []string{"HOME", "USER"} {
 			delete(environment, k)
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/canonical/pebble/issues/260 and https://github.com/canonical/pebble/issues/263

## Issue
As part of https://github.com/canonical/pebble/pull/234/files, pebble inherit's the daemon's environment when compiling the request to send to the pebble daemon. As a result, the `HOME` and `USER` environment variables are also inherited (especially troublesome as the `HOME` variable causes permission errors when executing `pebble exec --user=ubuntu --group=ubuntu whoami` given that the daemon user is running as `root`

## Solution
The code already correctly sets the `HOME` and `USER` variables in `request.go` based on the specified user and user's home directory. Therefore, nullify these env vars when inherited from the daemon's environment.

## Testing

```
root@host:/home/ubuntu/mnt/pebble# PEBBLE_TEST_USER=ubuntu PEBBLE_TEST_GROUP=ubuntu go test ./internals/daemon -v -check.v -check.f TestUserGroup                                               
=== RUN   Test                                                                                                                                                                                             
2023-07-27T22:02:51.055Z [test] Started daemon.                                                                                                                                                            
2023-07-27T22:02:51.061Z [test] POST /v1/exec 4.716403ms 202                                                                                                                                               
2023-07-27T22:02:51.066Z [test] GET /v1/tasks/1/websocket/control 4.3449ms 200                                                                                                                             
2023-07-27T22:02:51.067Z [test] GET /v1/tasks/1/websocket/stdio 116.761µs 200                                                                                                                              
2023-07-27T22:02:51.067Z [test] GET /v1/tasks/1/websocket/stderr 74.16µs 200                                                                                                                               
2023-07-27T22:02:51.083Z [test] GET /v1/changes/1/wait 15.936021ms 200                                                                                                                                     
PASS: api_exec_test.go:232: execSuite.TestUserGroup     0.028s                                                                                                                                             
2023-07-27T22:02:51.095Z [test] Started daemon.                                                                                                                                                            
PASS: api_exec_test.go:391: execSuite.TestUserGroupError        0.000s                                                                                                                                     
OK: 2 passed                                                                                                                                                                                               
--- PASS: Test (0.05s)                                                                                                                                                                                     
PASS                                                                                                                                                                                                       
ok      github.com/canonical/pebble/internals/daemon    0.060s                                                                                                                                             
```