### PR TITLE
test(testutil): fix tests when run with -count=2

### DIFF
--- a/internals/testutil/exec_test.go
+++ b/internals/testutil/exec_test.go
@@ -87,6 +87,8 @@ func (s *fakeCommandSuite) TestFakeCommandConflictEcho(c *check.C) {
 }
 
 func (s *fakeCommandSuite) TestFakeShellchecksWhenAvailable(c *check.C) {
+	shellchecked = make(map[string]bool) // reset checked cache
+
 	tmpDir := c.MkDir()
 	fakeShellcheck := FakeCommand(c, "shellcheck", fmt.Sprintf(`cat > %s/input`, tmpDir), false)
 	defer fakeShellcheck.Restore()


### PR DESCRIPTION
Currently when you run:

```
go test -count=2 -v ./internals/testutil/ -check.v
```

It fails with the following error:

```
FAIL: exec_test.go:89: fakeCommandSuite.TestFakeShellchecksWhenAvailable

using shellcheck: "/usr/bin/shellcheck"
exec_test.go:106:
    c.Assert(fakeShellcheck.Calls(), check.DeepEquals, [][]string{
        {"shellcheck", "-s", "bash", "-"},
    })
... obtained [][]string = [][]string(nil)
... expected [][]string = [][]string{[]string{"shellcheck", "-s", "bash", "-"}} ... Difference:
...     [][]string[0] != [][]string[1]
```

Because TestFakeShellchecksWhenAvailable relies on global state. Reset this global state before each run to allow this package's tests to be run more than once (-count=N where N>1).