### PR TITLE
ci: place files at top-level of release archives

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -49,7 +49,7 @@ jobs:
         echo Creating archive $ARCHIVE_FILE
         cp COPYING dist/build
         cp README.md dist/build
-        tar -czf dist/$ARCHIVE_FILE -C dist/build .
+        tar -czf dist/$ARCHIVE_FILE -C dist/build $(ls -A dist/build)
 
         # Share variables with subsequent steps
         echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
Follow up from a [conversation](https://github.com/canonical/chisel/pull/91#discussion_r1289629560) with @rebornplusplus which  made me realise that our release archives actually create a tarball containing a directory named `.` with the files within it.

This change makes all the files appear at the top-level of the archive.