### PR TITLE
Return multiple validation errors at once

### DIFF
--- a/internals/daemon/api_plan_test.go
+++ b/internals/daemon/api_plan_test.go
@@ -16,8 +16,11 @@ package daemon
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strings"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
@@ -181,21 +184,192 @@ services:
 	s.planLayersHasLen(c, 1)
 }
 
-func (s *apiSuite) TestLayersCombineFormatError(c *C) {
+// ! missing override in one service
+func (s *apiSuite) TestLayersCombineOneError(c *C) {
+	testLayersCombineFormatError(s, c,
+		"services:\n dynamic:\n  command: echo dynamic\n",
+		`layer "base" must define "override" for service "dynamic"`)
+
+}
+
+func (s *apiSuite) TestLayersCombineServicesMultiErrors(c *C) {
+	input := `
+services:
+	svc1:
+	  override: replace
+	  command: ""
+	  on-success: invalid
+	  on-failure: invalid
+	  on-check-failure:
+		 svc1: foo
+	  backoff-factor: 0
+	svc2:
+	  override: replace
+	  command: invalidCommand
+	  on-success: invalid
+	  on-failure: invalid
+	  on-check-failure:
+		 svc1: foo
+	  backoff-factor: 0
+	svc3:
+	  override: foo
+	  command: ""
+	  on-success: invalid
+	  on-failure: invalid
+	  on-check-failure:
+		 svc3: foo
+	  backoff-factor: 0
+	svc4:
+	  command: cmd
+	  on-success: invalid
+	  on-failure: invalid
+	  on-check-failure:
+		 svc4: foo
+	  backoff-factor: 0
+	  `
+
+	expectedError := `multiple errors validating plan:
+- layer "base" has invalid "override" value for service "svc3"
+- layer "base" must define "override" for service "svc4"
+- plan service "svc2" on-success action "invalid" invalid
+- plan service "svc2" on-failure action "invalid" invalid
+- plan service "svc2" on-check-failure action "foo" invalid
+- plan service "svc2" backoff-factor must be 1.0 or greater, not 0
+- plan must define "command" for service "svc1"
+- plan service "svc1" on-success action "invalid" invalid
+- plan service "svc1" on-failure action "invalid" invalid
+- plan service "svc1" on-check-failure action "foo" invalid
+- plan service "svc1" backoff-factor must be 1.0 or greater, not 0
+`
+
+	testLayersCombineFormatError(s, c, input, expectedError)
+
+}
+
+func (s *apiSuite) TestLayersCombineChecksMultiErrors(c *C) {
+	input := `
+checks:
+  svc1:
+    override: replace
+    level: foo
+    period: 0
+    timeout: 0
+    http:
+      url: ""
+    tcp:
+      port: 0
+    exec:
+      command: ""
+      service-context: foo
+      user-id: 0
+  svc2:
+    override: replace
+    level: alive
+    period: 10s
+    timeout: 10s
+    exec:
+      command: invalid
+  svc3:
+    override: foo
+    level: alive
+    exec:
+      command: ""
+  svc4:
+    level: alive
+    exec:
+      command: cmd
+	  `
+
+	expectedError := `multiple errors validating plan:
+- layer "base" has invalid "override" value for check "svc3"
+- layer "base" must define "override" for check "svc4"
+- plan check "svc2" timeout must be less than period
+- plan check "svc1" level must be "alive" or "ready"
+- plan check "svc1" period must not be zero
+- plan check "svc1" timeout must not be zero
+- plan must set "url" for http check "svc1"
+- plan must set "port" for tcp check "svc1"
+- plan must set "command" for exec check "svc1"
+- plan check "svc1" service context specifies non-existent service "foo"
+- plan check "svc1" has invalid user/group: must specify group, not just UID
+- plan must specify one of "http", "tcp", or "exec" for check "svc1"
+`
+
+	testLayersCombineFormatError(s, c, input, expectedError)
+
+}
+
+func (s *apiSuite) TestLayersCombineLogTargetMultiErrors(c *C) {
+	input := `
+log-targets:
+  svc1:
+    override: replace
+    type: foo
+  svc2:
+    override: replace
+    type: ""
+    services: ["foo"]
+  svc3:
+    override: foo
+    type: ""
+  svc4:
+    type: loki
+    services: ["foo"]
+	  `
+
+	expectedError := `multiple errors validating plan:
+- layer "base" has invalid "override" value for log target "svc3"
+- layer "base" must define "override" for log target "svc4"
+- log target "svc1" has unsupported type "foo", must be "loki" or "syslog"
+- plan must define "location" for log target "svc1"
+- plan must define "type" ("loki" or "syslog") for log target "svc2"
+- log target "svc2" specifies unknown service "foo"
+- plan must define "location" for log target "svc2"
+
+`
+
+	testLayersCombineFormatError(s, c, input, expectedError)
+
+}
+
+func testLayersCombineFormatError(s *apiSuite, c *C, content string, response string) {
+	// Manually escape the string
+	content = strings.ReplaceAll(content, "\t", "    ")
+	escapedContent := strings.ReplaceAll(content, "\n", "\\n")
+	escapedContent = strings.ReplaceAll(escapedContent, "\"", "\\\"")
+	payload := fmt.Sprintf(`{"action": "add", "combine": true, "label": "base", "format": "yaml", "layer": "%s"}`, escapedContent)
 	writeTestLayer(s.pebbleDir, planLayer)
 	_ = s.daemon(c)
 	layersCmd := apiCmd("/v1/layers")
-
-	payload := `{"action": "add", "combine": true, "label": "base", "format": "yaml", "layer": "services:\n dynamic:\n  command: echo dynamic\n"}`
 	req, err := http.NewRequest("POST", "/v1/layers", bytes.NewBufferString(payload))
 	c.Assert(err, IsNil)
 	rsp := v1PostLayers(layersCmd, req, nil).(*resp)
+
 	rec := httptest.NewRecorder()
 	rsp.ServeHTTP(rec, req)
 	c.Assert(rec.Code, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Status, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Type, Equals, ResponseTypeError)
 	result := rsp.Result.(*errorResult)
-	c.Assert(result.Message, Matches, `layer "base" must define "override" for service "dynamic"`)
+	sortedExpected := sortErrorLines(response)
+	sortedActual := sortErrorLines(result.Message)
+	c.Assert(sortedActual, Equals, sortedExpected)
+}
 
+func sortErrorLines(errorStr string) string {
+	lines := strings.Split(errorStr, "\n")
+
+	// Filter out empty lines
+	var nonEmptyLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			nonEmptyLines = append(nonEmptyLines, trimmed)
+		}
+	}
+
+	// Sort the non-empty lines
+	sort.Strings(nonEmptyLines)
+
+	return strings.Join(nonEmptyLines, "\n")
 }

--- a/internals/daemon/api_plan_test.go
+++ b/internals/daemon/api_plan_test.go
@@ -16,11 +16,8 @@ package daemon
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sort"
-	"strings"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/yaml.v3"
@@ -183,193 +180,19 @@ services:
 `[1:])
 	s.planLayersHasLen(c, 1)
 }
-
-// ! missing override in one service
-func (s *apiSuite) TestLayersCombineOneError(c *C) {
-	testLayersCombineFormatError(s, c,
-		"services:\n dynamic:\n  command: echo dynamic\n",
-		`layer "base" must define "override" for service "dynamic"`)
-
-}
-
-func (s *apiSuite) TestLayersCombineServicesMultiErrors(c *C) {
-	input := `
-services:
-	svc1:
-	  override: replace
-	  command: ""
-	  on-success: invalid
-	  on-failure: invalid
-	  on-check-failure:
-		 svc1: foo
-	  backoff-factor: 0
-	svc2:
-	  override: replace
-	  command: invalidCommand
-	  on-success: invalid
-	  on-failure: invalid
-	  on-check-failure:
-		 svc1: foo
-	  backoff-factor: 0
-	svc3:
-	  override: foo
-	  command: ""
-	  on-success: invalid
-	  on-failure: invalid
-	  on-check-failure:
-		 svc3: foo
-	  backoff-factor: 0
-	svc4:
-	  command: cmd
-	  on-success: invalid
-	  on-failure: invalid
-	  on-check-failure:
-		 svc4: foo
-	  backoff-factor: 0
-	  `
-
-	expectedError := `multiple errors validating plan:
-- layer "base" has invalid "override" value for service "svc3"
-- layer "base" must define "override" for service "svc4"
-- plan service "svc2" on-success action "invalid" invalid
-- plan service "svc2" on-failure action "invalid" invalid
-- plan service "svc2" on-check-failure action "foo" invalid
-- plan service "svc2" backoff-factor must be 1.0 or greater, not 0
-- plan must define "command" for service "svc1"
-- plan service "svc1" on-success action "invalid" invalid
-- plan service "svc1" on-failure action "invalid" invalid
-- plan service "svc1" on-check-failure action "foo" invalid
-- plan service "svc1" backoff-factor must be 1.0 or greater, not 0
-`
-
-	testLayersCombineFormatError(s, c, input, expectedError)
-
-}
-
-func (s *apiSuite) TestLayersCombineChecksMultiErrors(c *C) {
-	input := `
-checks:
-  svc1:
-    override: replace
-    level: foo
-    period: 0
-    timeout: 0
-    http:
-      url: ""
-    tcp:
-      port: 0
-    exec:
-      command: ""
-      service-context: foo
-      user-id: 0
-  svc2:
-    override: replace
-    level: alive
-    period: 10s
-    timeout: 10s
-    exec:
-      command: invalid
-  svc3:
-    override: foo
-    level: alive
-    exec:
-      command: ""
-  svc4:
-    level: alive
-    exec:
-      command: cmd
-	  `
-
-	expectedError := `multiple errors validating plan:
-- layer "base" has invalid "override" value for check "svc3"
-- layer "base" must define "override" for check "svc4"
-- plan check "svc2" timeout must be less than period
-- plan check "svc1" level must be "alive" or "ready"
-- plan check "svc1" period must not be zero
-- plan check "svc1" timeout must not be zero
-- plan must set "url" for http check "svc1"
-- plan must set "port" for tcp check "svc1"
-- plan must set "command" for exec check "svc1"
-- plan check "svc1" service context specifies non-existent service "foo"
-- plan check "svc1" has invalid user/group: must specify group, not just UID
-- plan must specify one of "http", "tcp", or "exec" for check "svc1"
-`
-
-	testLayersCombineFormatError(s, c, input, expectedError)
-
-}
-
-func (s *apiSuite) TestLayersCombineLogTargetMultiErrors(c *C) {
-	input := `
-log-targets:
-  svc1:
-    override: replace
-    type: foo
-  svc2:
-    override: replace
-    type: ""
-    services: ["foo"]
-  svc3:
-    override: foo
-    type: ""
-  svc4:
-    type: loki
-    services: ["foo"]
-	  `
-
-	expectedError := `multiple errors validating plan:
-- layer "base" has invalid "override" value for log target "svc3"
-- layer "base" must define "override" for log target "svc4"
-- log target "svc1" has unsupported type "foo", must be "loki" or "syslog"
-- plan must define "location" for log target "svc1"
-- plan must define "type" ("loki" or "syslog") for log target "svc2"
-- log target "svc2" specifies unknown service "foo"
-- plan must define "location" for log target "svc2"
-
-`
-
-	testLayersCombineFormatError(s, c, input, expectedError)
-
-}
-
-func testLayersCombineFormatError(s *apiSuite, c *C, content string, response string) {
-	// Manually escape the string
-	content = strings.ReplaceAll(content, "\t", "    ")
-	escapedContent := strings.ReplaceAll(content, "\n", "\\n")
-	escapedContent = strings.ReplaceAll(escapedContent, "\"", "\\\"")
-	payload := fmt.Sprintf(`{"action": "add", "combine": true, "label": "base", "format": "yaml", "layer": "%s"}`, escapedContent)
+func (s *apiSuite) TestLayersCombineFormatError(c *C) {
 	writeTestLayer(s.pebbleDir, planLayer)
 	_ = s.daemon(c)
 	layersCmd := apiCmd("/v1/layers")
+	payload := `{"action": "add", "combine": true, "label": "base", "format": "yaml", "layer": "services:\n dynamic:\n  command: echo dynamic\n"}`
 	req, err := http.NewRequest("POST", "/v1/layers", bytes.NewBufferString(payload))
 	c.Assert(err, IsNil)
 	rsp := v1PostLayers(layersCmd, req, nil).(*resp)
-
 	rec := httptest.NewRecorder()
 	rsp.ServeHTTP(rec, req)
 	c.Assert(rec.Code, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Status, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Type, Equals, ResponseTypeError)
 	result := rsp.Result.(*errorResult)
-	sortedExpected := sortErrorLines(response)
-	sortedActual := sortErrorLines(result.Message)
-	c.Assert(sortedActual, Equals, sortedExpected)
-}
-
-func sortErrorLines(errorStr string) string {
-	lines := strings.Split(errorStr, "\n")
-
-	// Filter out empty lines
-	var nonEmptyLines []string
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" {
-			nonEmptyLines = append(nonEmptyLines, trimmed)
-		}
-	}
-
-	// Sort the non-empty lines
-	sort.Strings(nonEmptyLines)
-
-	return strings.Join(nonEmptyLines, "\n")
+	c.Assert(result.Message, Matches, `layer "base" must define "override" for service "dynamic"`)
 }

--- a/internals/daemon/api_plan_test.go
+++ b/internals/daemon/api_plan_test.go
@@ -196,7 +196,6 @@ func (s *apiSuite) TestLayersCombineFormatError(c *C) {
 	c.Assert(rsp.Status, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Type, Equals, ResponseTypeError)
 	result := rsp.Result.(*errorResult)
-
-	c.Assert(result.Message, Matches, `(?s)\s*invalid plan:\n- layer "base" must define "override" for service "dynamic"`)
+	c.Assert(result.Message, Matches, `layer "base" must define "override" for service "dynamic"`)
 
 }

--- a/internals/daemon/api_plan_test.go
+++ b/internals/daemon/api_plan_test.go
@@ -196,5 +196,6 @@ func (s *apiSuite) TestLayersCombineFormatError(c *C) {
 	c.Assert(rsp.Status, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Type, Equals, ResponseTypeError)
 	result := rsp.Result.(*errorResult)
-	c.Assert(result.Message, Matches, `layer "base" must define "override" for service "dynamic"`)
+	c.Assert(result.Message, Matches, `(?s)\s*invalid plan:\n- layer "base" must define "override" for service "dynamic"`)
+
 }

--- a/internals/daemon/api_plan_test.go
+++ b/internals/daemon/api_plan_test.go
@@ -196,6 +196,7 @@ func (s *apiSuite) TestLayersCombineFormatError(c *C) {
 	c.Assert(rsp.Status, Equals, http.StatusBadRequest)
 	c.Assert(rsp.Type, Equals, ResponseTypeError)
 	result := rsp.Result.(*errorResult)
+
 	c.Assert(result.Message, Matches, `(?s)\s*invalid plan:\n- layer "base" must define "override" for service "dynamic"`)
 
 }

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -535,6 +535,7 @@ func (e *FormatError) Error() string {
 // CombineLayers combines the given layers into a single layer, with the later
 // layers overriding earlier ones.
 func CombineLayers(layers ...*Layer) (*Layer, error) {
+	var errorMessages []string // To collect multiple errors
 	combined := &Layer{
 		Services:   make(map[string]*Service),
 		Checks:     make(map[string]*Check),
@@ -560,15 +561,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			case ReplaceOverride:
 				combined.Services[name] = service.Copy()
 			case UnknownOverride:
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`layer %q must define "override" for service %q`,
-						layer.Label, service.Name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q must define "override" for service %q`,
+					layer.Label, service.Name))
 			default:
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`layer %q has invalid "override" value for service %q`,
-						layer.Label, service.Name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q has invalid "override" value for service %q`,
+					layer.Label, service.Name))
+
 			}
 		}
 
@@ -585,15 +583,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			case ReplaceOverride:
 				combined.Checks[name] = check.Copy()
 			case UnknownOverride:
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`layer %q must define "override" for check %q`,
-						layer.Label, check.Name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q must define "override" for check %q`,
+					layer.Label, check.Name))
 			default:
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`layer %q has invalid "override" value for check %q`,
-						layer.Label, check.Name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q has invalid "override" value for check %q`,
+					layer.Label, check.Name))
+
 			}
 		}
 
@@ -610,15 +605,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			case ReplaceOverride:
 				combined.LogTargets[name] = target.Copy()
 			case UnknownOverride:
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`layer %q must define "override" for log target %q`,
-						layer.Label, target.Name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q must define "override" for log target %q`,
+					layer.Label, target.Name))
+
 			default:
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`layer %q has invalid "override" value for log target %q`,
-						layer.Label, target.Name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q has invalid "override" value for log target %q`,
+					layer.Label, target.Name))
 			}
 		}
 	}
@@ -626,31 +618,22 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 	// Ensure fields in combined layers validate correctly (and set defaults).
 	for name, service := range combined.Services {
 		if service.Command == "" {
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`plan must define "command" for service %q`, name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`plan must define "command" for service %q`, name))
 		}
 		_, _, err := service.ParseCommand()
 		if err != nil {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan service %q command invalid: %v", name, err),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan service %q command invalid: %v", name, err))
 		}
 		if !validServiceAction(service.OnSuccess) {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan service %q on-success action %q invalid", name, service.OnSuccess),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan service %q on-success action %q invalid", name, service.OnSuccess))
+
 		}
 		if !validServiceAction(service.OnFailure) {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan service %q on-failure action %q invalid", name, service.OnFailure),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan service %q on-failure action %q invalid", name, service.OnFailure))
 		}
 		for _, action := range service.OnCheckFailure {
 			if !validServiceAction(action) {
-				return nil, &FormatError{
-					Message: fmt.Sprintf("plan service %q on-check-failure action %q invalid", name, action),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf("plan service %q on-check-failure action %q invalid", name, action))
 			}
 		}
 		if !service.BackoffDelay.IsSet {
@@ -659,9 +642,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		if !service.BackoffFactor.IsSet {
 			service.BackoffFactor.Value = defaultBackoffFactor
 		} else if service.BackoffFactor.Value < 1 {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan service %q backoff-factor must be 1.0 or greater, not %g", name, service.BackoffFactor.Value),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan service %q backoff-factor must be 1.0 or greater, not %g", name, service.BackoffFactor.Value))
 		}
 		if !service.BackoffLimit.IsSet {
 			service.BackoffLimit.Value = defaultBackoffLimit
@@ -671,27 +652,19 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 	for name, check := range combined.Checks {
 		if check.Level != UnsetLevel && check.Level != AliveLevel && check.Level != ReadyLevel {
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`plan check %q level must be "alive" or "ready"`, name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`plan check %q level must be "alive" or "ready"`, name))
 		}
 		if !check.Period.IsSet {
 			check.Period.Value = defaultCheckPeriod
 		} else if check.Period.Value == 0 {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan check %q period must not be zero", name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan check %q period must not be zero", name))
 		}
 		if !check.Timeout.IsSet {
 			check.Timeout.Value = defaultCheckTimeout
 		} else if check.Timeout.Value == 0 {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan check %q timeout must not be zero", name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan check %q timeout must not be zero", name))
 		} else if check.Timeout.Value >= check.Period.Value {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("plan check %q timeout must be less than period", name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf("plan check %q timeout must be less than period", name))
 		}
 		if check.Threshold == 0 {
 			// Default number of failures in a row before check triggers
@@ -703,51 +676,37 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		numTypes := 0
 		if check.HTTP != nil {
 			if check.HTTP.URL == "" {
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`plan must set "url" for http check %q`, name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`plan must set "url" for http check %q`, name))
 			}
 			numTypes++
 		}
 		if check.TCP != nil {
 			if check.TCP.Port == 0 {
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`plan must set "port" for tcp check %q`, name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`plan must set "port" for tcp check %q`, name))
 			}
 			numTypes++
 		}
 		if check.Exec != nil {
 			if check.Exec.Command == "" {
-				return nil, &FormatError{
-					Message: fmt.Sprintf(`plan must set "command" for exec check %q`, name),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf(`plan must set "command" for exec check %q`, name))
 			}
 			_, err := shlex.Split(check.Exec.Command)
 			if err != nil {
-				return nil, &FormatError{
-					Message: fmt.Sprintf("plan check %q command invalid: %v", name, err),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf("plan check %q command invalid: %v", name, err))
 			}
 			_, contextExists := combined.Services[check.Exec.ServiceContext]
 			if check.Exec.ServiceContext != "" && !contextExists {
-				return nil, &FormatError{
-					Message: fmt.Sprintf("plan check %q service context specifies non-existent service %q",
-						name, check.Exec.ServiceContext),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf("plan check %q service context specifies non-existent service %q",
+					name, check.Exec.ServiceContext))
 			}
 			_, _, err = osutil.NormalizeUidGid(check.Exec.UserID, check.Exec.GroupID, check.Exec.User, check.Exec.Group)
 			if err != nil {
-				return nil, &FormatError{
-					Message: fmt.Sprintf("plan check %q has invalid user/group: %v", name, err),
-				}
+				errorMessages = append(errorMessages, fmt.Sprintf("plan check %q has invalid user/group: %v", name, err))
 			}
 			numTypes++
 		}
 		if numTypes != 1 {
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`plan must specify one of "http", "tcp", or "exec" for check %q`, name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`plan must specify one of "http", "tcp", or "exec" for check %q`, name))
 		}
 	}
 
@@ -756,15 +715,11 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		case LokiTarget, SyslogTarget:
 			// valid, continue
 		case UnsetLogTarget:
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`plan must define "type" (%q or %q) for log target %q`,
-					LokiTarget, SyslogTarget, name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`plan must define "type" (%q or %q) for log target %q`,
+				LokiTarget, SyslogTarget, name))
 		default:
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
-					name, target.Type, LokiTarget, SyslogTarget),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
+				name, target.Type, LokiTarget, SyslogTarget))
 		}
 
 		// Validate service names specified in log target
@@ -776,17 +731,22 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			if _, ok := combined.Services[serviceName]; ok {
 				continue
 			}
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`log target %q specifies unknown service %q`,
-					target.Name, serviceName),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`log target %q specifies unknown service %q`,
+				target.Name, serviceName))
 		}
 
 		if target.Location == "" {
-			return nil, &FormatError{
-				Message: fmt.Sprintf(`plan must define "location" for log target %q`, name),
-			}
+			errorMessages = append(errorMessages, fmt.Sprintf(`plan must define "location" for log target %q`, name))
 		}
+	}
+
+	// Ensure combined layers don't have errors
+	if len(errorMessages) > 0 {
+		fullErrorMessage := "\ninvalid plan:\n- " + strings.Join(errorMessages, "\n- ")
+		return nil, &FormatError{
+			Message: fullErrorMessage,
+		}
+
 	}
 
 	// Ensure combined layers don't have cycles.

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -700,7 +700,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 			numTypes++
 		}
-		if numTypes != 1 {
+		if numTypes == 0 {
 			addErrorf(`plan must specify one of "http", "tcp", or "exec" for check %q`, name)
 		}
 	}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -566,7 +566,6 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			default:
 				errorMessages = append(errorMessages, fmt.Sprintf(`layer %q has invalid "override" value for service %q`,
 					layer.Label, service.Name))
-
 			}
 		}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -733,10 +733,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 			errorMessages = append(errorMessages, fmt.Sprintf(`log target %q specifies unknown service %q`,
 				target.Name, serviceName))
+
 		}
 
 		if target.Location == "" {
 			errorMessages = append(errorMessages, fmt.Sprintf(`plan must define "location" for log target %q`, name))
+
 		}
 	}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -528,8 +528,7 @@ type FormatError struct {
 	Message string
 }
 type ConfigError struct {
-	Message         string
-	OverrideError   bool
+	ServiceError    bool
 	ChecksError     bool
 	LogTargetsError bool
 }
@@ -542,6 +541,11 @@ func (e *FormatError) Error() string {
 // layers overriding earlier ones.
 func CombineLayers(layers ...*Layer) (*Layer, error) {
 	serviceErrors := make(map[string]ConfigError) //  a set to hold the names of services with error
+	var errorMessages []string
+	addError := func(message string) {
+		errorMessages = append(errorMessages, message)
+	}
+
 	combined := &Layer{
 		Services:   make(map[string]*Service),
 		Checks:     make(map[string]*Check),
@@ -568,26 +572,22 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 				combined.Services[name] = service.Copy()
 			case UnknownOverride:
 				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`layer %q must define "override" for service %q`,
-						layer.Label, service.Name),
-					OverrideError: true,
+					ServiceError: true,
 				}
+				addError(fmt.Sprintf(`layer %q must define "override" for service %q`,
+					layer.Label, service.Name))
 				continue // Skip to the next service in the loop
 			default:
 				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`layer %q has invalid "override" value for service %q`,
-						layer.Label, service.Name),
-					OverrideError: true,
+					ServiceError: true,
 				}
+				addError(fmt.Sprintf(`layer %q has invalid "override" value for service %q`,
+					layer.Label, service.Name))
 				continue
 
 			}
 		}
 		for name, check := range layer.Checks {
-
-			if serviceErrors[name].OverrideError {
-				continue
-			}
 			switch check.Override {
 			case MergeOverride:
 				if old, ok := combined.Checks[name]; ok {
@@ -601,28 +601,24 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 				combined.Checks[name] = check.Copy()
 			case UnknownOverride:
 				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`layer %q must define "override" for check %q`,
-						layer.Label, check.Name),
 					ChecksError: true,
 				}
+				addError(fmt.Sprintf(`layer %q must define "override" for check %q`,
+					layer.Label, check.Name))
 
 				continue // Skip to the next service in the loop
 
 			default:
 				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`layer %q has invalid "override" value for check %q`,
-						layer.Label, check.Name),
 					ChecksError: true,
 				}
+				addError(fmt.Sprintf(`layer %q has invalid "override" value for check %q`,
+					layer.Label, check.Name))
 				continue // Skip to the next service in the loop
 
 			}
 		}
 		for name, target := range layer.LogTargets {
-			// Skip this service if it already has an override error
-			if serviceErrors[name].OverrideError {
-				continue
-			}
 			switch target.Override {
 			case MergeOverride:
 				if old, ok := combined.LogTargets[name]; ok {
@@ -637,18 +633,18 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 				combined.LogTargets[name] = target.Copy()
 			case UnknownOverride:
 				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`layer %q must define "override" for log target %q`,
-						layer.Label, target.Name),
 					LogTargetsError: true,
 				}
+				addError(fmt.Sprintf(`layer %q must define "override" for log target %q`,
+					layer.Label, target.Name))
 				continue
 
 			default:
 				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`layer %q has invalid "override" value for log target %q`,
-						layer.Label, target.Name),
 					LogTargetsError: true,
 				}
+				addError(fmt.Sprintf(`layer %q has invalid "override" value for log target %q`,
+					layer.Label, target.Name))
 
 				continue
 			}
@@ -657,44 +653,29 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 
 	// Ensure fields in combined layers validate correctly (and set defaults).
 	for name, service := range combined.Services {
-		if serviceErrors[name].OverrideError {
+		if serviceErrors[name].ServiceError {
 			continue
 
 		}
 		if service.Command == "" {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`plan must define "command" for service %q`, name),
-			}
-			continue
+			addError(fmt.Sprintf(`plan must define "command" for service %q`, name))
+
+		} else if _, _, err := service.ParseCommand(); err != nil {
+			addError(fmt.Sprintf("plan service %q command invalid: %v", name, err))
 
 		}
-		_, _, err := service.ParseCommand()
-		if err != nil {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan service %q command invalid: %v", name, err),
-			}
-			continue
 
-		}
 		if !validServiceAction(service.OnSuccess) {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan service %q on-success action %q invalid", name, service.OnSuccess),
-			}
-			continue
+			addError(fmt.Sprintf("plan service %q on-success action %q invalid", name, service.OnSuccess))
+
 		}
 		if !validServiceAction(service.OnFailure) {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan service %q on-failure action %q invalid", name, service.OnFailure),
-			}
-			continue
+			addError(fmt.Sprintf("plan service %q on-failure action %q invalid", name, service.OnFailure))
 		}
 		for _, action := range service.OnCheckFailure {
 			if !validServiceAction(action) {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf("plan service %q on-check-failure action %q invalid", name, action),
-				}
+				addError(fmt.Sprintf("plan service %q on-check-failure action %q invalid", name, action))
 
-				continue
 			}
 		}
 		if !service.BackoffDelay.IsSet {
@@ -703,51 +684,34 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		if !service.BackoffFactor.IsSet {
 			service.BackoffFactor.Value = defaultBackoffFactor
 		} else if service.BackoffFactor.Value < 1 {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan service %q backoff-factor must be 1.0 or greater, not %g", name, service.BackoffFactor.Value),
-			}
-
-			continue
+			addError(fmt.Sprintf("plan service %q backoff-factor must be 1.0 or greater, not %g", name, service.BackoffFactor.Value))
 		}
 		if !service.BackoffLimit.IsSet {
 			service.BackoffLimit.Value = defaultBackoffLimit
 		}
-
 	}
 
 	for name, check := range combined.Checks {
 		if serviceErrors[name].ChecksError {
 			continue
-
 		}
 		if check.Level != UnsetLevel && check.Level != AliveLevel && check.Level != ReadyLevel {
-
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`plan check %q level must be "alive" or "ready"`, name),
-			}
-			continue
+			addError(fmt.Sprintf(`plan check %q level must be "alive" or "ready"`, name))
 		}
 		if !check.Period.IsSet {
 			check.Period.Value = defaultCheckPeriod
 		} else if check.Period.Value == 0 {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan check %q period must not be zero", name),
-			}
-			continue
+			addError(fmt.Sprintf("plan check %q period must not be zero", name))
 		}
 		if !check.Timeout.IsSet {
 			check.Timeout.Value = defaultCheckTimeout
 		} else if check.Timeout.Value == 0 {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan check %q timeout must not be zero", name),
-			}
-			continue
+			addError(fmt.Sprintf("plan check %q timeout must not be zero", name))
 
 		} else if check.Timeout.Value >= check.Period.Value {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf("plan check %q timeout must be less than period", name),
-			}
+			addError(fmt.Sprintf("plan check %q timeout must be less than period", name))
 			continue
+
 		}
 		if check.Threshold == 0 {
 			// Default number of failures in a row before check triggers
@@ -759,58 +723,37 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		numTypes := 0
 		if check.HTTP != nil {
 			if check.HTTP.URL == "" {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`plan must set "url" for http check %q`, name),
-				}
-				continue
+				addError(fmt.Sprintf(`plan must set "url" for http check %q`, name))
 			}
 			numTypes++
 		}
 		if check.TCP != nil {
 			if check.TCP.Port == 0 {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`plan must set "port" for tcp check %q`, name),
-				}
-				continue
+				addError(fmt.Sprintf(`plan must set "port" for tcp check %q`, name))
 			}
 			numTypes++
 		}
 		if check.Exec != nil {
 			if check.Exec.Command == "" {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf(`plan must set "command" for exec check %q`, name),
-				}
-				continue
+				addError(fmt.Sprintf(`plan must set "command" for exec check %q`, name))
+			} else if _, err := shlex.Split(check.Exec.Command); err != nil {
+				addError(fmt.Sprintf("plan check %q command invalid: %v", name, err))
 			}
-			_, err := shlex.Split(check.Exec.Command)
-			if err != nil {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf("plan check %q command invalid: %v", name, err),
-				}
-				continue
-			}
+
 			_, contextExists := combined.Services[check.Exec.ServiceContext]
 			if check.Exec.ServiceContext != "" && !contextExists {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf("plan check %q service context specifies non-existent service %q",
-						name, check.Exec.ServiceContext),
-				}
-				continue
+				addError(fmt.Sprintf("plan check %q service context specifies non-existent service %q",
+					name, check.Exec.ServiceContext))
+
 			}
-			_, _, err = osutil.NormalizeUidGid(check.Exec.UserID, check.Exec.GroupID, check.Exec.User, check.Exec.Group)
-			if err != nil {
-				serviceErrors[name] = ConfigError{
-					Message: fmt.Sprintf("plan check %q has invalid user/group: %v", name, err),
-				}
-				continue
+			if _, _, err := osutil.NormalizeUidGid(check.Exec.UserID, check.Exec.GroupID, check.Exec.User, check.Exec.Group); err != nil {
+				addError(fmt.Sprintf("plan check %q has invalid user/group: %v", name, err))
+
 			}
 			numTypes++
 		}
 		if numTypes != 1 {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`plan must specify one of "http", "tcp", or "exec" for check %q`, name),
-			}
-
+			addError(fmt.Sprintf(`plan must specify one of "http", "tcp", or "exec" for check %q`, name))
 		}
 	}
 
@@ -823,16 +766,11 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		case LokiTarget, SyslogTarget:
 			// valid, continue
 		case UnsetLogTarget:
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`plan must define "type" (%q or %q) for log target %q`,
-					LokiTarget, SyslogTarget, name),
-			}
-			continue
+			addError(fmt.Sprintf(`plan must define "type" (%q or %q) for log target %q`,
+				LokiTarget, SyslogTarget, name))
 		default:
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
-					name, target.Type, LokiTarget, SyslogTarget),
-			}
+			addError(fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
+				name, target.Type, LokiTarget, SyslogTarget))
 
 		}
 
@@ -845,35 +783,26 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			if _, ok := combined.Services[serviceName]; ok {
 				continue
 			}
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`log target %q specifies unknown service %q`,
-					target.Name, serviceName),
-			}
-			continue
+			addError(fmt.Sprintf(`log target %q specifies unknown service %q`,
+				target.Name, serviceName))
+
 		}
 
 		if target.Location == "" {
-			serviceErrors[name] = ConfigError{
-				Message: fmt.Sprintf(`plan must define "location" for log target %q`, name),
-			}
+			addError(fmt.Sprintf(`plan must define "location" for log target %q`, name))
 
 		}
-
 	}
+
 	// Ensure combined layers don't have cycles.
 	err := combined.checkCycles()
 	if err != nil {
 		return nil, err
 	}
-	errorMessages := []string{}
-	for _, er := range serviceErrors {
-		if len(serviceErrors) == 1 {
-			return nil, &FormatError{Message: er.Message}
-		}
-		errorMessages = append(errorMessages, er.Message)
 
+	if len(errorMessages) == 1 {
+		return nil, &FormatError{Message: errorMessages[0]}
 	}
-
 	if len(errorMessages) > 0 {
 		message := "multiple errors validating plan:\n- " + strings.Join(errorMessages, "\n- ")
 		return nil, &FormatError{Message: message}


### PR DESCRIPTION
This PR aims to improve error reporting by returning all validation errors at once when validating in `plan.CombineLayers.`

## Changes
- Removed early return statements in validation logic to allow for the collection of multiple errors.
- Stored multiple error messages in a slice, which is then used to form a unified FormatError.

## Rationale
Prior to this change, the function would exit early upon encountering the first error during validation. This was less user-friendly as it required multiple iterations to identify all the errors. With this PR, all errors are collated into a single message, thereby improving the debugging experience.

## Testing
Manually tested to confirm that all error conditions are caught and reported in one go.

Fixes #251