### PR TITLE
feat(daemon): daemon access for API extensions

### DIFF
--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -225,6 +225,10 @@ func (d *Daemon) Overlord() *overlord.Overlord {
 	return d.overlord
 }
 
+func (c *Command) Daemon() *Daemon {
+	return c.d
+}
+
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	st := c.d.state
 	st.Lock()


### PR DESCRIPTION
The following PR provided Pebble derived projects to extend the supplied daemon HTTP API handlers.

https://github.com/canonical/pebble/pull/265

However, currently such a handler cannot access the daemon, even though we added a daemon method to also expose the Overlord.

```go
func v1PostDevice(*daemon.Command, req *http.Request, _ *daemon.UserState) daemon.Response {
	:

	// Cannot access c.d (daemon is private)
        ovld := c.d.Overlord()

	:
}
```

This PR adds c.Daemon() to allow access inside externally defined HTTP API handlers.