### PR TITLE
Build Pebble snap with Go 1.20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go
+      - go/1.20/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOFLAGS: -trimpath -ldflags=-w -ldflags=-s


### PR DESCRIPTION
Based on https://github.com/canonical/pebble/pull/171, this PR is simply making sure the Pebble snap is built with Go 1.20 instead of whatever the latest stable Go version is in the snap store.