### PR TITLE
feat(overlord): allow adding external managers

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -12,3 +12,7 @@ issues:
   # these values ensure that all issues will be surfaced
   max-issues-per-linter: 0
   max-same-issues: 0
+
+run:
+  timeout: 5m
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         id: lint
         with:
           version: latest
-          args: '-c .github/.golangci.yml --out-format=colored-line-number'
+          args: '-c .github/.golangci.yml --out-format=colored-line-number --timeout 2m0s'
           skip-cache: true
 
       - name: Print error message

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         id: lint
         with:
           version: latest
-          args: '-c .github/.golangci.yml --out-format=colored-line-number --timeout 2m0s'
+          args: '-c .github/.golangci.yml --out-format=colored-line-number'
           skip-cache: true
 
       - name: Print error message

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -217,6 +217,10 @@ func userFromRequest(state interface{}, r *http.Request) (*UserState, error) {
 	return nil, nil
 }
 
+func (d *Daemon) Overlord() *overlord.Overlord {
+	return d.overlord
+}
+
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	st := c.d.state
 	st.Lock()

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -791,7 +791,14 @@ func New(opts *Options) (*Daemon, error) {
 		httpAddress:         opts.HTTPAddress,
 	}
 
-	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput, opts.OverlordExtension)
+	ovldOptions := overlord.Options{
+		PebbleDir:      opts.Dir,
+		RestartHandler: d,
+		ServiceOutput:  opts.ServiceOutput,
+		Extension:      opts.OverlordExtension,
+	}
+
+	ovld, err := overlord.New(ovldOptions)
 	if err == errExpectedReboot {
 		// we proceed without overlord until we reach Stop
 		// where we will schedule and wait again for a system restart.

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -72,10 +72,9 @@ type Options struct {
 	// log output will be written to the writer.
 	ServiceOutput io.Writer
 
-	// NewManagerFuncs is an optional slice of NewManagerFunc which will
-	// be passed to the overlord.New to create custom managers at overlord
-	// creation.
-	NewManagerFuncs []overlord.NewManagerFunc
+	// OverlordExtension is an optional struct used to extend the capabilities
+	// of the Overlord.
+	OverlordExtension overlord.Extension
 }
 
 // A Daemon listens for requests and routes them to the right command
@@ -792,7 +791,7 @@ func New(opts *Options) (*Daemon, error) {
 		httpAddress:         opts.HTTPAddress,
 	}
 
-	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput, opts.NewManagerFuncs)
+	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput, opts.OverlordExtension)
 	if err == errExpectedReboot {
 		// we proceed without overlord until we reach Stop
 		// where we will schedule and wait again for a system restart.

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -72,7 +72,7 @@ type Options struct {
 	// log output will be written to the writer.
 	ServiceOutput io.Writer
 
-	// OverlordExtension is an optional struct used to extend the capabilities
+	// OverlordExtension is an optional interface used to extend the capabilities
 	// of the Overlord.
 	OverlordExtension overlord.Extension
 }

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -72,10 +72,10 @@ type Options struct {
 	// log output will be written to the writer.
 	ServiceOutput io.Writer
 
-	// ManagerGenerators is an optional slice of ManagerGenerator which will
+	// NewManagerFuncs is an optional slice of NewManagerFunc which will
 	// be passed to the overlord.New to create custom managers at overlord
 	// creation.
-	ManagerGenerators []overlord.ManagerGenerator
+	NewManagerFuncs []overlord.NewManagerFunc
 }
 
 // A Daemon listens for requests and routes them to the right command
@@ -792,7 +792,7 @@ func New(opts *Options) (*Daemon, error) {
 		httpAddress:         opts.HTTPAddress,
 	}
 
-	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput, opts.ManagerGenerators)
+	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput, opts.NewManagerFuncs)
 	if err == errExpectedReboot {
 		// we proceed without overlord until we reach Stop
 		// where we will schedule and wait again for a system restart.

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -798,7 +798,7 @@ func New(opts *Options) (*Daemon, error) {
 		Extension:      opts.OverlordExtension,
 	}
 
-	ovld, err := overlord.New(ovldOptions)
+	ovld, err := overlord.New(&ovldOptions)
 	if err == errExpectedReboot {
 		// we proceed without overlord until we reach Stop
 		// where we will schedule and wait again for a system restart.

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -71,6 +71,11 @@ type Options struct {
 	// ServiceOuput is an optional io.Writer for the service log output, if set, all services
 	// log output will be written to the writer.
 	ServiceOutput io.Writer
+
+	// ManagerGenerators is an optional slice of ManagerGenerator which will
+	// be passed to the overlord.New to create custom managers at overlord
+	// creation.
+	ManagerGenerators []overlord.ManagerGenerator
 }
 
 // A Daemon listens for requests and routes them to the right command
@@ -787,7 +792,7 @@ func New(opts *Options) (*Daemon, error) {
 		httpAddress:         opts.HTTPAddress,
 	}
 
-	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput)
+	ovld, err := overlord.New(opts.Dir, d, opts.ServiceOutput, opts.ManagerGenerators)
 	if err == errExpectedReboot {
 		// we proceed without overlord until we reach Stop
 		// where we will schedule and wait again for a system restart.

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -112,8 +112,8 @@ func (m *fakeManager) Ensure() error {
 
 func (s *daemonSuite) TestExternalManager(c *C) {
 	generators := []overlord.ManagerGenerator{
-		func(o overlord.ManagerProvider) (any, overlord.StateManager) {
-			return fakeManager{}, &fakeManager{id: "expected"}
+		func(o overlord.ManagerProvider) (any, overlord.StateManager, error) {
+			return fakeManager{}, &fakeManager{id: "expected"}, nil
 		},
 	}
 

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -111,23 +111,23 @@ func (m *fakeManager) Ensure() error {
 }
 
 func (s *daemonSuite) TestExternalManager(c *C) {
-	generators := []overlord.ManagerGenerator{
-		func(o overlord.ManagerProvider) (any, overlord.StateManager, error) {
+	generators := []overlord.NewManagerFunc{
+		func(o overlord.ManagerEnvironment) (any, overlord.StateManager, error) {
 			return fakeManager{}, &fakeManager{id: "expected"}, nil
 		},
 	}
 
 	d, err := New(&Options{
-		Dir:               s.pebbleDir,
-		SocketPath:        s.socketPath,
-		HTTPAddress:       s.httpAddress,
-		ManagerGenerators: generators,
+		Dir:             s.pebbleDir,
+		SocketPath:      s.socketPath,
+		HTTPAddress:     s.httpAddress,
+		NewManagerFuncs: generators,
 	})
 	c.Assert(err, IsNil)
 
 	err = d.overlord.StateEngine().Ensure()
 	c.Assert(err, IsNil)
-	managerItf := d.overlord.GetExternalManager(fakeManager{})
+	managerItf := d.overlord.ExternalManager(fakeManager{})
 	c.Assert(managerItf, NotNil)
 	concrete, ok := managerItf.(*fakeManager)
 	c.Assert(ok, Equals, true)

--- a/internals/overlord/managers_test.go
+++ b/internals/overlord/managers_test.go
@@ -42,7 +42,7 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	s.dir = c.MkDir()
 
-	o, err := overlord.New(s.dir, nil, nil)
+	o, err := overlord.New(s.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 	s.o = o
 }

--- a/internals/overlord/managers_test.go
+++ b/internals/overlord/managers_test.go
@@ -42,7 +42,7 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	s.dir = c.MkDir()
 
-	o, err := overlord.New(s.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: s.dir})
 	c.Assert(err, IsNil)
 	s.o = o
 }

--- a/internals/overlord/managers_test.go
+++ b/internals/overlord/managers_test.go
@@ -42,7 +42,7 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	s.dir = c.MkDir()
 
-	o, err := overlord.New(overlord.Options{PebbleDir: s.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: s.dir})
 	c.Assert(err, IsNil)
 	s.o = o
 }

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -94,7 +94,7 @@ type Overlord struct {
 }
 
 // New creates an Overlord with all its state managers.
-func New(opts Options) (*Overlord, error) {
+func New(opts *Options) (*Overlord, error) {
 
 	o := &Overlord{
 		pebbleDir: opts.PebbleDir,

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -73,19 +73,19 @@ type Overlord struct {
 	externalManagers map[any]StateManager
 }
 
-// ManagerProvider is the interface that ManagerGenerator depends on
+// ManagerEnvironment is the interface that NewManagerFunc depends on
 //
-// Overlord implements ManagerProvider as it provides the necessary
+// Overlord implements ManagerEnvironment as it provides the necessary
 // handles to hook an external manager into the overlord's environment.
-type ManagerProvider interface {
+type ManagerEnvironment interface {
 	State() *state.State
 	TaskRunner() *state.TaskRunner
 }
 
-// ManagerGenerator is passed to Overlord to create a manager
+// NewManagerFunc is passed to Overlord to create a manager
 // The return value is a key, value pair where the key has to be a unique
 // identifier for the manager being created.
-type ManagerGenerator func(ManagerProvider) (key any, manager StateManager, err error)
+type NewManagerFunc func(ManagerEnvironment) (key any, manager StateManager, err error)
 
 // New creates a  Overlord with all its state managers.
 // It can be provided with an optional restart.Handler.
@@ -93,7 +93,7 @@ func New(
 	pebbleDir string,
 	restartHandler restart.Handler,
 	serviceOutput io.Writer,
-	generators []ManagerGenerator) (*Overlord, error) {
+	generators []NewManagerFunc) (*Overlord, error) {
 
 	o := &Overlord{
 		pebbleDir:        pebbleDir,
@@ -168,7 +168,7 @@ func New(
 	return o, nil
 }
 
-func (o *Overlord) GetExternalManager(tag any) StateManager {
+func (o *Overlord) ExternalManager(tag any) StateManager {
 	result, ok := o.externalManagers[tag]
 	if !ok {
 		panic("Manager tag not found")

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -151,7 +151,7 @@ func New(
 			return nil, err
 		}
 		for _, manager := range extraManagers {
-			o.addManager(manager)
+			o.stateEng.AddManager(manager)
 		}
 	}
 

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -153,7 +153,8 @@ func New(
 
 	for _, gen := range generators {
 		tag, manager := gen(o)
-		o.tagManager(tag, manager)
+		o.externalManagers[tag] = manager
+		o.addManager(manager)
 	}
 
 	// TaskRunner must be the last manager added to the StateEngine,
@@ -164,13 +165,12 @@ func New(
 	return o, nil
 }
 
-func (o *Overlord) tagManager(tag any, mgr StateManager) {
-	o.externalManagers[tag] = mgr
-	o.addManager(mgr)
-}
-
 func (o *Overlord) GetExternalManager(tag any) StateManager {
-	return o.externalManagers[tag]
+	result, ok := o.externalManagers[tag]
+	if !ok {
+		panic("Manager tag not found")
+	}
+	return result
 }
 
 func (o *Overlord) addManager(mgr StateManager) {

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -130,7 +130,7 @@ func New(opts Options) (*Overlord, error) {
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
 	o.logMgr = logstate.NewLogManager()
-	o.addManager(o.logMgr)
+	o.stateEng.AddManager(o.logMgr)
 
 	o.serviceMgr, err = servstate.NewManager(
 		s,
@@ -142,10 +142,10 @@ func New(opts Options) (*Overlord, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.addManager(o.serviceMgr)
+	o.stateEng.AddManager(o.serviceMgr)
 
 	o.commandMgr = cmdstate.NewManager(o.runner)
-	o.addManager(o.commandMgr)
+	o.stateEng.AddManager(o.commandMgr)
 
 	o.checkMgr = checkstate.NewManager()
 
@@ -178,10 +178,6 @@ func New(opts Options) (*Overlord, error) {
 
 func (o *Overlord) Extension() Extension {
 	return o.extension
-}
-
-func (o *Overlord) addManager(mgr StateManager) {
-	o.stateEng.AddManager(mgr)
 }
 
 func loadState(statePath string, restartHandler restart.Handler, backend state.Backend) (*state.State, error) {
@@ -485,7 +481,7 @@ func (o *Overlord) AddManager(mgr StateManager) {
 	if o.inited {
 		panic("internal error: cannot add managers to a fully initialized Overlord")
 	}
-	o.addManager(mgr)
+	o.stateEng.AddManager(mgr)
 }
 
 type fakeBackend struct {

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -77,11 +77,10 @@ type Overlord struct {
 	checkMgr   *checkstate.CheckManager
 	logMgr     *logstate.LogManager
 
-	// Overlord extension
 	extension Extension
 }
 
-// New creates a  Overlord with all its state managers.
+// New creates an Overlord with all its state managers.
 // It can be provided with an optional restart.Handler.
 func New(
 	pebbleDir string,

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -85,7 +85,7 @@ type ManagerProvider interface {
 // ManagerGenerator is passed to Overlord to create a manager
 // The return value is a key, value pair where the key has to be a unique
 // identifier for the manager being created.
-type ManagerGenerator func(ManagerProvider) (key any, manager StateManager)
+type ManagerGenerator func(ManagerProvider) (key any, manager StateManager, err error)
 
 // New creates a  Overlord with all its state managers.
 // It can be provided with an optional restart.Handler.
@@ -152,7 +152,10 @@ func New(
 	o.checkMgr.NotifyCheckFailed(o.serviceMgr.CheckFailed)
 
 	for _, gen := range generators {
-		tag, manager := gen(o)
+		tag, manager, err := gen(o)
+		if err != nil {
+			return nil, err
+		}
 		o.externalManagers[tag] = manager
 		o.addManager(manager)
 	}

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -81,20 +81,6 @@ type Overlord struct {
 	extension Extension
 }
 
-// ManagerEnvironment is the interface that NewManagerFunc depends on
-//
-// Overlord implements ManagerEnvironment as it provides the necessary
-// handles to hook an external manager into the overlord's environment.
-type ManagerEnvironment interface {
-	State() *state.State
-	TaskRunner() *state.TaskRunner
-}
-
-// NewManagerFunc is passed to Overlord to create a manager
-// The return value is a key, value pair where the key has to be a unique
-// identifier for the manager being created.
-type NewManagerFunc func(ManagerEnvironment) (key any, manager StateManager, err error)
-
 // New creates a  Overlord with all its state managers.
 // It can be provided with an optional restart.Handler.
 func New(

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -51,8 +51,7 @@ var (
 
 // Extension represents an extension of the Overlord.
 type Extension interface {
-	// ExtraManagers is called when building an Overlord, it allows additional
-	// managers to be added to the Overlord.
+	// ExtraManagers  allows additional managers to be used.
 	ExtraManagers(o *Overlord) ([]StateManager, error)
 }
 
@@ -64,7 +63,7 @@ type Options struct {
 	RestartHandler restart.Handler
 	// ServiceOutput is an optional output for the logging manager.
 	ServiceOutput io.Writer
-	// Extension, if set, defines additional components to add to the overlord.
+	// Extension allows extending the overlord with externally defined features.
 	Extension Extension
 }
 

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -51,7 +51,7 @@ var (
 
 // Extension represents an extension of the Overlord.
 type Extension interface {
-	// ExtraManagers  allows additional managers to be used.
+	// ExtraManagers allows additional StateManagers to be used.
 	ExtraManagers(o *Overlord) ([]StateManager, error)
 }
 

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -51,7 +51,8 @@ var (
 
 // Extension represents an extension of the Overlord.
 type Extension interface {
-	// ExtraManagers is called when building an Overlord.
+	// ExtraManagers is called when building an Overlord, it allows additional
+	// managers to be added to the Overlord.
 	ExtraManagers(o *Overlord) ([]StateManager, error)
 }
 
@@ -63,8 +64,7 @@ type Options struct {
 	RestartHandler restart.Handler
 	// ServiceOutput is an optional output for the logging manager.
 	ServiceOutput io.Writer
-	// Extension is an optional struct defining additional components to add to
-	// the overlord.
+	// Extension, if set, defines additional components to add to the overlord.
 	Extension Extension
 }
 

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -58,7 +58,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	restore := patch.Fake(42, 2, nil)
 	defer restore()
 
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
 
@@ -83,7 +83,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -111,7 +111,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	_, err = overlord.New(ovs.dir, nil, nil, nil)
+	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, ErrorMatches, "cannot read state: EOF")
 }
 
@@ -130,7 +130,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -175,7 +175,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	o.Loop()
@@ -185,7 +185,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -486,7 +486,7 @@ func (ovs *overlordSuite) TestCheckpoint(c *C) {
 	oldUmask := syscall.Umask(0)
 	defer syscall.Umask(oldUmask)
 
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	s := o.State()
@@ -727,7 +727,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 }
 
 func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -760,7 +760,7 @@ func (rb *testRestartHandler) RebootIsMissing(_ *state.State) error {
 func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 	rb := &testRestartHandler{}
 
-	o, err := overlord.New(ovs.dir, rb, nil, nil)
+	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -779,7 +779,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, rb, nil, nil)
+	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -792,7 +792,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, rb, nil, nil)
+	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -806,7 +806,7 @@ func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, rb, nil, nil)
+	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -822,7 +822,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, rb, nil, nil)
+	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
@@ -839,7 +839,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissingError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, rb, nil, nil)
+	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -58,7 +58,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	restore := patch.Fake(42, 2, nil)
 	defer restore()
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
 
@@ -83,7 +83,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -111,7 +111,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	_, err = overlord.New(ovs.dir, nil, nil)
+	_, err = overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, ErrorMatches, "cannot read state: EOF")
 }
 
@@ -130,7 +130,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -175,7 +175,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	o.Loop()
@@ -185,7 +185,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -486,7 +486,7 @@ func (ovs *overlordSuite) TestCheckpoint(c *C) {
 	oldUmask := syscall.Umask(0)
 	defer syscall.Umask(oldUmask)
 
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	s := o.State()
@@ -727,7 +727,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 }
 
 func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
-	o, err := overlord.New(ovs.dir, nil, nil)
+	o, err := overlord.New(ovs.dir, nil, nil, nil)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -760,7 +760,7 @@ func (rb *testRestartHandler) RebootIsMissing(_ *state.State) error {
 func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 	rb := &testRestartHandler{}
 
-	o, err := overlord.New(ovs.dir, rb, nil)
+	o, err := overlord.New(ovs.dir, rb, nil, nil)
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -779,7 +779,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, rb, nil)
+	_, err = overlord.New(ovs.dir, rb, nil, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -792,7 +792,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, rb, nil)
+	_, err = overlord.New(ovs.dir, rb, nil, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -806,7 +806,7 @@ func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, rb, nil)
+	_, err = overlord.New(ovs.dir, rb, nil, nil)
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -822,7 +822,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(ovs.dir, rb, nil)
+	_, err = overlord.New(ovs.dir, rb, nil, nil)
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
@@ -839,7 +839,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissingError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(ovs.dir, rb, nil)
+	_, err = overlord.New(ovs.dir, rb, nil, nil)
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -58,7 +58,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	restore := patch.Fake(42, 2, nil)
 	defer restore()
 
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
 
@@ -83,7 +83,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -111,7 +111,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, ErrorMatches, "cannot read state: EOF")
 }
 
@@ -130,7 +130,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -175,7 +175,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	o.Loop()
@@ -185,7 +185,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -486,7 +486,7 @@ func (ovs *overlordSuite) TestCheckpoint(c *C) {
 	oldUmask := syscall.Umask(0)
 	defer syscall.Umask(oldUmask)
 
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	s := o.State()
@@ -727,7 +727,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 }
 
 func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -760,7 +760,7 @@ func (rb *testRestartHandler) RebootIsMissing(_ *state.State) error {
 func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 	rb := &testRestartHandler{}
 
-	o, err := overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -779,7 +779,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -792,7 +792,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -806,7 +806,7 @@ func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -822,7 +822,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
@@ -839,7 +839,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissingError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")

--- a/internals/overlord/stateengine.go
+++ b/internals/overlord/stateengine.go
@@ -56,24 +56,8 @@ type StateEngine struct {
 	state   *state.State
 	stopped bool
 	// managers in use
-	mgrLock    sync.Mutex
-	managers   []StateManager
-	taskRunner StateManager
-}
-
-// orderedManagers returns all the managers added to this engine.
-//
-// The managers are ordered by their precedence when executing Ensure, Stop
-// and Wait: the task runner is the last item in the result.
-func (se *StateEngine) orderedManagers() []StateManager {
-	result := make([]StateManager, 0, len(se.managers)+1)
-	for _, m := range se.managers {
-		result = append(result, m)
-	}
-	if se.taskRunner != nil {
-		result = append(result, se.taskRunner)
-	}
-	return result
+	mgrLock  sync.Mutex
+	managers []StateManager
 }
 
 // NewStateEngine returns a new state engine.
@@ -111,7 +95,7 @@ func (se *StateEngine) Ensure() error {
 		return fmt.Errorf("state engine already stopped")
 	}
 	var errs []error
-	for _, m := range se.orderedManagers() {
+	for _, m := range se.managers {
 		err := m.Ensure()
 		if err != nil {
 			logger.Noticef("state ensure error: %v", err)
@@ -131,12 +115,6 @@ func (se *StateEngine) AddManager(m StateManager) {
 	se.managers = append(se.managers, m)
 }
 
-func (se *StateEngine) SetTaskRunner(taskRunner StateManager) {
-	se.mgrLock.Lock()
-	defer se.mgrLock.Unlock()
-	se.taskRunner = taskRunner
-}
-
 // Wait waits for all managers current activities.
 func (se *StateEngine) Wait() {
 	se.mgrLock.Lock()
@@ -144,7 +122,7 @@ func (se *StateEngine) Wait() {
 	if se.stopped {
 		return
 	}
-	for _, m := range se.orderedManagers() {
+	for _, m := range se.managers {
 		if waiter, ok := m.(StateWaiter); ok {
 			waiter.Wait()
 		}
@@ -158,7 +136,7 @@ func (se *StateEngine) Stop() {
 	if se.stopped {
 		return
 	}
-	for _, m := range se.orderedManagers() {
+	for _, m := range se.managers {
 		if stopper, ok := m.(StateStopper); ok {
 			stopper.Stop()
 		}


### PR DESCRIPTION
This change enables an external application importing Pebble to extend the overlord functionality by adding additional managers.

Example overlord extension:
```go
package ovldext

type OverlordExtension struct {
	fooManager *foostate.Manager
	barManager *barstate.Manager
}

func New() *OverlordExtension {
    return &OverlordExtension{}
}

func (oe *OverlordExtension) ExtraManagers(o *Overlord) ([]overlord.StateManager, error) {
    oe.fooManager, err := foostate.NewManager(o.State(), o.TaskRunner())
    if err != nil {
        return nil, err
    }
    oe.barManager, err = barstate.NewManager(o.State(), o.TaskRunner())
    if err != nil {
        return nil, err
    }
    return []overlord.StateManager{oe.fooManager, oe.barManager}, nil
}

func (oe *OverlordExtension) FooManager() *foostate.Manager { return oe.fooManager }

func (oe *OverlordExtension) BarManager() *barstate.Manager { return oe.barManager }

func Extension(o *overlord.Overlord) *OverlordExtension {
	return o.Extension().(*OverlordExtension)
}
```

Example startup code:
```go
    dopts := daemon.Options{
        Dir:        pebbleDir,
        SocketPath: socketPath,

        // Supply overlord extension
        OverlordExtension: ovldext.New()            
    }
    
    d, err := daemon.New(&dopts)
    if err != nil {
        return err
    }
```

External HTTP request handler example:
```go  
    :  
    // We can now get access to the overlord
    o := d.Overlord()
    
    // Get access to the custom state manager to perform the HTTP request
    fooManager := ovldext.Extension(o).FooManager()
    :
```