### PR TITLE
docs: introduce conventional commit guidelines

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -86,6 +86,25 @@ $ curl --unix-socket ~/pebble/.pebble.socket 'http://localhost/v1/services?names
 
 ## Code style
 
+### Commits
+
+Please format your commits following the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) style.
+
+Optionally, use the brackets to scope to a particular component where applicable.
+
+See below for some examples of commit headings:
+
+```
+feat: checks inherit context from services
+test: increase unit test stability
+feat(daemon): foo the bar correctly in the baz
+test(daemon): ensure the foo bars correctly in the baz
+ci(snap): upload the snap artefacts to Github
+chore(deps): update go.mod dependencies
+```
+
+Recommended prefixes are: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`,`perf:` and `test:`
+
 ### Imports
 
 Pebble imports should be arranged in three groups:


### PR DESCRIPTION
I'm posting this here for discussion. I've grown to quite like the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification. I think it naturally brings consistency to commit messages when reading the short log, and also encourages me personally to think carefully when I'm committing as to how I should break things up.

We've actually got some conventions emerging, but because we're not enforcing it, the commit log is starting to look a little untidy to my obsessive eye. 

Proposing this as a convention - happy for comments etc. If we can agree on the style, we can introduce a CI check.

Including some examples from the source of this commit:

```
feat: checks inherit context from services
test: increase unit test stability
feat(daemon): foo the bar correctly in the baz
test(daemon): ensure the foo bars correctly in the baz
ci(snap): upload the snap artefacts to Github
chore(deps): update go.mod dependencies
```

