### PR TITLE
feat(client): Export `DoSync`/`DoAsync` and `RequestInfo`.

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -89,8 +89,10 @@ type changeAndData struct {
 // Change fetches information about a Change given its ID.
 func (client *Client) Change(id string) (*Change, error) {
 	var chgd changeAndData
-	_, err := client.doSync("GET", "/v1/changes/"+id, nil, nil, nil, &chgd)
-	if err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/changes/" + id,
+	}, &chgd); err != nil {
 		return nil, err
 	}
 
@@ -111,7 +113,11 @@ func (client *Client) Abort(id string) (*Change, error) {
 	}
 
 	var chg Change
-	if _, err := client.doSync("POST", "/v1/changes/"+id, nil, nil, &body, &chg); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/changes/" + id,
+		Body:   &body,
+	}, &chg); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +164,11 @@ func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	}
 
 	var chgds []changeAndData
-	_, err := client.doSync("GET", "/v1/changes", query, nil, nil, &chgds)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/changes",
+		Query:  query,
+	}, &chgds)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +200,11 @@ func (client *Client) WaitChange(id string, opts *WaitChangeOptions) (*Change, e
 		query.Set("timeout", opts.Timeout.String())
 	}
 
-	_, err := client.doSync("GET", "/v1/changes/"+id+"/wait", query, nil, nil, &chgd)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/changes/" + id + "/wait",
+		Query:  query,
+	}, &chgd)
 	if err != nil {
 		return nil, err
 	}

--- a/client/changes.go
+++ b/client/changes.go
@@ -89,10 +89,11 @@ type changeAndData struct {
 // Change fetches information about a Change given its ID.
 func (client *Client) Change(id string) (*Change, error) {
 	var chgd changeAndData
-	if _, err := client.DoSync(&RequestInfo{
+	_, err := client.DoSync(&RequestInfo{
 		Method: "GET",
 		Path:   "/v1/changes/" + id,
-	}, &chgd); err != nil {
+	}, &chgd)
+	if err != nil {
 		return nil, err
 	}
 
@@ -113,11 +114,12 @@ func (client *Client) Abort(id string) (*Change, error) {
 	}
 
 	var chg Change
-	if _, err := client.DoSync(&RequestInfo{
+	_, err := client.DoSync(&RequestInfo{
 		Method: "POST",
 		Path:   "/v1/changes/" + id,
 		Body:   &body,
-	}, &chg); err != nil {
+	}, &chg)
+	if err != nil {
 		return nil, err
 	}
 

--- a/client/checks.go
+++ b/client/checks.go
@@ -79,7 +79,11 @@ func (client *Client) Checks(opts *ChecksOptions) ([]*CheckInfo, error) {
 		query["names"] = opts.Names
 	}
 	var checks []*CheckInfo
-	_, err := client.doSync("GET", "/v1/checks", query, nil, nil, &checks)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/checks",
+		Query:  query,
+	}, &checks)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -326,13 +326,27 @@ func decodeInto(reader io.Reader, v interface{}) error {
 	return nil
 }
 
-// doSync performs a request to the given path using the specified HTTP method.
+// RequestInfo holds the information to perform a request to the daemon.
+type RequestInfo struct {
+	Method  string
+	Path    string
+	Query   url.Values
+	Headers map[string]string
+	Body    io.Reader
+}
+
+// ResultInfo is empty for now, but this is the mechanism that conveys
+// general information that makes sense to requests at a more general
+// level, and might be disconnected from the specific request at hand.
+type ResultInfo struct{}
+
+// DoSync performs a request to the given path using the specified HTTP method.
 // It expects a "sync" response from the API and on success decodes the JSON
 // response payload into the given value using the "UseNumber" json decoding
 // which produces json.Numbers instead of float64 types for numbers.
-func (client *Client) doSync(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) (*ResultInfo, error) {
+func (client *Client) DoSync(req *RequestInfo, v interface{}) (*ResultInfo, error) {
 	var rsp response
-	if err := client.do(method, path, query, headers, body, &rsp); err != nil {
+	if err := client.do(req.Method, req.Path, req.Query, req.Headers, req.Body, &rsp); err != nil {
 		return nil, err
 	}
 	if err := rsp.err(client); err != nil {
@@ -354,22 +368,28 @@ func (client *Client) doSync(method, path string, query url.Values, headers map[
 	return &rsp.ResultInfo, nil
 }
 
-func (client *Client) doAsync(method, path string, query url.Values, headers map[string]string, body io.Reader) (changeID string, err error) {
-	_, changeID, err = client.doAsyncFull(method, path, query, headers, body)
+// DoAsync performs a request to the given path using the specified HTTP method.
+// It expects an "async" response from the API and on success returns the
+// change ID.
+func (client *Client) DoAsync(req *RequestInfo) (changeID string, err error) {
+	_, changeID, err = client.DoAsyncFull(req)
 	return
 }
 
-func (client *Client) doAsyncFull(method, path string, query url.Values, headers map[string]string, body io.Reader) (result json.RawMessage, changeID string, err error) {
+// DoAsync performs a request to the given path using the specified HTTP method.
+// It expects an "async" response from the API and on success returns the raw
+// JSON response from the daemon alongside the change ID.
+func (client *Client) DoAsyncFull(req *RequestInfo) (result json.RawMessage, changeID string, err error) {
 	var rsp response
 
-	if err := client.do(method, path, query, headers, body, &rsp); err != nil {
+	if err := client.do(req.Method, req.Path, req.Query, req.Headers, req.Body, &rsp); err != nil {
 		return nil, "", err
 	}
 	if err := rsp.err(client); err != nil {
 		return nil, "", err
 	}
 	if rsp.Type != "async" {
-		return nil, "", fmt.Errorf("expected async response for %q on %q, got %q", method, path, rsp.Type)
+		return nil, "", fmt.Errorf("expected async response for %q on %q, got %q", req.Method, req.Path, rsp.Type)
 	}
 	if rsp.StatusCode != 202 {
 		return nil, "", fmt.Errorf("operation not accepted")
@@ -380,11 +400,6 @@ func (client *Client) doAsyncFull(method, path string, query url.Values, headers
 
 	return rsp.Result, rsp.Change, nil
 }
-
-// ResultInfo is empty for now, but this is the mechanism that conveys
-// general information that makes sense to requests at a more general
-// level, and might be disconnected from the specific request at hand.
-type ResultInfo struct{}
 
 // A response produced by the REST API will usually fit in this
 // (exceptions are the icons/ endpoints obvs)
@@ -476,7 +491,10 @@ type SysInfo struct {
 func (client *Client) SysInfo() (*SysInfo, error) {
 	var sysInfo SysInfo
 
-	if _, err := client.doSync("GET", "/v1/system-info", nil, nil, nil, &sysInfo); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/system-info",
+	}, &sysInfo); err != nil {
 		return nil, fmt.Errorf("cannot obtain system details: %w", err)
 	}
 
@@ -497,8 +515,11 @@ func (client *Client) DebugPost(action string, params interface{}, result interf
 	if err != nil {
 		return err
 	}
-
-	_, err = client.doSync("POST", "/v1/debug", nil, nil, bytes.NewReader(body), result)
+	_, err = client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/debug",
+		Body:   bytes.NewReader(body),
+	}, result)
 	return err
 }
 
@@ -508,6 +529,10 @@ func (client *Client) DebugGet(action string, result interface{}, params map[str
 	for k, v := range params {
 		urlParams.Set(k, v)
 	}
-	_, err := client.doSync("GET", "/v1/debug", urlParams, nil, nil, &result)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/debug",
+		Query:  urlParams,
+	}, &result)
 	return err
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -100,7 +100,10 @@ func (cs *clientSuite) TestNewBaseURLError(c *C) {
 
 func (cs *clientSuite) TestClientDoReportsErrors(c *C) {
 	cs.err = errors.New("ouchie")
-	err := cs.cli.Do("GET", "/", nil, nil, nil)
+	err := cs.cli.Do(&client.RequestInfo{
+		Method: "GET",
+		Path:   "/",
+	}, nil)
 	c.Check(err, ErrorMatches, "cannot communicate with server: ouchie")
 	if cs.doCalls < 2 {
 		c.Fatalf("do did not retry")
@@ -111,7 +114,11 @@ func (cs *clientSuite) TestClientWorks(c *C) {
 	var v []int
 	cs.rsp = `[1,2]`
 	reqBody := ioutil.NopCloser(strings.NewReader(""))
-	err := cs.cli.Do("GET", "/this", nil, reqBody, &v)
+	err := cs.cli.Do(&client.RequestInfo{
+		Method: "GET",
+		Path:   "/this",
+		Body:   reqBody,
+	}, &v)
 	c.Check(err, IsNil)
 	c.Check(v, DeepEquals, []int{1, 2})
 	c.Assert(cs.req, NotNil)
@@ -123,7 +130,10 @@ func (cs *clientSuite) TestClientWorks(c *C) {
 
 func (cs *clientSuite) TestClientDefaultsToNoAuthorization(c *C) {
 	var v string
-	_ = cs.cli.Do("GET", "/this", nil, nil, &v)
+	_ = cs.cli.Do(&client.RequestInfo{
+		Method: "GET",
+		Path:   "/this",
+	}, &v)
 	c.Assert(cs.req, NotNil)
 	authorization := cs.req.Header.Get("Authorization")
 	c.Check(authorization, Equals, "")
@@ -273,7 +283,10 @@ func (cs *clientSuite) TestUserAgent(c *C) {
 	cli.SetDoer(cs)
 
 	var v string
-	_ = cli.Do("GET", "/", nil, nil, &v)
+	_ = cli.Do(&client.RequestInfo{
+		Method: "GET",
+		Path:   "/",
+	}, &v)
 	c.Assert(cs.req, NotNil)
 	c.Check(cs.req.Header.Get("User-Agent"), Equals, "some-agent/9.87")
 }

--- a/client/exec.go
+++ b/client/exec.go
@@ -152,7 +152,12 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	resultBytes, changeID, err := client.doAsyncFull("POST", "/v1/exec", nil, headers, &body)
+	resultBytes, changeID, err := client.DoAsyncFull(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/exec",
+		Headers: headers,
+		Body:    &body,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/client/exec.go
+++ b/client/exec.go
@@ -152,7 +152,7 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	resultBytes, changeID, err := client.DoAsyncFull(&RequestInfo{
+	resultBytes, changeID, err := client.DoAsync(&RequestInfo{
 		Method:  "POST",
 		Path:    "/v1/exec",
 		Headers: headers,

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -34,7 +34,10 @@ func (client *Client) Do(method, path string, query url.Values, body io.Reader, 
 }
 
 func (client *Client) FakeAsyncRequest() (changeId string, err error) {
-	changeId, err = client.doAsync("GET", "/v1/async-test", nil, nil, nil)
+	changeId, err = client.DoAsync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/async-test",
+	})
 	if err != nil {
 		return "", fmt.Errorf("cannot do async test: %v", err)
 	}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -16,8 +16,6 @@ package client
 
 import (
 	"fmt"
-	"io"
-	"net/url"
 )
 
 var (
@@ -29,12 +27,12 @@ func (client *Client) SetDoer(d doer) {
 	client.doer = d
 }
 
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
-	return client.do(method, path, query, nil, body, v)
+func (client *Client) Do(req *RequestInfo, output interface{}) error {
+	return client.do(req, output)
 }
 
 func (client *Client) FakeAsyncRequest() (changeId string, err error) {
-	changeId, err = client.DoAsync(&RequestInfo{
+	_, changeId, err = client.DoAsync(&RequestInfo{
 		Method: "GET",
 		Path:   "/v1/async-test",
 	})

--- a/client/files.go
+++ b/client/files.go
@@ -284,12 +284,13 @@ func (client *Client) MakeDir(opts *MakeDirOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.DoSync(&RequestInfo{
+	_, err := client.DoSync(&RequestInfo{
 		Method:  "POST",
 		Path:    "/v1/files",
 		Headers: headers,
 		Body:    &body,
-	}, &result); err != nil {
+	}, &result)
+	if err != nil {
 		return err
 	}
 
@@ -356,12 +357,13 @@ func (client *Client) RemovePath(opts *RemovePathOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.DoSync(&RequestInfo{
+	_, err := client.DoSync(&RequestInfo{
 		Method:  "POST",
 		Path:    "/v1/files",
 		Headers: headers,
 		Body:    &body,
-	}, &result); err != nil {
+	}, &result)
+	if err != nil {
 		return err
 	}
 

--- a/client/files.go
+++ b/client/files.go
@@ -121,7 +121,11 @@ func (client *Client) ListFiles(opts *ListFilesOptions) ([]*FileInfo, error) {
 	}
 
 	var results []fileInfoResult
-	_, err := client.doSync("GET", "/v1/files", q, nil, nil, &results)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/files",
+		Query:  q,
+	}, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +284,12 @@ func (client *Client) MakeDir(opts *MakeDirOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.doSync("POST", "/v1/files", nil, headers, &body, &result); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/files",
+		Headers: headers,
+		Body:    &body,
+	}, &result); err != nil {
 		return err
 	}
 
@@ -347,7 +356,12 @@ func (client *Client) RemovePath(opts *RemovePathOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.doSync("POST", "/v1/files", nil, headers, &body, &result); err != nil {
+	if _, err := client.DoSync(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/files",
+		Headers: headers,
+		Body:    &body,
+	}, &result); err != nil {
 		return err
 	}
 

--- a/client/plan.go
+++ b/client/plan.go
@@ -52,7 +52,11 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	if err := json.NewEncoder(&body).Encode(&payload); err != nil {
 		return err
 	}
-	_, err := client.doSync("POST", "/v1/layers", nil, nil, &body, nil)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/layers",
+		Body:   &body,
+	}, nil)
 	return err
 }
 
@@ -64,7 +68,11 @@ func (client *Client) PlanBytes(_ *PlanOptions) (data []byte, err error) {
 		"format": []string{"yaml"},
 	}
 	var dataStr string
-	_, err = client.doSync("GET", "/v1/plan", query, nil, nil, &dataStr)
+	_, err = client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/plan",
+		Query:  query,
+	}, &dataStr)
 	if err != nil {
 		return nil, err
 	}

--- a/client/services.go
+++ b/client/services.go
@@ -77,7 +77,12 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	return client.doAsyncFull("POST", "/v1/services", nil, headers, bytes.NewBuffer(data))
+	return client.DoAsyncFull(&RequestInfo{
+		Method:  "POST",
+		Path:    "/v1/services",
+		Headers: headers,
+		Body:    bytes.NewBuffer(data),
+	})
 }
 
 type ServicesOptions struct {
@@ -119,7 +124,11 @@ func (client *Client) Services(opts *ServicesOptions) ([]*ServiceInfo, error) {
 		"names": []string{strings.Join(opts.Names, ",")},
 	}
 	var services []*ServiceInfo
-	_, err := client.doSync("GET", "/v1/services", query, nil, nil, &services)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/services",
+		Query:  query,
+	}, &services)
 	if err != nil {
 		return nil, err
 	}

--- a/client/services.go
+++ b/client/services.go
@@ -77,7 +77,7 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	return client.DoAsyncFull(&RequestInfo{
+	return client.DoAsync(&RequestInfo{
 		Method:  "POST",
 		Path:    "/v1/services",
 		Headers: headers,

--- a/client/signals.go
+++ b/client/signals.go
@@ -36,7 +36,11 @@ func (client *Client) SendSignal(opts *SendSignalOptions) error {
 	if err != nil {
 		return fmt.Errorf("cannot encode JSON payload: %w", err)
 	}
-	_, err = client.doSync("POST", "/v1/signals", nil, nil, &body, nil)
+	_, err = client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/signals",
+		Body:   &body,
+	}, nil)
 	return err
 }
 

--- a/client/warnings.go
+++ b/client/warnings.go
@@ -52,7 +52,11 @@ func (client *Client) Warnings(opts WarningsOptions) ([]*Warning, error) {
 	if opts.All {
 		q.Add("select", "all")
 	}
-	_, err := client.doSync("GET", "/v1/warnings", q, nil, nil, &jws)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "GET",
+		Path:   "/v1/warnings",
+		Query:  q,
+	}, &jws)
 
 	ws := make([]*Warning, len(jws))
 	for i, jw := range jws {
@@ -77,6 +81,10 @@ func (client *Client) Okay(t time.Time) error {
 	if err := json.NewEncoder(&body).Encode(op); err != nil {
 		return err
 	}
-	_, err := client.doSync("POST", "/v1/warnings", nil, nil, &body, nil)
+	_, err := client.DoSync(&RequestInfo{
+		Method: "POST",
+		Path:   "/v1/warnings",
+		Body:   &body,
+	}, nil)
 	return err
 }


### PR DESCRIPTION
This patch exports `client.Do{Sync,Async}` methods and moves the arguments to a `RequestInfo` struct. The idea is that applications extending Pebble can call these helper methods in order to perform HTTP requests to the daemon through an extended client (see #285).