### PR TITLE
feat(cli): enable extended client access

### DIFF
--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -52,7 +52,7 @@ const defaultPebbleDir = "/var/lib/pebble/default"
 // ErrExtraArgs is returned  if extra arguments to a command are found
 var ErrExtraArgs = fmt.Errorf("too many arguments for command")
 
-// CmdOptions contains state that's required during each command execution.
+// CmdOptions exposes state made accessible during command execution.
 type CmdOptions struct {
 	// Client is the Pebble client instance
 	Client *client.Client

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -52,6 +52,14 @@ const defaultPebbleDir = "/var/lib/pebble/default"
 // ErrExtraArgs is returned  if extra arguments to a command are found
 var ErrExtraArgs = fmt.Errorf("too many arguments for command")
 
+// CmdOptions contains state that's required during each command execution.
+type CmdOptions struct {
+	// Client is the Pebble client instance
+	Client *client.Client
+	// Parser is the instance of the flags.Parser that processed the command.
+	Parser *flags.Parser
+}
+
 // CmdInfo holds information needed by the CLI to execute commands and
 // populate entries in the help manual.
 type CmdInfo struct {
@@ -67,9 +75,8 @@ type CmdInfo struct {
 	// command, and in the Pebble man page.
 	Description string
 
-	// Builder is a function that creates a new instance of the command
-	// struct containing an Execute(args []string) implementation.
-	Builder func() flags.Commander
+	// New is a function that creates a new instance of the command.
+	New func(*CmdOptions) flags.Commander
 
 	// ArgsHelp (optional) contains help about the command-line arguments
 	// (including options) supported by the command.
@@ -139,22 +146,6 @@ func fixupArg(optName string) string {
 	return optName
 }
 
-type clientSetter interface {
-	setClient(*client.Client)
-}
-
-type clientMixin struct {
-	client *client.Client
-}
-
-func (ch *clientMixin) setClient(cli *client.Client) {
-	ch.client = cli
-}
-
-type parserSetter interface {
-	setParser(*flags.Parser)
-}
-
 type defaultOptions struct {
 	Version func() `long:"version" hidden:"yes" description:"Print the version and exit"`
 }
@@ -192,13 +183,7 @@ func Parser(cli *client.Client) *flags.Parser {
 
 	// Add all commands
 	for _, c := range commands {
-		obj := c.Builder()
-		if x, ok := obj.(clientSetter); ok {
-			x.setClient(cli)
-		}
-		if x, ok := obj.(parserSetter); ok {
-			x.setParser(parser)
-		}
+		obj := c.New(&CmdOptions{Client: cli, Parser: parser})
 
 		var target *flags.Command
 		if c.Debug {

--- a/internals/cli/cmd_add.go
+++ b/internals/cli/cmd_add.go
@@ -32,12 +32,13 @@ label (or append if the label is not found).
 `
 
 type cmdAdd struct {
-	clientMixin
 	Combine    bool `long:"combine"`
 	Positional struct {
 		Label     string `positional-arg-name:"<label>" required:"1"`
 		LayerPath string `positional-arg-name:"<layer-path>" required:"1"`
 	} `positional-args:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -48,7 +49,9 @@ func init() {
 		ArgsHelp: map[string]string{
 			"--combine": "Combine the new layer with an existing layer that has the given label (default is to append)",
 		},
-		Builder: func() flags.Commander { return &cmdAdd{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdAdd{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_add.go
+++ b/internals/cli/cmd_add.go
@@ -32,13 +32,13 @@ label (or append if the label is not found).
 `
 
 type cmdAdd struct {
+	client *client.Client
+
 	Combine    bool `long:"combine"`
 	Positional struct {
 		Label     string `positional-arg-name:"<label>" required:"1"`
 		LayerPath string `positional-arg-name:"<layer-path>" required:"1"`
 	} `positional-args:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_autostart.go
+++ b/internals/cli/cmd_autostart.go
@@ -36,7 +36,11 @@ func init() {
 		Summary:     cmdAutoStartSummary,
 		Description: cmdAutoStartDescription,
 		ArgsHelp:    waitArgsHelp,
-		Builder:     func() flags.Commander { return &cmdAutoStart{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdAutoStart{
+				waitMixin: waitMixin{client: opts.Client},
+			}
+		},
 	})
 }
 

--- a/internals/cli/cmd_autostart.go
+++ b/internals/cli/cmd_autostart.go
@@ -27,8 +27,9 @@ to start by default.
 `
 
 type cmdAutoStart struct {
-	waitMixin
 	client *client.Client
+
+	waitMixin
 }
 
 func init() {

--- a/internals/cli/cmd_autostart.go
+++ b/internals/cli/cmd_autostart.go
@@ -28,6 +28,7 @@ to start by default.
 
 type cmdAutoStart struct {
 	waitMixin
+	client *client.Client
 }
 
 func init() {
@@ -37,9 +38,7 @@ func init() {
 		Description: cmdAutoStartDescription,
 		ArgsHelp:    waitArgsHelp,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdAutoStart{
-				waitMixin: waitMixin{client: opts.Client},
-			}
+			return &cmdAutoStart{client: opts.Client}
 		},
 	})
 }
@@ -55,7 +54,7 @@ func (cmd cmdAutoStart) Execute(args []string) error {
 		return err
 	}
 
-	if _, err := cmd.wait(changeID); err != nil {
+	if _, err := cmd.wait(cmd.client, changeID); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -30,11 +30,12 @@ The changes command displays a summary of system changes performed recently.
 `
 
 type cmdChanges struct {
-	clientMixin
 	timeMixin
 	Positional struct {
 		Service string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
+
+	client *client.Client
 }
 
 const cmdTasksSummary = "List a change's tasks"
@@ -54,14 +55,20 @@ func init() {
 		Summary:     cmdChangesSummary,
 		Description: cmdChangesDescription,
 		ArgsHelp:    timeArgsHelp,
-		Builder:     func() flags.Commander { return &cmdChanges{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdChanges{client: opts.Client}
+		},
 	})
 	AddCommand(&CmdInfo{
 		Name:        "tasks",
 		Summary:     cmdTasksSummary,
 		Description: cmdTasksDescription,
 		ArgsHelp:    merge(changeIDMixinArgsHelp, timeArgsHelp),
-		Builder:     func() flags.Commander { return &cmdTasks{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdTasks{
+				changeIDMixin: changeIDMixin{client: opts.Client},
+			}
+		},
 	})
 }
 

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -30,12 +30,12 @@ The changes command displays a summary of system changes performed recently.
 `
 
 type cmdChanges struct {
+	client *client.Client
+
 	timeMixin
 	Positional struct {
 		Service string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
-
-	client *client.Client
 }
 
 const cmdTasksSummary = "List a change's tasks"
@@ -45,6 +45,8 @@ change that happened recently.
 `
 
 type cmdTasks struct {
+	client *client.Client
+
 	timeMixin
 	changeIDMixin
 }
@@ -65,9 +67,7 @@ func init() {
 		Description: cmdTasksDescription,
 		ArgsHelp:    merge(changeIDMixinArgsHelp, timeArgsHelp),
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdTasks{
-				changeIDMixin: changeIDMixin{client: opts.Client},
-			}
+			return &cmdTasks{client: opts.Client}
 		},
 	})
 }
@@ -140,7 +140,7 @@ func (c *cmdChanges) Execute(args []string) error {
 }
 
 func (c *cmdTasks) Execute([]string) error {
-	chid, err := c.GetChangeID()
+	chid, err := c.GetChangeID(c.client)
 	if err != nil {
 		if err == noChangeFoundOK {
 			return nil

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -30,11 +30,12 @@ arguments.
 `
 
 type cmdChecks struct {
-	clientMixin
 	Level      string `long:"level"`
 	Positional struct {
 		Checks []string `positional-arg-name:"<check>"`
 	} `positional-args:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -45,7 +46,9 @@ func init() {
 		ArgsHelp: map[string]string{
 			"--level": `Check level to filter for ("alive" or "ready")`,
 		},
-		Builder: func() flags.Commander { return &cmdChecks{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdChecks{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -30,12 +30,12 @@ arguments.
 `
 
 type cmdChecks struct {
+	client *client.Client
+
 	Level      string `long:"level"`
 	Positional struct {
 		Checks []string `positional-arg-name:"<check>"`
 	} `positional-args:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -47,14 +47,14 @@ These subcommands are currently supported:
 `
 
 type cmdEnter struct {
+	client *client.Client
+	parser *flags.Parser
+
 	sharedRunEnterOpts
 	Run        bool `long:"run"`
 	Positional struct {
 		Cmd []string `positional-arg-name:"<subcommand>"`
 	} `positional-args:"yes"`
-
-	client *client.Client
-	parser *flags.Parser
 }
 
 func init() {

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/canonical/go-flags"
 
+	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/internals/logger"
 )
 
@@ -46,12 +47,13 @@ These subcommands are currently supported:
 `
 
 type cmdEnter struct {
-	clientMixin
 	sharedRunEnterOpts
 	Run        bool `long:"run"`
 	Positional struct {
 		Cmd []string `positional-arg-name:"<subcommand>"`
 	} `positional-args:"yes"`
+
+	client *client.Client
 	parser *flags.Parser
 }
 
@@ -60,7 +62,9 @@ func init() {
 		Name:        "enter",
 		Summary:     cmdEnterSummary,
 		Description: cmdEnterDescription,
-		Builder:     func() flags.Commander { return &cmdEnter{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdEnter{client: opts.Client, parser: opts.Parser}
+		},
 		ArgsHelp: merge(sharedRunEnterArgsHelp, map[string]string{
 			"--run": "Start default services before executing subcommand",
 		}),
@@ -104,8 +108,8 @@ func (cmd *cmdEnter) Execute(args []string) error {
 
 	runCmd := cmdRun{
 		sharedRunEnterOpts: cmd.sharedRunEnterOpts,
+		client:             cmd.client,
 	}
-	runCmd.setClient(cmd.client)
 
 	if len(cmd.Positional.Cmd) == 0 {
 		runCmd.run(nil)
@@ -194,8 +198,4 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	}
 
 	return err
-}
-
-func (cmd *cmdEnter) setParser(parser *flags.Parser) {
-	cmd.parser = parser
 }

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -43,6 +43,8 @@ pebble exec --timeout 10s -- echo -n foo bar
 `
 
 type cmdExec struct {
+	client *client.Client
+
 	WorkingDir     string        `short:"w"`
 	Env            []string      `long:"env"`
 	UserID         *int          `long:"uid"`
@@ -58,8 +60,6 @@ type cmdExec struct {
 	Positional     struct {
 		Command string `positional-arg-name:"<command>" required:"1"`
 	} `positional-args:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -43,7 +43,6 @@ pebble exec --timeout 10s -- echo -n foo bar
 `
 
 type cmdExec struct {
-	clientMixin
 	WorkingDir     string        `short:"w"`
 	Env            []string      `long:"env"`
 	UserID         *int          `long:"uid"`
@@ -59,6 +58,8 @@ type cmdExec struct {
 	Positional     struct {
 		Command string `positional-arg-name:"<command>" required:"1"`
 	} `positional-args:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -81,7 +82,9 @@ func init() {
 			"-I":        "Disable interactive mode and use a pipe for stdin",
 		},
 		PassAfterNonOption: true,
-		Builder:            func() flags.Commander { return &cmdExec{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdExec{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -31,12 +31,13 @@ The help command displays information about commands.
 `
 
 type cmdHelp struct {
+	parser *flags.Parser
+
 	All        bool `long:"all"`
 	Manpage    bool `long:"man" hidden:"true"`
 	Positional struct {
 		Subs []string `positional-arg-name:"<command>"`
 	} `positional-args:"yes"`
-	parser *flags.Parser
 }
 
 func init() {

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -48,7 +48,9 @@ func init() {
 			"--all": "Show a short summary of all commands",
 			"--man": "Generate the manpage",
 		},
-		Builder: func() flags.Commander { return &cmdHelp{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdHelp{parser: opts.Parser}
+		},
 	})
 }
 

--- a/internals/cli/cmd_logs.go
+++ b/internals/cli/cmd_logs.go
@@ -34,13 +34,14 @@ if none are specified) and displays them in chronological order.
 `
 
 type cmdLogs struct {
-	clientMixin
 	Follow     bool   `short:"f" long:"follow"`
 	Format     string `long:"format"`
 	N          string `short:"n"`
 	Positional struct {
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -53,7 +54,9 @@ func init() {
 			"--format": "Output format: \"text\" (default) or \"json\" (JSON lines).",
 			"-n":       "Number of logs to show (before following); defaults to 30.\nIf 'all', show all buffered logs.",
 		},
-		Builder: func() flags.Commander { return &cmdLogs{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdLogs{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_logs.go
+++ b/internals/cli/cmd_logs.go
@@ -34,14 +34,14 @@ if none are specified) and displays them in chronological order.
 `
 
 type cmdLogs struct {
+	client *client.Client
+
 	Follow     bool   `short:"f" long:"follow"`
 	Format     string `long:"format"`
 	N          string `short:"n"`
 	Positional struct {
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -33,16 +33,14 @@ may be specified for the last path element.
 `
 
 type cmdLs struct {
-	timeMixin
+	client *client.Client
 
+	timeMixin
 	Directory  bool `short:"d"`
 	LongFormat bool `short:"l"`
-
 	Positional struct {
 		Path string `positional-arg-name:"<path>"`
 	} `positional-args:"yes" required:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -33,7 +33,6 @@ may be specified for the last path element.
 `
 
 type cmdLs struct {
-	clientMixin
 	timeMixin
 
 	Directory  bool `short:"d"`
@@ -42,6 +41,8 @@ type cmdLs struct {
 	Positional struct {
 		Path string `positional-arg-name:"<path>"`
 	} `positional-args:"yes" required:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -53,7 +54,9 @@ func init() {
 			"-d": "List matching entries themselves, not directory contents",
 			"-l": "Use a long listing format",
 		}),
-		Builder: func() flags.Commander { return &cmdLs{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdLs{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_mkdir.go
+++ b/internals/cli/cmd_mkdir.go
@@ -30,18 +30,17 @@ The mkdir command creates the specified directory.
 `
 
 type cmdMkdir struct {
+	client *client.Client
+
 	MakeParents bool   `short:"p"`
 	Permissions string `short:"m"`
 	UserID      *int   `long:"uid"`
 	User        string `long:"user"`
 	GroupID     *int   `long:"gid"`
 	Group       string `long:"group"`
-
-	Positional struct {
+	Positional  struct {
 		Path string `positional-arg-name:"<path>"`
 	} `positional-args:"yes" required:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_mkdir.go
+++ b/internals/cli/cmd_mkdir.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/canonical/go-flags"
+
 	"github.com/canonical/pebble/client"
 )
 

--- a/internals/cli/cmd_mkdir.go
+++ b/internals/cli/cmd_mkdir.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/canonical/go-flags"
-
 	"github.com/canonical/pebble/client"
 )
 
@@ -30,8 +29,6 @@ The mkdir command creates the specified directory.
 `
 
 type cmdMkdir struct {
-	clientMixin
-
 	MakeParents bool   `short:"p"`
 	Permissions string `short:"m"`
 	UserID      *int   `long:"uid"`
@@ -42,6 +39,8 @@ type cmdMkdir struct {
 	Positional struct {
 		Path string `positional-arg-name:"<path>"`
 	} `positional-args:"yes" required:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -49,7 +48,6 @@ func init() {
 		Name:        "mkdir",
 		Summary:     cmdMkdirSummary,
 		Description: cmdMkdirDescription,
-		Builder:     func() flags.Commander { return &cmdMkdir{} },
 		ArgsHelp: map[string]string{
 			"-p":      "Create parent directories as needed",
 			"-m":      "Set permissions (e.g. 0644)",
@@ -57,6 +55,9 @@ func init() {
 			"--user":  "Use specified username",
 			"--gid":   "Use specified group ID",
 			"--group": "Use specified group name",
+		},
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdMkdir{client: opts.Client}
 		},
 	})
 }

--- a/internals/cli/cmd_plan.go
+++ b/internals/cli/cmd_plan.go
@@ -27,7 +27,7 @@ format. Layers are combined according to the override rules defined in them.
 `
 
 type cmdPlan struct {
-	clientMixin
+	client *client.Client
 }
 
 func init() {
@@ -35,7 +35,9 @@ func init() {
 		Name:        "plan",
 		Summary:     cmdPlanSummary,
 		Description: cmdPlanDescription,
-		Builder:     func() flags.Commander { return &cmdPlan{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdPlan{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_replan.go
+++ b/internals/cli/cmd_replan.go
@@ -29,6 +29,7 @@ current plan.
 
 type cmdReplan struct {
 	waitMixin
+	client *client.Client
 }
 
 func init() {
@@ -38,9 +39,7 @@ func init() {
 		Description: cmdReplanDescription,
 		ArgsHelp:    waitArgsHelp,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdReplan{
-				waitMixin: waitMixin{client: opts.Client},
-			}
+			return &cmdReplan{client: opts.Client}
 		},
 	})
 }
@@ -56,7 +55,7 @@ func (cmd cmdReplan) Execute(args []string) error {
 		return err
 	}
 
-	if _, err := cmd.wait(changeID); err != nil {
+	if _, err := cmd.wait(cmd.client, changeID); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/internals/cli/cmd_replan.go
+++ b/internals/cli/cmd_replan.go
@@ -28,8 +28,9 @@ current plan.
 `
 
 type cmdReplan struct {
-	waitMixin
 	client *client.Client
+
+	waitMixin
 }
 
 func init() {

--- a/internals/cli/cmd_replan.go
+++ b/internals/cli/cmd_replan.go
@@ -37,7 +37,11 @@ func init() {
 		Summary:     cmdReplanSummary,
 		Description: cmdReplanDescription,
 		ArgsHelp:    waitArgsHelp,
-		Builder:     func() flags.Commander { return &cmdReplan{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdReplan{
+				waitMixin: waitMixin{client: opts.Client},
+			}
+		},
 	})
 }
 

--- a/internals/cli/cmd_restart.go
+++ b/internals/cli/cmd_restart.go
@@ -38,7 +38,11 @@ func init() {
 		Summary:     cmdRestartSummary,
 		Description: cmdRestartDescription,
 		ArgsHelp:    waitArgsHelp,
-		Builder:     func() flags.Commander { return &cmdRestart{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdRestart{
+				waitMixin: waitMixin{client: opts.Client},
+			}
+		},
 	})
 }
 

--- a/internals/cli/cmd_restart.go
+++ b/internals/cli/cmd_restart.go
@@ -30,6 +30,7 @@ type cmdRestart struct {
 	Positional struct {
 		Services []string `positional-arg-name:"<service>" required:"1"`
 	} `positional-args:"yes"`
+	client *client.Client
 }
 
 func init() {
@@ -39,9 +40,7 @@ func init() {
 		Description: cmdRestartDescription,
 		ArgsHelp:    waitArgsHelp,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdRestart{
-				waitMixin: waitMixin{client: opts.Client},
-			}
+			return &cmdRestart{client: opts.Client}
 		},
 	})
 }
@@ -59,7 +58,7 @@ func (cmd cmdRestart) Execute(args []string) error {
 		return err
 	}
 
-	if _, err := cmd.wait(changeID); err != nil {
+	if _, err := cmd.wait(cmd.client, changeID); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/internals/cli/cmd_restart.go
+++ b/internals/cli/cmd_restart.go
@@ -26,11 +26,12 @@ The restart command restarts the named service(s) in the correct order.
 `
 
 type cmdRestart struct {
+	client *client.Client
+
 	waitMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>" required:"1"`
 	} `positional-args:"yes"`
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_rm.go
+++ b/internals/cli/cmd_rm.go
@@ -26,11 +26,12 @@ The rm command removes a file or directory.
 `
 
 type cmdRm struct {
-	clientMixin
 	Recursive  bool `short:"r"`
 	Positional struct {
 		Path string `positional-arg-name:"<path>"`
 	} `positional-args:"yes" required:"yes"`
+
+	client *client.Client
 }
 
 func init() {
@@ -41,7 +42,9 @@ func init() {
 		ArgsHelp: map[string]string{
 			"-r": "Remove all files and directories recursively in the specified path",
 		},
-		Builder: func() flags.Commander { return &cmdRm{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdRm{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_rm.go
+++ b/internals/cli/cmd_rm.go
@@ -26,12 +26,12 @@ The rm command removes a file or directory.
 `
 
 type cmdRm struct {
+	client *client.Client
+
 	Recursive  bool `short:"r"`
 	Positional struct {
 		Path string `positional-arg-name:"<path>"`
 	} `positional-args:"yes" required:"yes"`
-
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -60,8 +60,8 @@ var sharedRunEnterArgsHelp = map[string]string{
 }
 
 type cmdRun struct {
-	clientMixin
 	sharedRunEnterOpts
+	client *client.Client
 }
 
 func init() {
@@ -70,7 +70,9 @@ func init() {
 		Summary:     cmdRunSummary,
 		Description: cmdRunDescription,
 		ArgsHelp:    sharedRunEnterArgsHelp,
-		Builder:     func() flags.Commander { return &cmdRun{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdRun{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -60,8 +60,9 @@ var sharedRunEnterArgsHelp = map[string]string{
 }
 
 type cmdRun struct {
-	sharedRunEnterOpts
 	client *client.Client
+
+	sharedRunEnterOpts
 }
 
 func init() {

--- a/internals/cli/cmd_services.go
+++ b/internals/cli/cmd_services.go
@@ -29,11 +29,11 @@ about all services if none are specified.
 `
 
 type cmdServices struct {
-	clientMixin
 	timeMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
+	client *client.Client
 }
 
 func init() {
@@ -42,7 +42,9 @@ func init() {
 		Summary:     cmdServicesSummary,
 		Description: cmdServicesDescription,
 		ArgsHelp:    timeArgsHelp,
-		Builder:     func() flags.Commander { return &cmdServices{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdServices{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_services.go
+++ b/internals/cli/cmd_services.go
@@ -29,11 +29,12 @@ about all services if none are specified.
 `
 
 type cmdServices struct {
+	client *client.Client
+
 	timeMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_signal.go
+++ b/internals/cli/cmd_signal.go
@@ -32,11 +32,11 @@ pebble signal HUP mysql nginx
 `
 
 type cmdSignal struct {
-	clientMixin
 	Positional struct {
 		Signal   string   `positional-arg-name:"<SIGNAL>"`
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes" required:"yes"`
+	client *client.Client
 }
 
 func init() {
@@ -44,7 +44,9 @@ func init() {
 		Name:        "signal",
 		Summary:     cmdSignalSummary,
 		Description: cmdSignalDescription,
-		Builder:     func() flags.Commander { return &cmdSignal{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdSignal{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_signal.go
+++ b/internals/cli/cmd_signal.go
@@ -32,11 +32,12 @@ pebble signal HUP mysql nginx
 `
 
 type cmdSignal struct {
+	client *client.Client
+
 	Positional struct {
 		Signal   string   `positional-arg-name:"<SIGNAL>"`
 		Services []string `positional-arg-name:"<service>"`
 	} `positional-args:"yes" required:"yes"`
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_start.go
+++ b/internals/cli/cmd_start.go
@@ -31,6 +31,7 @@ type cmdStart struct {
 	Positional struct {
 		Services []string `positional-arg-name:"<service>" required:"1"`
 	} `positional-args:"yes"`
+	client *client.Client
 }
 
 func init() {
@@ -40,9 +41,7 @@ func init() {
 		Description: cmdStartDescription,
 		ArgsHelp:    waitArgsHelp,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdStart{
-				waitMixin: waitMixin{client: opts.Client},
-			}
+			return &cmdStart{client: opts.Client}
 		},
 	})
 }
@@ -60,7 +59,7 @@ func (cmd cmdStart) Execute(args []string) error {
 		return err
 	}
 
-	if _, err := cmd.wait(changeID); err != nil {
+	if _, err := cmd.wait(cmd.client, changeID); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/internals/cli/cmd_start.go
+++ b/internals/cli/cmd_start.go
@@ -39,7 +39,11 @@ func init() {
 		Summary:     cmdStartSummary,
 		Description: cmdStartDescription,
 		ArgsHelp:    waitArgsHelp,
-		Builder:     func() flags.Commander { return &cmdStart{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdStart{
+				waitMixin: waitMixin{client: opts.Client},
+			}
+		},
 	})
 }
 

--- a/internals/cli/cmd_start.go
+++ b/internals/cli/cmd_start.go
@@ -27,11 +27,12 @@ any other services it depends on, in the correct order.
 `
 
 type cmdStart struct {
+	client *client.Client
+
 	waitMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>" required:"1"`
 	} `positional-args:"yes"`
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_stop.go
+++ b/internals/cli/cmd_stop.go
@@ -38,8 +38,12 @@ func init() {
 		Name:        "stop",
 		Summary:     cmdStopSummary,
 		Description: cmdStopDescription,
-		Builder:     func() flags.Commander { return &cmdStop{} },
 		ArgsHelp:    waitArgsHelp,
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdStop{
+				waitMixin: waitMixin{client: opts.Client},
+			}
+		},
 	})
 }
 

--- a/internals/cli/cmd_stop.go
+++ b/internals/cli/cmd_stop.go
@@ -31,6 +31,7 @@ type cmdStop struct {
 	Positional struct {
 		Services []string `positional-arg-name:"<service>" required:"1"`
 	} `positional-args:"yes"`
+	client *client.Client
 }
 
 func init() {
@@ -40,9 +41,7 @@ func init() {
 		Description: cmdStopDescription,
 		ArgsHelp:    waitArgsHelp,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdStop{
-				waitMixin: waitMixin{client: opts.Client},
-			}
+			return &cmdStop{client: opts.Client}
 		},
 	})
 }
@@ -60,7 +59,7 @@ func (cmd cmdStop) Execute(args []string) error {
 		return err
 	}
 
-	if _, err := cmd.wait(changeID); err != nil {
+	if _, err := cmd.wait(cmd.client, changeID); err != nil {
 		if err == noWait {
 			return nil
 		}

--- a/internals/cli/cmd_stop.go
+++ b/internals/cli/cmd_stop.go
@@ -27,11 +27,12 @@ any other service that depends on it, in the correct order.
 `
 
 type cmdStop struct {
+	client *client.Client
+
 	waitMixin
 	Positional struct {
 		Services []string `positional-arg-name:"<service>" required:"1"`
 	} `positional-args:"yes"`
-	client *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_version.go
+++ b/internals/cli/cmd_version.go
@@ -29,8 +29,8 @@ The version command displays the versions of the running client and server.
 `
 
 type cmdVersion struct {
-	clientMixin
 	ClientOnly bool `long:"client"`
+	client     *client.Client
 }
 
 func init() {
@@ -41,7 +41,9 @@ func init() {
 		ArgsHelp: map[string]string{
 			"--client": "Only display the client version",
 		},
-		Builder: func() flags.Commander { return &cmdVersion{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdVersion{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_version.go
+++ b/internals/cli/cmd_version.go
@@ -29,8 +29,9 @@ The version command displays the versions of the running client and server.
 `
 
 type cmdVersion struct {
+	client *client.Client
+
 	ClientOnly bool `long:"client"`
-	client     *client.Client
 }
 
 func init() {

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -43,11 +43,11 @@ Warnings expire automatically, and once expired they are forgotten.
 `
 
 type cmdWarnings struct {
-	clientMixin
 	timeMixin
 	unicodeMixin
 	All     bool `long:"all"`
 	Verbose bool `long:"verbose"`
+	client  *client.Client
 }
 
 const cmdOkaySummary = "Acknowledge warnings"
@@ -58,7 +58,9 @@ Once acknowledged, a warning won't appear again unless it reoccurs and
 sufficient time has passed.
 `
 
-type cmdOkay struct{ clientMixin }
+type cmdOkay struct {
+	client *client.Client
+}
 
 func init() {
 	AddCommand(&CmdInfo{
@@ -69,13 +71,17 @@ func init() {
 			"--all":     "Show all warnings",
 			"--verbose": "Show more information",
 		}),
-		Builder: func() flags.Commander { return &cmdWarnings{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdWarnings{client: opts.Client}
+		},
 	})
 	AddCommand(&CmdInfo{
 		Name:        "okay",
 		Summary:     cmdOkaySummary,
 		Description: cmdOkayDescription,
-		Builder:     func() flags.Commander { return &cmdOkay{} },
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdOkay{client: opts.Client}
+		},
 	})
 }
 

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -43,11 +43,12 @@ Warnings expire automatically, and once expired they are forgotten.
 `
 
 type cmdWarnings struct {
+	client *client.Client
+
 	timeMixin
 	unicodeMixin
 	All     bool `long:"all"`
 	Verbose bool `long:"verbose"`
-	client  *client.Client
 }
 
 const cmdOkaySummary = "Acknowledge warnings"

--- a/internals/cli/last.go
+++ b/internals/cli/last.go
@@ -26,7 +26,6 @@ type changeIDMixin struct {
 	Positional     struct {
 		ChangeID string `positional-arg-name:"<change-id>"`
 	} `positional-args:"yes"`
-	client *client.Client
 }
 
 var changeIDMixinArgsHelp = map[string]string{
@@ -37,7 +36,7 @@ var changeIDMixinArgsHelp = map[string]string{
 // should not be user-visible, but keep it clear and polite because mistakes happen
 var noChangeFoundOK = errors.New("no change found but that's ok")
 
-func (l *changeIDMixin) GetChangeID() (string, error) {
+func (l *changeIDMixin) GetChangeID(cli *client.Client) (string, error) {
 	if l.Positional.ChangeID == "" && l.LastChangeType == "" {
 		return "", fmt.Errorf("please provide change ID or type with --last=<type>")
 	}
@@ -50,7 +49,6 @@ func (l *changeIDMixin) GetChangeID() (string, error) {
 		return string(l.Positional.ChangeID), nil
 	}
 
-	cli := l.client
 	// note that at this point we know l.LastChangeType != ""
 	kind := l.LastChangeType
 	optional := false

--- a/internals/cli/last.go
+++ b/internals/cli/last.go
@@ -22,11 +22,11 @@ import (
 )
 
 type changeIDMixin struct {
-	clientMixin
 	LastChangeType string `long:"last"`
 	Positional     struct {
 		ChangeID string `positional-arg-name:"<change-id>"`
 	} `positional-args:"yes"`
+	client *client.Client
 }
 
 var changeIDMixinArgsHelp = map[string]string{

--- a/internals/cli/wait.go
+++ b/internals/cli/wait.go
@@ -41,7 +41,7 @@ var waitArgsHelp = map[string]string{
 
 var noWait = errors.New("no wait for op")
 
-func (wmx waitMixin) wait(c *client.Client, id string) (*client.Change, error) {
+func (wmx waitMixin) wait(cli *client.Client, id string) (*client.Change, error) {
 	if wmx.NoWait {
 		fmt.Fprintf(Stdout, "%s\n", id)
 		return nil, noWait
@@ -56,7 +56,7 @@ func (wmx waitMixin) wait(c *client.Client, id string) (*client.Change, error) {
 		if sig == nil || wmx.skipAbort {
 			return
 		}
-		_, err := c.Abort(id)
+		_, err := cli.Abort(id)
 		if err != nil {
 			fmt.Fprintf(Stderr, err.Error()+"\n")
 		}
@@ -77,7 +77,7 @@ func (wmx waitMixin) wait(c *client.Client, id string) (*client.Change, error) {
 	lastLog := map[string]string{}
 	for {
 		var rebootingErr error
-		chg, err := c.Change(id)
+		chg, err := cli.Change(id)
 		if err != nil {
 			// A client.Error means we were able to communicate with
 			// the server (got an answer).
@@ -99,7 +99,7 @@ func (wmx waitMixin) wait(c *client.Client, id string) (*client.Change, error) {
 			time.Sleep(pollTime)
 			continue
 		}
-		if maintErr, ok := c.Maintenance().(*client.Error); ok && maintErr.Kind == client.ErrorKindSystemRestart {
+		if maintErr, ok := cli.Maintenance().(*client.Error); ok && maintErr.Kind == client.ErrorKindSystemRestart {
 			rebootingErr = maintErr
 		}
 		if !tMax.IsZero() {

--- a/internals/cli/wait.go
+++ b/internals/cli/wait.go
@@ -31,9 +31,9 @@ var (
 )
 
 type waitMixin struct {
-	clientMixin
 	NoWait    bool `long:"no-wait"`
 	skipAbort bool
+	client    *client.Client
 }
 
 var waitArgsHelp = map[string]string{


### PR DESCRIPTION
This patch gets rid of the `clientMixin` in command structs in favor of passing a `CmdOptions` struct to the `New` (formerly `Builder`) function in `CmdInfo`.

Example usage:

#### Command implementation
```go
type cmdFoo struct {
        /* ... */
	client *MyClient
}

func init() {
	AddCommand(&CmdInfo{
		/* ... */
		New: func(opts *CmdOptions) flags.Commander {
			return &cmdFoo{client: &MyClient{opts.Client}}
		},
	})
}

func (cmd *cmdFoo) Execute(args []string) error {
        return cmd.client.Foo()
}
```

#### Client implementation
```go
import "github.com/canonical/pebble/client"

type MyClient struct {
        *client.Client
}

func (c *MyClient) Foo() error {
        /* ... */
}
```