### PR TITLE
feat(state): add core support for Pebble Notices

### DIFF
--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -79,7 +79,15 @@ func (ovs *overlordSuite) TestNew(c *C) {
 }
 
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
-	fakeState := []byte(fmt.Sprintf(`{"data":{"patch-level":%d,"patch-sublevel":%d,"patch-sublevel-last-version":%q,"some":"data"},"changes":null,"tasks":null,"last-change-id":0,"last-task-id":0,"last-lane-id":0}`, patch.Level, patch.Sublevel, cmd.Version))
+	fakeState := []byte(fmt.Sprintf(`{
+		"data": {"patch-level": %d, "patch-sublevel": %d, "patch-sublevel-last-version": %q, "some": "data"},
+		"changes": null,
+		"tasks": null,
+		"last-change-id": 0,
+		"last-task-id": 0,
+		"last-lane-id": 0,
+		"last-notice-id": 0
+	}`, patch.Level, patch.Sublevel, cmd.Version))
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 

--- a/internals/overlord/state/export_test.go
+++ b/internals/overlord/state/export_test.go
@@ -73,3 +73,12 @@ var (
 	ErrNoWarningExpireAfter = errNoWarningExpireAfter
 	ErrNoWarningRepeatAfter = errNoWarningRepeatAfter
 )
+
+func (s *State) AddNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) {
+	s.addNoticeWithTime(now, noticeType, key, data, repeatAfter)
+}
+
+// Return total number of notices, including expired ones that haven't yet been pruned.
+func (s *State) NumNotices() int {
+	return len(s.notices)
+}

--- a/internals/overlord/state/export_test.go
+++ b/internals/overlord/state/export_test.go
@@ -74,10 +74,6 @@ var (
 	ErrNoWarningRepeatAfter = errNoWarningRepeatAfter
 )
 
-func (s *State) AddNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) string {
-	return s.addNoticeWithTime(now, noticeType, key, data, repeatAfter)
-}
-
 // NumNotices returns the total number of notices, including expired ones that
 // haven't yet been pruned.
 func (s *State) NumNotices() int {

--- a/internals/overlord/state/export_test.go
+++ b/internals/overlord/state/export_test.go
@@ -78,7 +78,8 @@ func (s *State) AddNoticeWithTime(now time.Time, noticeType NoticeType, key stri
 	return s.addNoticeWithTime(now, noticeType, key, data, repeatAfter)
 }
 
-// Return total number of notices, including expired ones that haven't yet been pruned.
+// NumNotices returns the total number of notices, including expired ones that
+// haven't yet been pruned.
 func (s *State) NumNotices() int {
 	return len(s.notices)
 }

--- a/internals/overlord/state/export_test.go
+++ b/internals/overlord/state/export_test.go
@@ -74,8 +74,8 @@ var (
 	ErrNoWarningRepeatAfter = errNoWarningRepeatAfter
 )
 
-func (s *State) AddNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) {
-	s.addNoticeWithTime(now, noticeType, key, data, repeatAfter)
+func (s *State) AddNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) string {
+	return s.addNoticeWithTime(now, noticeType, key, data, repeatAfter)
 }
 
 // Return total number of notices, including expired ones that haven't yet been pruned.

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -326,8 +326,8 @@ func (s *State) unflattenNotices(flat []*Notice) {
 // out or is cancelled. If there are existing notices that match the
 // filters, WaitNotices will return them immediately.
 func (s *State) WaitNotices(ctx context.Context, filters NoticeFilters) ([]*Notice, error) {
-	// State is already locked here by the caller, so notices won't be being
-	// added concurrently.
+	// State is already locked here by the caller, so notices won't be added
+	// concurrently.
 	notices := s.Notices(filters)
 	if len(notices) > 0 {
 		return notices, nil // if there are existing notices, return them right away

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -26,9 +26,6 @@ import (
 )
 
 const (
-	// MaxNoticeKeyLength is the maximum key length for notices, in bytes.
-	MaxNoticeKeyLength = 255
-
 	// NoticeExpireAfter is the expiry time for notices.
 	//
 	// Note that the expiry time for snapd warnings is 28 days, but a shorter
@@ -200,8 +197,8 @@ func (s *State) AddNotice(noticeType NoticeType, key string, data map[string]str
 }
 
 func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) string {
-	if noticeType == "" || key == "" || len(key) > MaxNoticeKeyLength {
-		// Programming error (max key length has already been checked by API)
+	if noticeType == "" || key == "" {
+		// Programming error
 		logger.Panicf("Internal error, please report: attempted to add invalid notice (type %q, key %q)",
 			noticeType, key)
 	}

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -196,9 +196,9 @@ func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key stri
 	notice, ok := s.notices[uniqueKey]
 	if !ok {
 		// First occurrence of this notice type+key
-		s.noticeId++
+		s.lastNoticeId++
 		notice = &Notice{
-			id:            strconv.Itoa(s.noticeId),
+			id:            strconv.Itoa(s.lastNoticeId),
 			noticeType:    noticeType,
 			key:           key,
 			firstOccurred: now,
@@ -299,24 +299,13 @@ func (s *State) flattenNotices(filters NoticeFilters) []*Notice {
 func (s *State) unflattenNotices(flat []*Notice) {
 	now := time.Now()
 	s.notices = make(map[string]*Notice)
-	maxNoticeId := 0
 	for _, n := range flat {
 		if n.expired(now) {
 			continue
 		}
 		uniqueKey := uniqueNoticeKey(n.noticeType, n.key)
 		s.notices[uniqueKey] = n
-
-		// Evaluate the highest ID and start noticeId state from there.
-		noticeId, err := strconv.Atoi(n.id)
-		if err != nil {
-			logger.Panicf("Internal error: invalid notice ID %q: %v", n.id, err)
-		}
-		if noticeId > maxNoticeId {
-			maxNoticeId = noticeId
-		}
 	}
-	s.noticeId = maxNoticeId
 }
 
 // WaitNotices waits for notices that match the filters to exist or occur,

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -76,11 +76,10 @@ type Notice struct {
 	// Additional data captured from the last occurrence of one of these notices.
 	lastData map[string]string
 
-	// How much time after one of these was last repeated should we allow it
-	// to repeat.
+	// How long after one of these was last repeated should we allow it to repeat.
 	repeatAfter time.Duration
 
-	// How much time since one of these last occurred should we drop the notice.
+	// How long since one of these last occurred until we should drop the notice.
 	expireAfter time.Duration
 }
 

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/canonical/pebble/internals/logger"
+)
+
+const (
+	MaxNoticeKeyLength = 255
+
+	noticeExpireAfter = 7 * 24 * time.Hour
+)
+
+// Notice represents an aggregated notice. The combination of type and key is unique.
+type Notice struct {
+	// Server-generated unique ID for this notice (a surrogate key). Users
+	// shouldn't rely on this, but this will be a monotonically increasing
+	// number (like change ID).
+	id string
+
+	// The notice's type.
+	noticeType NoticeType
+
+	// The notice key: a string that must be unique for this notice type.
+	// For example, for the "change-update" notice, the key is the change ID.
+	// For a warning, the key would be the warning message.
+	//
+	// This is limited to a maximum of 255 bytes when added (it's an error
+	// to add a notice with a longer key).
+	key string
+
+	// The first time one of these notices (type and key combination) occurred.
+	firstOccurred time.Time
+
+	// The last time one of these notices occurred.
+	lastOccurred time.Time
+
+	// Same as lastOccurred when the notice was last repeated. Only updated
+	// once lastOccurred > lastRepeated + repeatAfter.
+	lastRepeated time.Time
+
+	// The number of times one of these notices has occurred.
+	occurrences int
+
+	// Additional data for the last occurrence of this type and key combination.
+	lastData map[string]string
+
+	// How much time after one of these last occurred should we allow it to repeat.
+	repeatAfter time.Duration
+
+	// How much time since one of these last occurred should we drop the notice.
+	expireAfter time.Duration
+}
+
+func (n *Notice) String() string {
+	return fmt.Sprintf("Notice %s (%s:%s)", n.id, n.noticeType, n.key)
+}
+
+// expired reports whether this notice has expired (relative to the given "now").
+func (n *Notice) expired(now time.Time) bool {
+	return n.lastOccurred.Add(n.expireAfter).Before(now)
+}
+
+// jsonNotice exists so we can control how a Notice is marshalled to JSON. It
+// needs to live in this package (rather than the API) because we save state
+// to disk as JSON.
+type jsonNotice struct {
+	ID            string            `json:"id"`
+	Type          string            `json:"type"`
+	Key           string            `json:"key"`
+	FirstOccurred time.Time         `json:"first-occurred"`
+	LastOccurred  time.Time         `json:"last-occurred"`
+	LastRepeated  time.Time         `json:"last-repeated"`
+	Occurrences   int               `json:"occurrences"`
+	LastData      map[string]string `json:"last-data,omitempty"`
+	RepeatAfter   string            `json:"repeat-after,omitempty"`
+	ExpireAfter   string            `json:"expire-after,omitempty"`
+}
+
+func (n *Notice) MarshalJSON() ([]byte, error) {
+	jn := jsonNotice{
+		ID:            n.id,
+		Type:          string(n.noticeType),
+		Key:           n.key,
+		FirstOccurred: n.firstOccurred,
+		LastOccurred:  n.lastOccurred,
+		LastRepeated:  n.lastRepeated,
+		Occurrences:   n.occurrences,
+		LastData:      n.lastData,
+	}
+	if n.repeatAfter != 0 {
+		jn.RepeatAfter = n.repeatAfter.String()
+	}
+	if n.expireAfter != 0 {
+		jn.ExpireAfter = n.expireAfter.String()
+	}
+	return json.Marshal(jn)
+}
+
+func (n *Notice) UnmarshalJSON(data []byte) error {
+	var jn jsonNotice
+	err := json.Unmarshal(data, &jn)
+	if err != nil {
+		return err
+	}
+	n.id = jn.ID
+	n.noticeType = NoticeType(jn.Type)
+	n.key = jn.Key
+	n.firstOccurred = jn.FirstOccurred
+	n.lastOccurred = jn.LastOccurred
+	n.lastRepeated = jn.LastRepeated
+	n.occurrences = jn.Occurrences
+	n.lastData = jn.LastData
+	if jn.RepeatAfter != "" {
+		n.repeatAfter, err = time.ParseDuration(jn.RepeatAfter)
+		if err != nil {
+			return fmt.Errorf("invalid repeat-after duration: %w", err)
+		}
+	}
+	if jn.ExpireAfter != "" {
+		n.expireAfter, err = time.ParseDuration(jn.ExpireAfter)
+		if err != nil {
+			return fmt.Errorf("invalid expire-after duration: %w", err)
+		}
+	}
+	return nil
+}
+
+type NoticeType string
+
+const (
+	// Recorded whenever a change is updated: when it is first spawned or its
+	// status was updated.
+	NoticeChangeUpdate NoticeType = "change-update"
+
+	// A client notice reported via the Pebble client API or "pebble notify".
+	// The key and data fields are provided by the user. The key must be in
+	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.
+	NoticeClient NoticeType = "client"
+
+	// Warnings are a subset of notices where the key is a human-readable
+	// warning message.
+	NoticeWarning NoticeType = "warning"
+)
+
+// NoticeTypeFromString validates the given string and returns the NoticeType,
+// or empty string if it's not valid.
+func NoticeTypeFromString(s string) NoticeType {
+	noticeType := NoticeType(s)
+	switch noticeType {
+	case NoticeChangeUpdate, NoticeClient, NoticeWarning:
+		return noticeType
+	default:
+		return ""
+	}
+}
+
+// AddNotice adds an occurrence of a notice with the specified type and key
+// and key-value data.
+func (s *State) AddNotice(noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) {
+	s.addNoticeWithTime(time.Now(), noticeType, key, data, repeatAfter)
+}
+
+func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) {
+	if noticeType == "" || key == "" || len(key) > MaxNoticeKeyLength {
+		// Programming error (max key length has already been checked by API)
+		logger.Panicf("Internal error, please report: attempted to add invalid notice (type %q, key %q)",
+			noticeType, key)
+	}
+
+	s.writing()
+
+	now = now.UTC()
+	newOrRepeated := false
+	uniqueKey := uniqueNoticeKey(noticeType, key)
+	notice, ok := s.notices[uniqueKey]
+	if !ok {
+		// First occurrence of this notice type+key
+		s.noticeId++
+		notice = &Notice{
+			id:            strconv.Itoa(s.noticeId),
+			noticeType:    noticeType,
+			key:           key,
+			firstOccurred: now,
+			lastRepeated:  now,
+			repeatAfter:   repeatAfter,
+			expireAfter:   noticeExpireAfter,
+			occurrences:   1,
+		}
+		s.notices[uniqueKey] = notice
+		newOrRepeated = true
+	} else {
+		// Additional occurrence, update existing notice
+		notice.occurrences++
+		if repeatAfter != 0 && now.After(notice.lastRepeated.Add(repeatAfter)) {
+			// Update last repeated time if repeat-after time has elapsed
+			notice.lastRepeated = now
+			newOrRepeated = true
+		}
+	}
+	notice.lastOccurred = now
+	notice.lastData = data
+	notice.repeatAfter = repeatAfter
+
+	if newOrRepeated {
+		s.processNoticeWaiters()
+	}
+}
+
+func uniqueNoticeKey(noticeType NoticeType, key string) string {
+	return string(noticeType) + ":" + key
+}
+
+// NoticeFilters allows filter notices by various fields.
+type NoticeFilters struct {
+	// Type, if set, includes only notices of this type.
+	Type NoticeType
+	// Key, if set, includes only notices with this key.
+	Key string
+	// After, if set, includes only notices that were last repeated after this time.
+	After time.Time
+}
+
+// matches reports whether the notice n matches these filters
+func (f NoticeFilters) matches(n *Notice) bool {
+	if f.Type != "" && f.Type != n.noticeType {
+		return false
+	}
+	if f.Key != "" && f.Key != n.key {
+		return false
+	}
+	if !f.After.IsZero() && !n.lastRepeated.After(f.After) {
+		return false
+	}
+	return true
+}
+
+// Notices returns the list of notices that match the filters (if any),
+// ordered by the last-repeated time.
+func (s *State) Notices(filters NoticeFilters) []*Notice {
+	s.reading()
+
+	notices := s.flattenNotices(filters)
+	sort.Slice(notices, func(i, j int) bool {
+		return notices[i].lastRepeated.Before(notices[j].lastRepeated)
+	})
+	return notices
+}
+
+// Notice return a single notice by ID, or nil if not found.
+func (s *State) Notice(id string) *Notice {
+	s.reading()
+
+	// Could use another map for lookup, but the number of notices will likely
+	// be small, and this function is probably only used rarely by the CLI, so
+	// performance is unlikely to matter.
+	for _, notice := range s.notices {
+		if notice.id == id {
+			return notice
+		}
+	}
+	return nil
+}
+
+func (s *State) flattenNotices(filters NoticeFilters) []*Notice {
+	now := time.Now()
+	var notices []*Notice
+	for _, n := range s.notices {
+		if n.expired(now) || !filters.matches(n) {
+			continue
+		}
+		notices = append(notices, n)
+	}
+	return notices
+}
+
+func (s *State) unflattenNotices(flat []*Notice) {
+	now := time.Now()
+	s.notices = make(map[string]*Notice)
+	maxNoticeId := 0
+	for _, n := range flat {
+		if n.expired(now) {
+			continue
+		}
+		uniqueKey := uniqueNoticeKey(n.noticeType, n.key)
+		s.notices[uniqueKey] = n
+
+		// Evaluate the highest ID and start noticeId state from there.
+		noticeId, err := strconv.Atoi(n.id)
+		if err != nil {
+			logger.Panicf("Internal error: invalid notice ID %q: %v", n.id, err)
+		}
+		if noticeId > maxNoticeId {
+			maxNoticeId = noticeId
+		}
+	}
+	s.noticeId = maxNoticeId
+}
+
+// WaitNotices waits for notices that match the filters to exist or occur,
+// returning the list of matching notices ordered by the last-repeated time.
+//
+// It waits till there is at least one matching notice or the context times
+// out or is cancelled. If there are existing notices that match the
+// filters, WaitNotices will return them immediately.
+func (s *State) WaitNotices(ctx context.Context, filters NoticeFilters) ([]*Notice, error) {
+	// State is already locked here by the caller, so notices won't be being
+	// added concurrently.
+	notices := s.Notices(filters)
+	if len(notices) > 0 {
+		return notices, nil // if there are existing notices, return them right away
+	}
+
+	// Add a waiter channel for AddNotice to send to when matching notices arrive.
+	ch, waiterId := s.addNoticeWaiter(filters, ctx.Done())
+	defer s.removeNoticeWaiter(waiterId) // state will be re-locked when this is called
+
+	// Unlock state while waiting, to allow new notices to arrive (all state
+	// methods expect the caller to have locked the state before the call).
+	s.Unlock()
+	defer s.Lock()
+
+	select {
+	case notices = <-ch:
+		// One or more new notices arrived
+		return notices, nil
+	case <-ctx.Done(): // sender (processNoticeWaiters) also waits on this done channel
+		return nil, ctx.Err()
+	}
+}
+
+// noticeWaiter tracks a single WaitNotices call.
+type noticeWaiter struct {
+	filters NoticeFilters
+	ch      chan []*Notice
+	done    <-chan struct{}
+}
+
+// addNoticeWaiter adds a notice-waiter with the given filters. Processing
+// notices for this waiter stops when the done channel is closed.
+func (s *State) addNoticeWaiter(filters NoticeFilters, done <-chan struct{}) (ch chan []*Notice, waiterId int) {
+	s.noticeWaiterId++
+	waiter := noticeWaiter{
+		filters: filters,
+		ch:      make(chan []*Notice),
+		done:    done,
+	}
+	s.noticeWaiters[s.noticeWaiterId] = waiter
+	return waiter.ch, s.noticeWaiterId
+}
+
+// removeNoticeWaiter removes the notice-waiter with the given ID.
+func (s *State) removeNoticeWaiter(waiterId int) {
+	delete(s.noticeWaiters, waiterId)
+}
+
+// processNoticeWaiters loops through the list of notice-waiters, and wakes up
+// and sends to any that match the filters.
+func (s *State) processNoticeWaiters() {
+	for waiterId, waiter := range s.noticeWaiters {
+		notices := s.Notices(waiter.filters)
+		if len(notices) == 0 {
+			continue // no notices with these filters
+		}
+		select {
+		case waiter.ch <- notices:
+			// Got matching notices, send them to related WaitNotices.
+			// And remove the waiter so we don't try to send to its channel again
+			// if another notice comes in.
+			s.removeNoticeWaiter(waiterId)
+		case <-waiter.done:
+			// Will happen if WaitNotices times out (it also waits on this done channel)
+		}
+	}
+}

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -29,9 +29,12 @@ const (
 	// MaxNoticeKeyLength is the maximum key length for notices, in bytes.
 	MaxNoticeKeyLength = 255
 
-	// Expiry time for notices. Note that the expiry time for snapd warnings
-	// is 28 days, but a shorter time for Pebble notices seems appropriate.
-	noticeExpireAfter = 7 * 24 * time.Hour
+	// NoticeExpireAfter is the expiry time for notices.
+	//
+	// Note that the expiry time for snapd warnings is 28 days, but a shorter
+	// time for Pebble notices seems appropriate, as they're intended more for
+	// machine consumption.
+	NoticeExpireAfter = 7 * 24 * time.Hour
 )
 
 // Notice represents an aggregated notice. The combination of type and key is unique.
@@ -44,7 +47,7 @@ type Notice struct {
 
 	// The notice type represents a group of notices originating from a common
 	// source. For example, notices originating from the CLI client have type
-	// "client".
+	// "custom".
 	noticeType NoticeType
 
 	// The notice key is a string that differentiates notices of this type.
@@ -80,6 +83,9 @@ type Notice struct {
 	repeatAfter time.Duration
 
 	// How long since one of these last occurred until we should drop the notice.
+	//
+	// The repeatAfter duration must be less than this, because the notice
+	// won't be tracked after it expires.
 	expireAfter time.Duration
 }
 
@@ -164,10 +170,10 @@ const (
 	// status was updated. The key for change-update notices is the change ID.
 	NoticeChangeUpdate NoticeType = "change-update"
 
-	// A client notice reported via the Pebble client API or "pebble notify".
+	// A custom notice reported via the Pebble client API or "pebble notify".
 	// The key and data fields are provided by the user. The key must be in
 	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.
-	NoticeClient NoticeType = "client"
+	NoticeCustom NoticeType = "custom"
 
 	// Warnings are a subset of notices where the key is a human-readable
 	// warning message.
@@ -179,7 +185,7 @@ const (
 func NoticeTypeFromString(s string) NoticeType {
 	noticeType := NoticeType(s)
 	switch noticeType {
-	case NoticeChangeUpdate, NoticeClient, NoticeWarning:
+	case NoticeChangeUpdate, NoticeCustom, NoticeWarning:
 		return noticeType
 	default:
 		return ""
@@ -187,11 +193,8 @@ func NoticeTypeFromString(s string) NoticeType {
 }
 
 // AddNotice records an occurrence of a notice with the specified type and key
-// and key-value data, returning the notice ID.
-//
-// The notice's repeatAfter time is set on the first occurrence; a value of
-// zero means "never repeat". It is only updated on subsequent occurrences if
-// the repeatAfter argument is nonzero.
+// and key-value data, returning the notice ID. A repeatAfter time of zero
+// means "always repeat".
 func (s *State) AddNotice(noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) string {
 	return s.addNoticeWithTime(time.Now(), noticeType, key, data, repeatAfter)
 }
@@ -218,8 +221,7 @@ func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key stri
 			key:           key,
 			firstOccurred: now,
 			lastRepeated:  now,
-			repeatAfter:   repeatAfter,
-			expireAfter:   noticeExpireAfter,
+			expireAfter:   NoticeExpireAfter,
 			occurrences:   1,
 		}
 		s.notices[uniqueKey] = notice
@@ -227,17 +229,15 @@ func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key stri
 	} else {
 		// Additional occurrence, update existing notice
 		notice.occurrences++
-		if repeatAfter != 0 {
-			notice.repeatAfter = repeatAfter
-		}
-		if notice.repeatAfter != 0 && now.After(notice.lastRepeated.Add(notice.repeatAfter)) {
-			// Update last repeated time if repeat-after time has elapsed
+		if repeatAfter == 0 || now.After(notice.lastRepeated.Add(repeatAfter)) {
+			// Update last repeated time if repeat-after time has elapsed (or is zero)
 			notice.lastRepeated = now
 			newOrRepeated = true
 		}
 	}
 	notice.lastOccurred = now
 	notice.lastData = data
+	notice.repeatAfter = repeatAfter
 
 	if newOrRepeated {
 		s.processNoticeWaiters()
@@ -250,28 +250,40 @@ func uniqueNoticeKey(noticeType NoticeType, key string) string {
 	return string(noticeType) + ":" + key
 }
 
-// NoticeFilters allows filter notices by various fields.
+// NoticeFilters allows filtering notices by various fields.
 type NoticeFilters struct {
-	// Type, if set, includes only notices of this type.
-	Type NoticeType
-	// Key, if set, includes only notices with this key.
-	Key string
+	// Types, if not empty, includes only notices whose type is one of these.
+	Types []NoticeType
+
+	// Keys, if not empty, includes only notices whose key is one of these.
+	Keys []string
+
 	// After, if set, includes only notices that were last repeated after this time.
 	After time.Time
 }
 
 // matches reports whether the notice n matches these filters
 func (f NoticeFilters) matches(n *Notice) bool {
-	if f.Type != "" && f.Type != n.noticeType {
+	// Can't use strutil.ListContains as Types is []NoticeType, not []string
+	if len(f.Types) > 0 && !sliceContains(f.Types, n.noticeType) {
 		return false
 	}
-	if f.Key != "" && f.Key != n.key {
+	if len(f.Keys) > 0 && !sliceContains(f.Keys, n.key) {
 		return false
 	}
 	if !f.After.IsZero() && !n.lastRepeated.After(f.After) {
 		return false
 	}
 	return true
+}
+
+func sliceContains[T comparable](haystack []T, needle T) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // Notices returns the list of notices that match the filters (if any),

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -176,12 +176,12 @@ func NoticeTypeFromString(s string) NoticeType {
 }
 
 // AddNotice adds an occurrence of a notice with the specified type and key
-// and key-value data.
-func (s *State) AddNotice(noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) {
-	s.addNoticeWithTime(time.Now(), noticeType, key, data, repeatAfter)
+// and key-value data, returning the notice ID.
+func (s *State) AddNotice(noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) string {
+	return s.addNoticeWithTime(time.Now(), noticeType, key, data, repeatAfter)
 }
 
-func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) {
+func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key string, data map[string]string, repeatAfter time.Duration) string {
 	if noticeType == "" || key == "" || len(key) > MaxNoticeKeyLength {
 		// Programming error (max key length has already been checked by API)
 		logger.Panicf("Internal error, please report: attempted to add invalid notice (type %q, key %q)",
@@ -225,6 +225,8 @@ func (s *State) addNoticeWithTime(now time.Time, noticeType NoticeType, key stri
 	if newOrRepeated {
 		s.processNoticeWaiters()
 	}
+
+	return notice.id
 }
 
 func uniqueNoticeKey(noticeType NoticeType, key string) string {

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -119,11 +119,11 @@ func (s *noticesSuite) TestOccurrences(c *C) {
 	notices := st.Notices(state.NoticeFilters{})
 	c.Assert(notices, HasLen, 2)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["id"], Equals, "1")
-	c.Assert(n["occurrences"], Equals, 3.0)
+	c.Check(n["id"], Equals, "1")
+	c.Check(n["occurrences"], Equals, 3.0)
 	n = noticeToMap(c, notices[1])
-	c.Assert(n["id"], Equals, "2")
-	c.Assert(n["occurrences"], Equals, 1.0)
+	c.Check(n["id"], Equals, "2")
+	c.Check(n["occurrences"], Equals, 1.0)
 }
 
 func (s *noticesSuite) TestRepeatAfter(c *C) {
@@ -173,11 +173,11 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	notices := st.Notices(state.NoticeFilters{Type: state.NoticeWarning})
 	c.Assert(notices, HasLen, 2)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["type"].(string), Equals, "warning")
-	c.Assert(n["key"].(string), Equals, "Warning 1!")
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "Warning 1!")
 	n = noticeToMap(c, notices[1])
-	c.Assert(n["type"].(string), Equals, "warning")
-	c.Assert(n["key"].(string), Equals, "Warning 2!")
+	c.Check(n["type"], Equals, "warning")
+	c.Check(n["key"], Equals, "Warning 2!")
 }
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
@@ -192,8 +192,8 @@ func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 	notices := st.Notices(state.NoticeFilters{Key: "example.com/x"})
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["type"].(string), Equals, "client")
-	c.Assert(n["key"].(string), Equals, "example.com/x")
+	c.Check(n["type"], Equals, "client")
+	c.Check(n["key"], Equals, "example.com/x")
 }
 
 func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
@@ -214,8 +214,8 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 	notices = st.Notices(state.NoticeFilters{After: lastRepeated})
 	c.Assert(notices, HasLen, 1)
 	n = noticeToMap(c, notices[0])
-	c.Assert(n["type"].(string), Equals, "client")
-	c.Assert(n["key"].(string), Equals, "foo.com/y")
+	c.Check(n["type"], Equals, "client")
+	c.Check(n["key"], Equals, "foo.com/y")
 }
 
 func (s *noticesSuite) TestNotice(c *C) {
@@ -232,13 +232,14 @@ func (s *noticesSuite) TestNotice(c *C) {
 	notices := st.Notices(state.NoticeFilters{})
 	c.Assert(notices, HasLen, 3)
 	n := noticeToMap(c, notices[1])
-	noticeId := n["id"].(string)
+	noticeId, ok := n["id"].(string)
+	c.Assert(ok, Equals, true)
 
 	notice := st.Notice(noticeId)
 	c.Assert(notice, NotNil)
 	n = noticeToMap(c, notice)
-	c.Assert(n["type"].(string), Equals, "client")
-	c.Assert(n["key"].(string), Equals, "foo.com/y")
+	c.Check(n["type"], Equals, "client")
+	c.Check(n["key"], Equals, "foo.com/y")
 }
 
 func (s *noticesSuite) TestEmptyState(c *C) {
@@ -266,8 +267,8 @@ func (s *noticesSuite) TestCheckpoint(c *C) {
 	notices := st2.Notices(state.NoticeFilters{})
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["type"], Equals, "client")
-	c.Assert(n["key"], Equals, "foo.com/bar")
+	c.Check(n["type"], Equals, "client")
+	c.Check(n["key"], Equals, "foo.com/bar")
 }
 
 func (s *noticesSuite) TestDeleteExpired(c *C) {
@@ -309,8 +310,8 @@ func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["type"].(string), Equals, "client")
-	c.Assert(n["key"].(string), Equals, "example.com/x")
+	c.Check(n["type"], Equals, "client")
+	c.Check(n["key"], Equals, "example.com/x")
 }
 
 func (s *noticesSuite) TestWaitNoticesNew(c *C) {
@@ -332,7 +333,7 @@ func (s *noticesSuite) TestWaitNoticesNew(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["key"].(string), Equals, "example.com/y")
+	c.Assert(n["key"], Equals, "example.com/y")
 }
 
 func (s *noticesSuite) TestWaitNoticesTimeout(c *C) {
@@ -395,7 +396,7 @@ func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(notices, HasLen, 1)
 			n := noticeToMap(c, notices[0])
-			c.Assert(n["key"].(string), Equals, key)
+			c.Assert(n["key"], Equals, key)
 		}(i)
 	}
 

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -1,0 +1,430 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/overlord/state"
+)
+
+type noticesSuite struct{}
+
+var _ = Suite(&noticesSuite{})
+
+func (s *noticesSuite) TestMarshal(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	start := time.Now()
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	st.AddNotice(state.NoticeClient, "foo.com/bar", map[string]string{"k": "v"}, 0)
+
+	notices := st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 1)
+
+	// Convert it to a map so we're not testing the JSON string directly
+	// (order of fields doesn't matter).
+	n := noticeToMap(c, notices[0])
+
+	firstOccurred, err := time.Parse(time.RFC3339, n["first-occurred"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(!firstOccurred.Before(start), Equals, true) // firstOccurred >= start
+	lastOccurred, err := time.Parse(time.RFC3339, n["last-occurred"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(lastOccurred.After(firstOccurred), Equals, true) // lastOccurred > firstOccurred
+	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(lastRepeated.Equal(firstOccurred), Equals, true) // lastRepeated == firstOccurred
+
+	delete(n, "first-occurred")
+	delete(n, "last-occurred")
+	delete(n, "last-repeated")
+	c.Assert(n, DeepEquals, map[string]any{
+		"id":           "1",
+		"type":         "client",
+		"key":          "foo.com/bar",
+		"occurrences":  2.0,
+		"last-data":    map[string]any{"k": "v"},
+		"expire-after": "168h0m0s",
+	})
+}
+
+func (s *noticesSuite) TestUnmarshal(c *C) {
+	noticeJSON := []byte(`{
+		"id": "1",
+		"type": "client",
+		"key": "foo.com/bar",
+		"first-occurred": "2023-09-01T05:23:01Z",
+		"last-occurred": "2023-09-01T07:23:02Z",
+		"last-repeated": "2023-09-01T06:23:03.123456789Z",
+		"occurrences": 2,
+		"last-data": {"k": "v"},
+		"repeat-after": "60m",
+		"expire-after": "168h0m0s"
+	}`)
+	var notice *state.Notice
+	err := json.Unmarshal(noticeJSON, &notice)
+	c.Assert(err, IsNil)
+
+	// The Notice fields aren't exported, so we need to marshal it into JSON
+	// and then unmarshal it into a map to test.
+	n := noticeToMap(c, notice)
+	c.Assert(n, DeepEquals, map[string]any{
+		"id":             "1",
+		"type":           "client",
+		"key":            "foo.com/bar",
+		"first-occurred": "2023-09-01T05:23:01Z",
+		"last-occurred":  "2023-09-01T07:23:02Z",
+		"last-repeated":  "2023-09-01T06:23:03.123456789Z",
+		"occurrences":    2.0,
+		"last-data":      map[string]any{"k": "v"},
+		"repeat-after":   "1h0m0s",
+		"expire-after":   "168h0m0s",
+	})
+}
+
+func (s *noticesSuite) TestOccurrences(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	time.Sleep(time.Microsecond)
+	st.AddNotice(state.NoticeChangeUpdate, "123", nil, 0)
+
+	notices := st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["id"], Equals, "1")
+	c.Assert(n["occurrences"], Equals, 3.0)
+	n = noticeToMap(c, notices[1])
+	c.Assert(n["id"], Equals, "2")
+	c.Assert(n["occurrences"], Equals, 1.0)
+}
+
+func (s *noticesSuite) TestRepeatAfter(c *C) {
+	const repeatAfter = 10 * time.Second
+
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, repeatAfter)
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, repeatAfter)
+
+	notices := st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	firstOccurred, err := time.Parse(time.RFC3339, n["first-occurred"].(string))
+	c.Assert(err, IsNil)
+	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+
+	// LastRepeated won't yet be updated as we only waited 1us (repeat-after is long)
+	c.Assert(lastRepeated.Equal(firstOccurred), Equals, true)
+
+	// Add a notice (with faked time) after a long time and ensure it has repeated
+	future := time.Now().Add(repeatAfter)
+	st.AddNoticeWithTime(future, state.NoticeClient, "foo.com/bar", nil, repeatAfter)
+	notices = st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 1)
+	n = noticeToMap(c, notices[0])
+	newLastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+	c.Assert(newLastRepeated.After(lastRepeated), Equals, true)
+}
+
+func (s *noticesSuite) TestNoticesFilterType(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	st.AddNotice(state.NoticeChangeUpdate, "123", nil, 0)
+	st.AddNotice(state.NoticeWarning, "Warning 1!", nil, 0)
+	time.Sleep(time.Microsecond)
+	st.AddNotice(state.NoticeWarning, "Warning 2!", nil, 0)
+
+	notices := st.Notices(state.NoticeFilters{Type: state.NoticeWarning})
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["type"].(string), Equals, "warning")
+	c.Assert(n["key"].(string), Equals, "Warning 1!")
+	n = noticeToMap(c, notices[1])
+	c.Assert(n["type"].(string), Equals, "warning")
+	c.Assert(n["key"].(string), Equals, "Warning 2!")
+}
+
+func (s *noticesSuite) TestNoticesFilterKey(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	st.AddNotice(state.NoticeClient, "example.com/x", nil, 0)
+	st.AddNotice(state.NoticeClient, "foo.com/baz", nil, 0)
+
+	notices := st.Notices(state.NoticeFilters{Key: "example.com/x"})
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["type"].(string), Equals, "client")
+	c.Assert(n["key"].(string), Equals, "example.com/x")
+}
+
+func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/x", nil, 0)
+	notices := st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+	c.Assert(err, IsNil)
+
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	st.AddNotice(state.NoticeClient, "foo.com/y", nil, 0)
+
+	notices = st.Notices(state.NoticeFilters{After: lastRepeated})
+	c.Assert(notices, HasLen, 1)
+	n = noticeToMap(c, notices[0])
+	c.Assert(n["type"].(string), Equals, "client")
+	c.Assert(n["key"].(string), Equals, "foo.com/y")
+}
+
+func (s *noticesSuite) TestNotice(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/x", nil, 0)
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	st.AddNotice(state.NoticeClient, "foo.com/y", nil, 0)
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	st.AddNotice(state.NoticeClient, "foo.com/z", nil, 0)
+
+	notices := st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 3)
+	n := noticeToMap(c, notices[1])
+	noticeId := n["id"].(string)
+
+	notice := st.Notice(noticeId)
+	c.Assert(notice, NotNil)
+	n = noticeToMap(c, notice)
+	c.Assert(n["type"].(string), Equals, "client")
+	c.Assert(n["key"].(string), Equals, "foo.com/y")
+}
+
+func (s *noticesSuite) TestEmptyState(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	notices := st.Notices(state.NoticeFilters{})
+	c.Check(notices, HasLen, 0)
+}
+
+func (s *noticesSuite) TestCheckpoint(c *C) {
+	backend := &fakeStateBackend{}
+	st := state.New(backend)
+	st.Lock()
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	st.Unlock()
+	c.Assert(backend.checkpoints, HasLen, 1)
+
+	st2, err := state.ReadState(nil, bytes.NewReader(backend.checkpoints[0]))
+	c.Assert(err, IsNil)
+	st2.Lock()
+	defer st2.Unlock()
+
+	notices := st2.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["type"], Equals, "client")
+	c.Assert(n["key"], Equals, "foo.com/bar")
+}
+
+func (s *noticesSuite) TestDeleteExpired(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	old := time.Now().Add(-8 * 24 * time.Hour)
+	st.AddNoticeWithTime(old, state.NoticeClient, "foo.com/w", nil, 0)
+	st.AddNoticeWithTime(old, state.NoticeClient, "foo.com/x", nil, 0)
+	st.AddNotice(state.NoticeClient, "foo.com/y", nil, 0)
+	time.Sleep(time.Microsecond) // ensure there's time between the occurrences
+	st.AddNotice(state.NoticeClient, "foo.com/z", nil, 0)
+
+	c.Assert(st.NumNotices(), Equals, 4)
+	st.Prune(0, 0, 0)
+	c.Assert(st.NumNotices(), Equals, 2)
+
+	notices := st.Notices(state.NoticeFilters{})
+	c.Assert(notices, HasLen, 2)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["key"], Equals, "foo.com/y")
+	n = noticeToMap(c, notices[1])
+	c.Assert(n["key"], Equals, "foo.com/z")
+}
+
+func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	st.AddNotice(state.NoticeClient, "foo.com/bar", nil, 0)
+	st.AddNotice(state.NoticeClient, "example.com/x", nil, 0)
+	st.AddNotice(state.NoticeClient, "foo.com/baz", nil, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	notices, err := st.WaitNotices(ctx, state.NoticeFilters{Key: "example.com/x"})
+	c.Assert(err, IsNil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["type"].(string), Equals, "client")
+	c.Assert(n["key"].(string), Equals, "example.com/x")
+}
+
+func (s *noticesSuite) TestWaitNoticesNew(c *C) {
+	st := state.New(nil)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		st.Lock()
+		defer st.Unlock()
+		st.AddNotice(state.NoticeClient, "example.com/x", nil, 0)
+		st.AddNotice(state.NoticeClient, "example.com/y", nil, 0)
+	}()
+
+	st.Lock()
+	defer st.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	notices, err := st.WaitNotices(ctx, state.NoticeFilters{Key: "example.com/y"})
+	c.Assert(err, IsNil)
+	c.Assert(notices, HasLen, 1)
+	n := noticeToMap(c, notices[0])
+	c.Assert(n["key"].(string), Equals, "example.com/y")
+}
+
+func (s *noticesSuite) TestWaitNoticesTimeout(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	notices, err := st.WaitNotices(ctx, state.NoticeFilters{})
+	c.Assert(err, ErrorMatches, "context deadline exceeded")
+	c.Assert(notices, HasLen, 0)
+}
+
+func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			st.Lock()
+			st.AddNotice(state.NoticeClient, fmt.Sprintf("a.b/%d", i), nil, 0)
+			st.Unlock()
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var after time.Time
+	for total := 0; total < 10; {
+		notices, err := st.WaitNotices(ctx, state.NoticeFilters{After: after})
+		c.Assert(err, IsNil)
+		c.Assert(len(notices) > 0, Equals, true)
+		total += len(notices)
+		n := noticeToMap(c, notices[len(notices)-1])
+		lastRepeated, err := time.Parse(time.RFC3339, n["last-repeated"].(string))
+		c.Assert(err, IsNil)
+		after = lastRepeated
+	}
+}
+
+func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
+	const numWaiters = 100
+
+	st := state.New(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numWaiters; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			st.Lock()
+			defer st.Unlock()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			key := fmt.Sprintf("a.b/%d", i)
+			notices, err := st.WaitNotices(ctx, state.NoticeFilters{Key: key})
+			c.Assert(err, IsNil)
+			c.Assert(notices, HasLen, 1)
+			n := noticeToMap(c, notices[0])
+			c.Assert(n["key"].(string), Equals, key)
+		}(i)
+	}
+
+	for i := 0; i < numWaiters; i++ {
+		st.Lock()
+		st.AddNotice(state.NoticeClient, fmt.Sprintf("a.b/%d", i), nil, 0)
+		st.Unlock()
+		time.Sleep(time.Microsecond)
+	}
+
+	// Wait for WaitNotice goroutines to finish
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		done <- struct{}{}
+	}()
+	select {
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for WaitNotice goroutines to finish")
+	case <-done:
+	}
+}
+
+// noticeToMap converts a Notice to a map using a JSON marshal-unmarshal round trip.
+func noticeToMap(c *C, notice *state.Notice) map[string]any {
+	buf, err := json.Marshal(notice)
+	c.Assert(err, IsNil)
+	var n map[string]any
+	err = json.Unmarshal(buf, &n)
+	c.Assert(err, IsNil)
+	return n
+}

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -87,6 +87,7 @@ type State struct {
 	lastTaskId   int
 	lastChangeId int
 	lastLaneId   int
+	lastNoticeId int
 
 	backend  Backend
 	data     customData
@@ -94,7 +95,6 @@ type State struct {
 	tasks    map[string]*Task
 	warnings map[string]*Warning
 	notices  map[string]*Notice
-	noticeId int
 
 	noticeWaiters  map[int]noticeWaiter
 	noticeWaiterId int
@@ -158,6 +158,7 @@ type marshalledState struct {
 	LastChangeId int `json:"last-change-id"`
 	LastTaskId   int `json:"last-task-id"`
 	LastLaneId   int `json:"last-lane-id"`
+	LastNoticeId int `json:"last-notice-id"`
 }
 
 // MarshalJSON makes State a json.Marshaller
@@ -173,6 +174,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		LastTaskId:   s.lastTaskId,
 		LastChangeId: s.lastChangeId,
 		LastLaneId:   s.lastLaneId,
+		LastNoticeId: s.lastNoticeId,
 	})
 }
 
@@ -192,6 +194,7 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	s.lastChangeId = unmarshalled.LastChangeId
 	s.lastTaskId = unmarshalled.LastTaskId
 	s.lastLaneId = unmarshalled.LastLaneId
+	s.lastNoticeId = unmarshalled.LastNoticeId
 	// backlink state again
 	for _, t := range s.tasks {
 		t.state = s

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -94,7 +94,7 @@ type State struct {
 	changes  map[string]*Change
 	tasks    map[string]*Task
 	warnings map[string]*Warning
-	notices  map[string]*Notice
+	notices  map[noticeKey]*Notice
 
 	noticeWaiters  map[int]noticeWaiter
 	noticeWaiterId int
@@ -112,7 +112,7 @@ func New(backend Backend) *State {
 		changes:       make(map[string]*Change),
 		tasks:         make(map[string]*Task),
 		warnings:      make(map[string]*Warning),
-		notices:       make(map[string]*Notice),
+		notices:       make(map[noticeKey]*Notice),
 		noticeWaiters: make(map[int]noticeWaiter),
 		modified:      true,
 		cache:         make(map[interface{}]interface{}),
@@ -169,7 +169,7 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		Changes:  s.changes,
 		Tasks:    s.tasks,
 		Warnings: s.flattenWarnings(),
-		Notices:  s.flattenNotices(NoticeFilters{}),
+		Notices:  s.flattenNotices(nil),
 
 		LastTaskId:   s.lastTaskId,
 		LastChangeId: s.lastChangeId,


### PR DESCRIPTION
This implements the core state aspects of Pebble Notices -- spec [JU048](https://docs.google.com/document/d/16PJ85fefalQd7JbWSxkRWn0Ye-Hs8S1yE99eW7pk8fA/edit).

The key user-visible methods are `State.AddNotice` to add a new notices, `State.Notices` and `State.Notice` to fetch and filter existing notices, and `State.WaitNotices` to wait (or long-poll) for notices as they occur.

The follow-on changes are in separate PRs for easier review:

* The notices API: `/v1/notices` and `/v1/notices/{id}` -- #296
* The Go client for notices -- #297 
* The CLI: `pebble notices`, `pebble notice`, and `pebble notify`) -- #298 
* Recording `change-update` notices whenever a change is spawned/updated - TODO
* Using notices to implement warnings (notices are basically a superset of warnings) - TODO
