### PR TITLE
feat: add "health" command

### DIFF
--- a/client/health.go
+++ b/client/health.go
@@ -27,7 +27,6 @@ type HealthOptions struct {
 	Names []string
 }
 
-// healthInfo holds the result of a Health call.
 type healthInfo struct {
 	Healthy bool `json:"healthy"`
 }

--- a/client/health.go
+++ b/client/health.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client
+
+import "net/url"
+
+type HealthOptions ChecksOptions
+
+// HealthInfo holds health information for a single health check.
+type HealthInfo struct {
+	// Healthy is the status of health.
+	Healthy bool `json:"healthy"`
+}
+
+// Health fetches healthy status of specified checks.
+func (client *Client) Health(opts *HealthOptions) (*HealthInfo, error) {
+	query := make(url.Values)
+	if opts.Level != UnsetLevel {
+		query.Set("level", string(opts.Level))
+	}
+	if len(opts.Names) > 0 {
+		query["names"] = opts.Names
+	}
+
+	var health HealthInfo
+	_, err := client.doSync("GET", "/v1/health", query, nil, nil, &health)
+	if err != nil {
+		return nil, err
+	}
+	return &health, nil
+}

--- a/client/health.go
+++ b/client/health.go
@@ -16,11 +16,27 @@ package client
 
 import "net/url"
 
-type HealthOptions ChecksOptions
+// HealthOptions holds query options to pass to a Health call.
+type HealthOptions struct {
+	// Level is the check level to filter for. A check is included in the
+	// healthiness determination if this field is not set, or if it is
+	// equal to the check's level.
+	Level CheckLevel
 
-// HealthInfo holds health information for a single health check.
+	// Names is the list of check names to filter for. A check is included in
+	// the healthiness determination if this field is nil or empty slice, or
+	// if one of the values in the slice is equal to the check's name.
+	Names []string
+}
+
+// HealthInfo holds the result of a Health call.
 type HealthInfo struct {
-	// Healthy is the status of health.
+	// Healthy is the status of health. A set of checks are deemed "healthy"
+	// if all of them of are up, and "unhealthy" otherwise. When queried
+	// using level, if the queried level equals to "alive", only the alive
+	// checks are selected. However, "ready" implies alive. Thus, if the
+	// queried level is "ready", both the alive and ready leveled checks are
+	// considered.
 	Healthy bool `json:"healthy"`
 }
 

--- a/client/health.go
+++ b/client/health.go
@@ -33,9 +33,9 @@ type HealthOptions struct {
 type HealthInfo struct {
 	// Healthy is the status of health. A set of checks are deemed "healthy"
 	// if all of them of are up, and "unhealthy" otherwise. When queried
-	// using level, if the queried level equals to "alive", only the alive
+	// using level, if the queried level equals "alive", only the alive
 	// checks are selected. However, "ready" implies alive. Thus, if the
-	// queried level is "ready", both the alive and ready leveled checks are
+	// queried level is "ready", both the alive and ready checks are
 	// considered.
 	Healthy bool `json:"healthy"`
 }

--- a/client/health_test.go
+++ b/client/health_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package client_test
+
+import (
+	"net/url"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/client"
+)
+
+func (cs *clientSuite) TestHealthGet(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"status": "OK",
+		"result": {
+			"healthy": true
+		}
+	}`
+
+	opts := client.HealthOptions{
+		Level: client.AliveLevel,
+		Names: []string{"chk1", "chk3"},
+	}
+	health, err := cs.cli.Health(&opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(health, check.DeepEquals, &client.HealthInfo{
+		Healthy: true,
+	})
+	c.Assert(cs.req.Method, check.Equals, "GET")
+	c.Assert(cs.req.URL.Path, check.Equals, "/v1/health")
+	c.Assert(cs.req.URL.Query(), check.DeepEquals, url.Values{
+		"level": {"alive"},
+		"names": {"chk1", "chk3"},
+	})
+}

--- a/client/health_test.go
+++ b/client/health_test.go
@@ -38,9 +38,7 @@ func (cs *clientSuite) TestHealthGet(c *check.C) {
 	}
 	health, err := cs.cli.Health(&opts)
 	c.Assert(err, check.IsNil)
-	c.Assert(health, check.DeepEquals, &client.HealthInfo{
-		Healthy: true,
-	})
+	c.Assert(health, check.Equals, true)
 	c.Assert(cs.req.Method, check.Equals, "GET")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v1/health")
 	c.Assert(cs.req.URL.Query(), check.DeepEquals, url.Values{
@@ -61,9 +59,7 @@ func (cs *clientSuite) TestHealthDefaultOptions(c *check.C) {
 
 	health, err := cs.cli.Health(&client.HealthOptions{})
 	c.Assert(err, check.IsNil)
-	c.Assert(health, check.DeepEquals, &client.HealthInfo{
-		Healthy: false,
-	})
+	c.Assert(health, check.Equals, false)
 	c.Assert(cs.req.Method, check.Equals, "GET")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v1/health")
 	c.Assert(cs.req.URL.Query(), check.DeepEquals, url.Values{})

--- a/client/health_test.go
+++ b/client/health_test.go
@@ -48,3 +48,23 @@ func (cs *clientSuite) TestHealthGet(c *check.C) {
 		"names": {"chk1", "chk3"},
 	})
 }
+
+func (cs *clientSuite) TestHealthDefaultOptions(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 502,
+		"status": "Bad Gateway",
+		"result": {
+			"healthy": false
+		}
+	}`
+
+	health, err := cs.cli.Health(&client.HealthOptions{})
+	c.Assert(err, check.IsNil)
+	c.Assert(health, check.DeepEquals, &client.HealthInfo{
+		Healthy: false,
+	})
+	c.Assert(cs.req.Method, check.Equals, "GET")
+	c.Assert(cs.req.URL.Path, check.Equals, "/v1/health")
+	c.Assert(cs.req.URL.Query(), check.DeepEquals, url.Values{})
+}

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -32,7 +32,7 @@ arguments.
 type cmdChecks struct {
 	client *client.Client
 
-	Level      string `long:"level"`
+	Level      string `long:"level" choice:"alive" choice:"ready"`
 	Positional struct {
 		Checks []string `positional-arg-name:"<check>"`
 	} `positional-args:"yes"`
@@ -44,7 +44,7 @@ func init() {
 		Summary:     cmdChecksSummary,
 		Description: cmdChecksDescription,
 		ArgsHelp: map[string]string{
-			"--level": `Check level to filter for ("alive" or "ready")`,
+			"--level": "Check level to filter for",
 		},
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdChecks{client: opts.Client}

--- a/internals/cli/cmd_health.go
+++ b/internals/cli/cmd_health.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/canonical/go-flags"
+
+	"github.com/canonical/pebble/client"
+)
+
+const cmdHealthSummary = "Query health of checks."
+const cmdHealthDescription = `
+The health command queries the health of configured Pebble checks.
+
+It returns an exit code 0 if all the requested Pebble checks are healthy, or
+an exit code 1 if at least one of the requested Pebble checks are unhealthy.
+`
+
+type cmdHealth struct {
+	client *client.Client
+
+	Format     string `long:"format" choice:"text" choice:"json" default:"text"`
+	Level      string `long:"level" choice:"alive" choice:"ready"`
+	Positional struct {
+		Checks []string `positional-arg-name:"<check>"`
+	} `positional-args:"yes"`
+}
+
+var cmdHealthArgsHelp = map[string]string{
+	"--format": `Output format`,
+	"--level":  `Check level to filter for`,
+}
+
+func init() {
+	AddCommand(&CmdInfo{
+		Name:        "health",
+		Summary:     cmdHealthSummary,
+		Description: cmdHealthDescription,
+		ArgsHelp:    cmdHealthArgsHelp,
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdHealth{client: opts.Client}
+		},
+	})
+}
+
+func (cmd *cmdHealth) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	opts := client.HealthOptions{
+		Level: client.CheckLevel(cmd.Level),
+		Names: cmd.Positional.Checks,
+	}
+	health, err := cmd.client.Health(&opts)
+	if err != nil {
+		return err
+	}
+
+	switch cmd.Format {
+	case "", "text":
+		status := "unhealthy"
+		if health.Healthy {
+			status = "healthy"
+		}
+		fmt.Fprintf(Stdout, "%s\n", status)
+	case "json":
+		encoder := json.NewEncoder(Stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.Encode(&health)
+	default:
+		return fmt.Errorf(`invalid output format (expected "json" or "text", not %q)`, cmd.Format)
+	}
+
+	if !health.Healthy {
+		return fmt.Errorf("check(s) are unhealthy")
+	}
+
+	return nil
+}

--- a/internals/cli/cmd_health.go
+++ b/internals/cli/cmd_health.go
@@ -23,12 +23,12 @@ import (
 	"github.com/canonical/pebble/client"
 )
 
-const cmdHealthSummary = "Query health of checks."
+const cmdHealthSummary = "Query health of checks"
 const cmdHealthDescription = `
-The health command queries the health of configured Pebble checks.
+The health command queries the health of configured checks.
 
-It returns an exit code 0 if all the requested Pebble checks are healthy, or
-an exit code 1 if at least one of the requested Pebble checks are unhealthy.
+It returns an exit code 0 if all the requested checks are healthy, or
+an exit code 1 if at least one of the requested checks are unhealthy.
 `
 
 type cmdHealth struct {
@@ -42,8 +42,8 @@ type cmdHealth struct {
 }
 
 var cmdHealthArgsHelp = map[string]string{
-	"--format": `Output format`,
-	"--level":  `Check level to filter for`,
+	"--format": "Output format",
+	"--level":  "Check level to filter for",
 }
 
 func init() {
@@ -78,17 +78,19 @@ func (cmd *cmdHealth) Execute(args []string) error {
 		if health.Healthy {
 			status = "healthy"
 		}
-		fmt.Fprintf(Stdout, "%s\n", status)
+		fmt.Fprintln(Stdout, status)
 	case "json":
 		encoder := json.NewEncoder(Stdout)
-		encoder.SetEscapeHTML(false)
-		encoder.Encode(&health)
+		err := encoder.Encode(&health)
+		if err != nil {
+			return err
+		}
 	default:
-		return fmt.Errorf(`invalid output format (expected "json" or "text", not %q)`, cmd.Format)
+		panic(fmt.Sprintf("internal error: invalid output format %q", cmd.Format)) // already checked by go-flags
 	}
 
 	if !health.Healthy {
-		return fmt.Errorf("check(s) are unhealthy")
+		panic(&exitStatus{1})
 	}
 
 	return nil

--- a/internals/cli/cmd_health.go
+++ b/internals/cli/cmd_health.go
@@ -15,7 +15,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/canonical/go-flags"
@@ -34,7 +33,6 @@ an exit code 1 if at least one of the requested checks are unhealthy.
 type cmdHealth struct {
 	client *client.Client
 
-	Format     string `long:"format" choice:"text" choice:"json" default:"text"`
 	Level      string `long:"level" choice:"alive" choice:"ready"`
 	Positional struct {
 		Checks []string `positional-arg-name:"<check>"`
@@ -42,8 +40,7 @@ type cmdHealth struct {
 }
 
 var cmdHealthArgsHelp = map[string]string{
-	"--format": "Output format",
-	"--level":  "Check level to filter for",
+	"--level": "Check level to filter for",
 }
 
 func init() {
@@ -72,24 +69,13 @@ func (cmd *cmdHealth) Execute(args []string) error {
 		return err
 	}
 
-	switch cmd.Format {
-	case "", "text":
-		status := "unhealthy"
-		if health.Healthy {
-			status = "healthy"
-		}
-		fmt.Fprintln(Stdout, status)
-	case "json":
-		encoder := json.NewEncoder(Stdout)
-		err := encoder.Encode(&health)
-		if err != nil {
-			return err
-		}
-	default:
-		panic(fmt.Sprintf("internal error: invalid output format %q", cmd.Format)) // already checked by go-flags
+	status := "unhealthy"
+	if health {
+		status = "healthy"
 	}
+	fmt.Fprintln(Stdout, status)
 
-	if !health.Healthy {
+	if !health {
 		panic(&exitStatus{1})
 	}
 

--- a/internals/cli/cmd_health_test.go
+++ b/internals/cli/cmd_health_test.go
@@ -66,27 +66,6 @@ func (s *PebbleSuite) TestHealthLevel(c *check.C) {
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
-func (s *PebbleSuite) TestHealthFormat(c *check.C) {
-	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
-		c.Assert(r.Method, check.Equals, "GET")
-		c.Assert(r.URL.Path, check.Equals, "/v1/health")
-		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
-		fmt.Fprintf(w, `{
-			"type": "sync",
-			"status-code": 200,
-			"result": {"healthy": true}
-		}`)
-	})
-
-	restore := fakeArgs("pebble", "health", "--format", "json")
-	defer restore()
-
-	exitCode := cli.PebbleMain()
-	c.Check(exitCode, check.Equals, 0)
-	c.Check(s.Stdout(), check.Equals, "{\"healthy\":true}\n")
-	c.Check(s.Stderr(), check.Equals, "")
-}
-
 func (s *PebbleSuite) TestHealthSpecificChecks(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, check.Equals, "GET")
@@ -119,14 +98,4 @@ func (s *PebbleSuite) TestHealthBadLevel(c *check.C) {
 	c.Check(exitCode, check.Equals, 1)
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Matches, "error: Invalid value .* Allowed values are: alive or ready\n")
-}
-
-func (s *PebbleSuite) TestHealthBadFormat(c *check.C) {
-	restore := fakeArgs("pebble", "health", "--format", "foo")
-	defer restore()
-
-	exitCode := cli.PebbleMain()
-	c.Check(exitCode, check.Equals, 1)
-	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Matches, "error: Invalid value .* Allowed values are: text or json\n")
 }

--- a/internals/cli/cmd_health_test.go
+++ b/internals/cli/cmd_health_test.go
@@ -24,28 +24,16 @@ import (
 	"github.com/canonical/pebble/internals/cli"
 )
 
-func (s *PebbleSuite) TestHealthHelp(c *check.C) {
-	restore := fakeArgs("pebble", "health", "-h")
-	defer restore()
-
-	exitCode := cli.PebbleMain()
-	c.Check(exitCode, check.Equals, 0)
-	c.Check(s.Stdout(), check.Not(check.Matches), "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
-	c.Check(s.Stdout(), check.Matches, "^(?s)Usage:\n  pebble health \\[health-OPTIONS\\] \\[<check>\\.\\.\\.\\].*")
-	c.Check(s.Stdout(), check.Matches, "(?s).*The health command queries the health of configured Pebble checks.*")
-	c.Check(s.Stderr(), check.Equals, "")
-}
-
 func (s *PebbleSuite) TestHealth(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, check.Equals, "GET")
 		c.Assert(r.URL.Path, check.Equals, "/v1/health")
 		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
 		fmt.Fprintf(w, `{
-	"type": "sync",
-	"status-code": 200,
-	"result": {"healthy": true}
-}`)
+			"type": "sync",
+			"status-code": 200,
+			"result": {"healthy": true}
+		}`)
 	})
 
 	restore := fakeArgs("pebble", "health")
@@ -61,12 +49,12 @@ func (s *PebbleSuite) TestHealthLevel(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, check.Equals, "GET")
 		c.Assert(r.URL.Path, check.Equals, "/v1/health")
-		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{"level": []string{"alive"}})
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{"level": {"alive"}})
 		fmt.Fprintf(w, `{
-	"type": "sync",
-	"status-code": 502,
-	"result": {"healthy": false}
-}`)
+			"type": "sync",
+			"status-code": 502,
+			"result": {"healthy": false}
+		}`)
 	})
 
 	restore := fakeArgs("pebble", "health", "--level", "alive")
@@ -75,7 +63,7 @@ func (s *PebbleSuite) TestHealthLevel(c *check.C) {
 	exitCode := cli.PebbleMain()
 	c.Check(exitCode, check.Equals, 1)
 	c.Check(s.Stdout(), check.Equals, "unhealthy\n")
-	c.Check(s.Stderr(), check.Equals, "error: check(s) are unhealthy\n")
+	c.Check(s.Stderr(), check.Equals, "")
 }
 
 func (s *PebbleSuite) TestHealthFormat(c *check.C) {
@@ -84,10 +72,10 @@ func (s *PebbleSuite) TestHealthFormat(c *check.C) {
 		c.Assert(r.URL.Path, check.Equals, "/v1/health")
 		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
 		fmt.Fprintf(w, `{
-	"type": "sync",
-	"status-code": 200,
-	"result": {"healthy": true}
-}`)
+			"type": "sync",
+			"status-code": 200,
+			"result": {"healthy": true}
+		}`)
 	})
 
 	restore := fakeArgs("pebble", "health", "--format", "json")
@@ -104,14 +92,14 @@ func (s *PebbleSuite) TestHealthSpecificChecks(c *check.C) {
 		c.Assert(r.Method, check.Equals, "GET")
 		c.Assert(r.URL.Path, check.Equals, "/v1/health")
 		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{
-			"level": []string{"ready"},
-			"names": []string{"chk1", "chk3"},
+			"level": {"ready"},
+			"names": {"chk1", "chk3"},
 		})
 		fmt.Fprintf(w, `{
-	"type": "sync",
-	"status-code": 200,
-	"result": {"healthy": true}
-}`)
+			"type": "sync",
+			"status-code": 200,
+			"result": {"healthy": true}
+		}`)
 	})
 
 	restore := fakeArgs("pebble", "health", "--level", "ready", "chk1", "chk3")

--- a/internals/cli/cmd_health_test.go
+++ b/internals/cli/cmd_health_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/cli"
+)
+
+func (s *PebbleSuite) TestHealthHelp(c *check.C) {
+	restore := fakeArgs("pebble", "health", "-h")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Not(check.Matches), "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
+	c.Check(s.Stdout(), check.Matches, "^(?s)Usage:\n  pebble health \\[health-OPTIONS\\] \\[<check>\\.\\.\\.\\].*")
+	c.Check(s.Stdout(), check.Matches, "(?s).*The health command queries the health of configured Pebble checks.*")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealth(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/health")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
+		fmt.Fprintf(w, `{
+	"type": "sync",
+	"status-code": 200,
+	"result": {"healthy": true}
+}`)
+	})
+
+	restore := fakeArgs("pebble", "health")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, "healthy\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthLevel(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/health")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{"level": []string{"alive"}})
+		fmt.Fprintf(w, `{
+	"type": "sync",
+	"status-code": 502,
+	"result": {"healthy": false}
+}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--level", "alive")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 1)
+	c.Check(s.Stdout(), check.Equals, "unhealthy\n")
+	c.Check(s.Stderr(), check.Equals, "error: check(s) are unhealthy\n")
+}
+
+func (s *PebbleSuite) TestHealthFormat(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/health")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
+		fmt.Fprintf(w, `{
+	"type": "sync",
+	"status-code": 200,
+	"result": {"healthy": true}
+}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "json")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, "{\"healthy\":true}\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthSpecificChecks(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/health")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{
+			"level": []string{"ready"},
+			"names": []string{"chk1", "chk3"},
+		})
+		fmt.Fprintf(w, `{
+	"type": "sync",
+	"status-code": 200,
+	"result": {"healthy": true}
+}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--level", "ready", "chk1", "chk3")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, "healthy\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthBadLevel(c *check.C) {
+	restore := fakeArgs("pebble", "health", "--level", "foo")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Matches, "error: Invalid value .* Allowed values are: alive or ready\n")
+}
+
+func (s *PebbleSuite) TestHealthBadFormat(c *check.C) {
+	restore := fakeArgs("pebble", "health", "--format", "foo")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Matches, "error: Invalid value .* Allowed values are: text or json\n")
+}

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -184,7 +184,7 @@ var HelpCategories = []HelpCategory{{
 }, {
 	Label:       "Services",
 	Description: "manage services",
-	Commands:    []string{"services", "logs", "checks", "start", "restart", "signal", "stop", "replan"},
+	Commands:    []string{"services", "logs", "checks", "health", "start", "restart", "signal", "stop", "replan"},
 }, {
 	Label:       "Files",
 	Description: "work with files and execute commands",

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -184,7 +184,11 @@ var HelpCategories = []HelpCategory{{
 }, {
 	Label:       "Services",
 	Description: "manage services",
-	Commands:    []string{"services", "logs", "checks", "health", "start", "restart", "signal", "stop", "replan"},
+	Commands:    []string{"services", "logs", "start", "restart", "signal", "stop", "replan"},
+}, {
+	Label:       "Checks",
+	Description: "manage health checks",
+	Commands:    []string{"checks", "health"},
 }, {
 	Label:       "Files",
 	Description: "work with files and execute commands",

--- a/internals/daemon/api_health_test.go
+++ b/internals/daemon/api_health_test.go
@@ -115,6 +115,9 @@ func (s *healthSuite) TestLevel(c *C) {
 				if test.readyCheck != "" {
 					checks = append(checks, &checkstate.CheckInfo{Name: "r", Level: plan.ReadyLevel, Status: checkstate.CheckStatus(test.readyCheck)})
 				}
+				// Add a check which is down with level unset, to ensure that
+				// the level-unset checks do not impact the outcomes of level-queries.
+				checks = append(checks, &checkstate.CheckInfo{Name: "u", Level: plan.UnsetLevel, Status: checkstate.CheckStatusDown})
 				return checks, nil
 			})
 			defer restore()


### PR DESCRIPTION
This PR adds a new "health" command to Pebble. The health command queries the health of configured pebble checks. It outputs "healthy" and returns an exit code of 0 if all the specified checks are healthy. Otherwise, it outputs "unhealthy" and returns with an exit code of 1.

The "health" command accepts _~~two~~_ **one** option with arguments:

  - The --level option takes an argument, either "alive" or "ready". It queries the health of only those checks with the same level. Note that, ready implies alive. Thus, if the ready checks are healthy but one of the alive checks is not, the overall output will be "unhealthy".

Usage:

    pebble health [health-OPTIONS] [<check>...]

This PR includes a few tests too for the relevant changes.

---

This command does not add any new logic to Pebble, as it relies entirely on the already existing implementation of the Pebble health API. Nonetheless, the hereby proposed feature (and [corresponding spec](https://docs.google.com/document/d/1nhQf9tmMHh5elZIFnJQA07zzhVh8aRqDnc6Cqm-IHEU/edit?usp=drivesdk)) identifies certain edge cases where the resulting health outcome isn’t the most intuitive or predictable. Examples:

 - `pebble health --level=ready` can be healthy even if
      1. there are no checks of that level
      2. checks with no level are down

 - `pebble health --level=alive` will be healthy even if ready checks are down

---

**Major changes from the initial commit(s)**

| Commit | Description |
| - | - |
| https://github.com/canonical/pebble/pull/299/commits/0186355e2090f6f38bbfb3a496c15ddb8935befc | `checks` and `health` appear in a new category in `pebble help`. |
| https://github.com/canonical/pebble/pull/299/commits/aee03aa58bbd9266be9185cdd9753890bd933b90 | Dropped the `--format` option from `health` command due to recent feedbacks. |