### PR TITLE
Run unit tests only on Go 1.20

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: stable  # latest stable version of Go
+        go-version-file: "go.mod"
 
     - name: Build binary and create archive
       id: build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,16 +12,17 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        go: ['1.20']
 
-    name: Go unit tests
-
+    name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version-file: 'go.mod'
+        go-version: ${{ matrix.go }}
 
     - name: Test and build
       run: |
@@ -32,14 +33,13 @@ jobs:
     runs-on: ubuntu-latest
 
     name: Root Tests
-
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version-file: 'go.mod'
+        go-version: ${{ matrix.go }}
 
     - name: Test
       run: |
@@ -55,12 +55,11 @@ jobs:
     runs-on: ubuntu-latest
 
     name: Format check
-
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,8 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        go: ['1.20', '1.19', '1.18', '1.17']
 
-    name: Go ${{ matrix.go }}
+    name: Go unit tests
 
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
 
     - name: Test and build
       run: |


### PR DESCRIPTION
As established in #171, Pebble no longer needs to support Go versions before Go 1.20. Hence, it no longer makes sense to run the unit tests with Go versions before 1.20.