### PR TITLE
docs: fix polarity of before/after in "service dependencies" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Pebble takes service dependencies into account when starting and stopping servic
 
 For example, if service `nginx` requires `logger`, `pebble start nginx` will start both `nginx` and `logger` (in an undefined order). Running `pebble stop logger` will stop both `nginx` and `logger`; however, running `pebble stop nginx` will only stop `nginx` (`nginx` depends on `logger`, not the other way around).
 
-When multiple services need to be started together, they're started in order according to the `before` and `after` configuration, waiting 1 second for each to ensure the command doesn't exit too quickly. The `before` option is a list of services that must be started before this one (it may or may not `require` them). Or if it's easier to specify this ordering the other way around, `after` is a list of services that must be started after this one.
+When multiple services need to be started together, they're started in order according to the `before` and `after` configuration, waiting 1 second for each to ensure the command doesn't exit too quickly. The `before` option is a list of services that this service must start before (it may or may not `require` them). Or if it's easier to specify this ordering the other way around, `after` is a list of services that this service must start after.
 
 Note that currently, `before` and `after` are of limited usefulness, because Pebble only waits 1 second before moving on to start the next service, with no additional checks that the previous service is operating correctly.
 


### PR DESCRIPTION
Thanks @troyanov for pointing out the mistake.

See also recent changes in #290 (though that didn't introduce this problem).