### PR TITLE
fix(servstate): use WaitDelay to avoid Command.Wait blocking on stdin/out/err

### DIFF
--- a/internals/daemon/api_logs.go
+++ b/internals/daemon/api_logs.go
@@ -126,7 +126,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			err = encoder.Encode(newJSONLog(<-fifo))
 		}
 		if err != nil {
-			logger.Noticef("error writing logs: %v", err)
+			logger.Noticef("Cannot write logs: %v", err)
 			return false
 		}
 		flushWriter(w)
@@ -186,7 +186,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			// Otherwise encode and output log directly.
 			err := encoder.Encode(newJSONLog(log))
 			if err != nil {
-				logger.Noticef("error writing logs: %v", err)
+				logger.Noticef("Cannot write logs: %v", err)
 				return
 			}
 			if follow {

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -168,7 +168,7 @@ func (c *Command) canAccess(r *http.Request, user *UserState) accessResult {
 	if err == nil {
 		isUser = true
 	} else if err != errNoID {
-		logger.Noticef("Unexpected error when attempting to get UID: %s", err)
+		logger.Noticef("Cannot parse UID from remote address %q: %s", r.RemoteAddr, err)
 		return accessForbidden
 	}
 

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -168,7 +168,7 @@ func (c *Command) canAccess(r *http.Request, user *UserState) accessResult {
 	if err == nil {
 		isUser = true
 	} else if err != errNoID {
-		logger.Noticef("unexpected error when attempting to get UID: %s", err)
+		logger.Noticef("Unexpected error when attempting to get UID: %s", err)
 		return accessForbidden
 	}
 
@@ -530,7 +530,7 @@ func (d *Daemon) HandleRestart(t restart.RestartType) {
 		defer d.mu.Unlock()
 		d.restartSocket = true
 	default:
-		logger.Noticef("internal error: restart handler called with unknown restart type: %v", t)
+		logger.Noticef("Internal error: restart handler called with unknown restart type: %v", t)
 	}
 	d.tomb.Kill(nil)
 }
@@ -760,12 +760,12 @@ func (d *Daemon) RebootIsMissing(st *state.State) error {
 		// might get rolled back!!
 		restart.ClearReboot(st)
 		clearReboot(st)
-		logger.Noticef("pebble was restarted while a system restart was expected, pebble retried to schedule and waited again for a system restart %d times and is giving up", rebootMaxTentatives)
+		logger.Noticef("Pebble was restarted while a system restart was expected, pebble retried to schedule and waited again for a system restart %d times and is giving up", rebootMaxTentatives)
 		return nil
 	}
 	st.Set("daemon-system-restart-tentative", nTentative)
 	d.state = st
-	logger.Noticef("pebble was restarted while a system restart was expected, pebble will try to schedule and wait for a system restart again (tenative %d/%d)", nTentative, rebootMaxTentatives)
+	logger.Noticef("Pebble was restarted while a system restart was expected, pebble will try to schedule and wait for a system restart again (tenative %d/%d)", nTentative, rebootMaxTentatives)
 	return errExpectedReboot
 }
 

--- a/internals/daemon/response.go
+++ b/internals/daemon/response.go
@@ -93,7 +93,7 @@ func (r *resp) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	status := r.Status
 	bs, err := r.MarshalJSON()
 	if err != nil {
-		logger.Noticef("cannot marshal %#v to JSON: %v", *r, err)
+		logger.Noticef("Cannot marshal %#v to JSON: %v", *r, err)
 		bs = nil
 		status = 500
 	}

--- a/internals/overlord/checkstate/checkers.go
+++ b/internals/overlord/checkstate/checkers.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/canonical/x-go/strutil/shlex"
 
@@ -38,6 +39,7 @@ import (
 const (
 	maxErrorBytes = 10 * 1024
 	maxErrorLines = 20
+	execWaitDelay = time.Second
 )
 
 // httpChecker is a checker that ensures an HTTP GET at a specified URL returns 20x.
@@ -167,6 +169,7 @@ func (c *execChecker) check(ctx context.Context) error {
 	defer ringBuffer.Close()
 	cmd.Stdout = ringBuffer
 	cmd.Stderr = ringBuffer
+	cmd.WaitDelay = execWaitDelay
 	err = reaper.StartCommand(cmd)
 	if err != nil {
 		return err

--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -42,6 +42,7 @@ import (
 const (
 	connectTimeout   = 5 * time.Second
 	handshakeTimeout = 5 * time.Second
+	waitDelay        = time.Second
 
 	wsControl = "control"
 	wsStdio   = "stdio"
@@ -343,6 +344,7 @@ func (e *execution) do(ctx context.Context, task *state.Task) error {
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	cmd.WaitDelay = waitDelay
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	if e.userID != nil && e.groupID != nil {

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -400,6 +400,18 @@ func (s *serviceData) startInternal() error {
 	s.cmd.Stdout = logWriter
 	s.cmd.Stderr = logWriter
 
+	// Add WaitDelay to ensure cmd.Wait() returns in a reasonable timeframe if
+	// the goroutines that cmd.Start() uses to copy Stdin/Stdout/Stderr are
+	// blocked when copying due to a sub-subprocess holding onto them. Read
+	// more details in these issues:
+	//
+	// - https://github.com/golang/go/issues/23019
+	// - https://github.com/golang/go/issues/50436
+	//
+	// This isn't the original intent of kill-delay, but it seems reasonable
+	// to reuse it in this context.
+	s.cmd.WaitDelay = s.killDelay()
+
 	// Start the process!
 	logger.Noticef("Service %q starting: %s", serviceName, s.config.Command)
 	err = reaper.StartCommand(s.cmd)
@@ -616,9 +628,9 @@ func (s *serviceData) sendSignal(signal string) error {
 }
 
 // killDelay reports the duration that this service should be given when being
-// asked to shutdown gracefully before being force terminated. The value
-// returned will either be the services pre configured value or the default
-// kill delay for pebble.
+// asked to shut down gracefully before being force-terminated. The value
+// returned will either be the service's pre-configured value, or the default
+// kill delay if that is not set.
 func (s *serviceData) killDelay() time.Duration {
 	if s.config.KillDelay.IsSet {
 		return s.config.KillDelay.Value

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -402,8 +402,9 @@ func (s *serviceData) startInternal() error {
 
 	// Add WaitDelay to ensure cmd.Wait() returns in a reasonable timeframe if
 	// the goroutines that cmd.Start() uses to copy Stdin/Stdout/Stderr are
-	// blocked when copying due to a sub-subprocess holding onto them. Read
-	// more details in these issues:
+	// blocked when copying due to a sub-subprocess holding onto them. This
+	// only happens if the sub-subprocess uses setsid or setpgid to change
+	// the process group. Read more details in these issues:
 	//
 	// - https://github.com/golang/go/issues/23019
 	// - https://github.com/golang/go/issues/50436

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -409,8 +409,10 @@ func (s *serviceData) startInternal() error {
 	// - https://github.com/golang/go/issues/50436
 	//
 	// This isn't the original intent of kill-delay, but it seems reasonable
-	// to reuse it in this context.
-	s.cmd.WaitDelay = s.killDelay()
+	// to reuse it in this context. Use a value slightly less than the kill
+	// delay (90% of it) to avoid racing with trying to send SIGKILL (to a
+	// process that has already exited).
+	s.cmd.WaitDelay = time.Duration(s.killDelay().Seconds() * 0.9 * float64(time.Second))
 
 	// Start the process!
 	logger.Noticef("Service %q starting: %s", serviceName, s.config.Command)

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -413,7 +413,7 @@ func (s *serviceData) startInternal() error {
 	// to reuse it in this context. Use a value slightly less than the kill
 	// delay (90% of it) to avoid racing with trying to send SIGKILL (to a
 	// process that has already exited).
-	s.cmd.WaitDelay = time.Duration(s.killDelay().Seconds() * 0.9 * float64(time.Second))
+	s.cmd.WaitDelay = s.killDelay() * 9 / 10 // will only overflow if kill-delay is 32 years!
 
 	// Start the process!
 	logger.Noticef("Service %q starting: %s", serviceName, s.config.Command)

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -1666,7 +1666,7 @@ services:
         command: %s
         environment:
             PEBBLE_TEST_WAITDELAY: 1
-        kill-delay: 10ms
+        kill-delay: 50ms
 `, testExecutable))
 	err = s.manager.AppendLayer(layer)
 	c.Assert(err, IsNil)

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -1666,7 +1666,7 @@ services:
         command: %s
         environment:
             PEBBLE_TEST_WAITDELAY: 1
-        kill-delay: 200ms
+        kill-delay: 10ms
 `, testExecutable))
 	err = s.manager.AppendLayer(layer)
 	c.Assert(err, IsNil)

--- a/internals/overlord/stateengine.go
+++ b/internals/overlord/stateengine.go
@@ -98,7 +98,7 @@ func (se *StateEngine) Ensure() error {
 	for _, m := range se.managers {
 		err := m.Ensure()
 		if err != nil {
-			logger.Noticef("state ensure error: %v", err)
+			logger.Noticef("State ensure error: %v", err)
 			errs = append(errs, err)
 		}
 	}

--- a/internals/reaper/reaper.go
+++ b/internals/reaper/reaper.go
@@ -173,7 +173,7 @@ func StartCommand(cmd *exec.Cmd) error {
 			case ch <- -1:
 			default:
 			}
-			logger.Noticef("internal error: new PID %d observed while still being tracked", cmd.Process.Pid)
+			logger.Noticef("Internal error: new PID %d observed while still being tracked", cmd.Process.Pid)
 		}
 		// Channel is 1-buffered so the send in reapOnce never blocks, if for
 		// some reason someone forgets to call WaitCommand.


### PR DESCRIPTION
Use `os.exec`'s [`Cmd.WaitDelay`](https://pkg.go.dev/os/exec#Cmd.WaitDelay) to ensure `cmd.Wait()` returns in a reasonable timeframe if the goroutines that `cmd.Start()` uses to copy stdin/out/err are blocked when copying due to a sub-subprocess holding onto them. Read more details about the issue in https://github.com/golang/go/issues/23019 and the proposed solution (that was added in Go 1.20) in https://github.com/golang/go/issues/50436.

This solves [issue 149](https://github.com/canonical/pebble/issues/149), where Patroni wasn't restarting properly even after a `KILL` signal was sent to it. I had originally mis-diagnosed this problem as an issue with Pebble not tracking the process tree of processes that daemonise and change their process group (which is still an issue, but is not causing this problem). The Patroni process wasn't being marked as finished at all due to being blocked on the `cmd.Wait()`. Patroni starts sub-processes and "forwards" stdin/out/err, so the copy goroutines block. Thankfully Go 1.20 introduced `WaitDelay` to allow you to easily work around this exact problem.

The fix itself is [this one-liner](https://github.com/canonical/pebble/pull/275):

```go
s.cmd.WaitDelay = s.killDelay() // defaults to 5 seconds
```

This will really only be a problem for services, but we make the same change for exec and exec health checks as it won't hurt there either.

Also, as a drive-by, this PR also canonicalises some log messages: our style is to start with an uppercase letter (for logs, not errors) and to use "Cannot X" rather than "Error Xing".

Fixes #149.