### PR TITLE
docs: fix "service dependencies" section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ For example, if service `nginx` requires `logger`, `pebble start nginx` will sta
 
 When multiple services need to be started together, they're started in order according to the `before` and `after` configuration, waiting 1 second for each to ensure the command doesn't exit too quickly. The `before` option is a list of services that must be started before this one (it may or may not `require` them). Or if it's easier to specify this ordering the other way around, `after` is a list of services that must be started after this one.
 
-Note that currently, `before` and `after` are of limited usefulness, because Pebble only waits 1 second before moving on to start the next service, with no additional checks that the previous service is operating correctly. In future, health checks may be used for this, but right now the logic is simplistic.
+Note that currently, `before` and `after` are of limited usefulness, because Pebble only waits 1 second before moving on to start the next service, with no additional checks that the previous service is operating correctly.
 
 If the configuration of `requires`, `before`, and `after` for a service results in a cycle or "loop", an error will be returned when attempting to start or stop the service.
 

--- a/README.md
+++ b/README.md
@@ -244,11 +244,13 @@ If you want to force a service to restart even if its service configuration hasn
 
 ### Service dependencies
 
-Pebble takes service dependencies into account when starting and stopping services. Before the service manager starts a service, Pebble first starts the services that service depends on (configured with `required`). Conversely, before stopping a service, Pebble first stops services that depend on that service.
+Pebble takes service dependencies into account when starting and stopping services. When Pebble starts a service, it also starts the services which that service depends on (configured with `required`). Conversely, when stopping a service, Pebble also stops services which depend on that service.
 
-For example, if service `nginx` requires `logger`, `pebble start nginx` will start `logger` and then start `nginx`. Running `pebble stop logger` will stop `nginx` and then `logger`; however, running `pebble stop nginx` will only stop `nginx` (`nginx` depends on `logger`, not the other way around).
+For example, if service `nginx` requires `logger`, `pebble start nginx` will start both `nginx` and `logger` (in an undefined order). Running `pebble stop logger` will stop both `nginx` and `logger`; however, running `pebble stop nginx` will only stop `nginx` (`nginx` depends on `logger`, not the other way around).
 
-If multiple dependencies need to be started at once, they're started in order according to the `before` and `after` configuration: `before` is a list of services that must be started before this one (but it doesn't `require` them). Or if it's easier to specify the other way around, `after` is a list of services that must be started after this one.
+When multiple services need to be started together, they're started in order according to the `before` and `after` configuration, waiting 1 second for each to ensure the command doesn't exit too quickly. The `before` option is a list of services that must be started before this one (it may or may not `require` them). Or if it's easier to specify this ordering the other way around, `after` is a list of services that must be started after this one.
+
+Note that currently, `before` and `after` are of limited usefulness, because Pebble only waits 1 second before moving on to start the next service, with no additional checks that the previous service is operating correctly. In future, health checks may be used for this, but right now the logic is simplistic.
 
 If the configuration of `requires`, `before`, and `after` for a service results in a cycle or "loop", an error will be returned when attempting to start or stop the service.
 


### PR DESCRIPTION
It currently says that "requires" does ordering ("Before ... first"), but that's not true -- "requires" only specifies dependencies. It "before" and "after" that does ordering.

Also note that limited usefulness of before/after as Pebble doesn't really check that a service is "up", just waits 1s.