### PR TITLE
refactor(cli): pass client config to cli.Run()

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -18,11 +18,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/internals/cli"
 )
 
 func main() {
-	if err := cli.Run(); err != nil {
+	clientConfig := &client.Config{}
+	_, clientConfig.Socket = cli.GetEnvPaths()
+	if err := cli.Run(clientConfig); err != nil {
 		fmt.Fprintf(cli.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -243,9 +243,6 @@ var (
 	osExit      = os.Exit
 )
 
-// ClientConfig is the configuration of the Client used by all commands.
-var clientConfig client.Config
-
 // exitStatus can be used in panic(&exitStatus{code}) to cause Pebble's main
 // function to exit with a given exit code, for the rare cases when you want
 // to return an exit code other than 0 or 1, or when an error return is not
@@ -258,7 +255,7 @@ func (e *exitStatus) Error() string {
 	return fmt.Sprintf("internal error: exitStatus{%d} being handled as normal error", e.code)
 }
 
-func Run() error {
+func Run(config *client.Config) error {
 	defer func() {
 		if v := recover(); v != nil {
 			if e, ok := v.(*exitStatus); ok {
@@ -270,9 +267,7 @@ func Run() error {
 
 	logger.SetLogger(logger.New(os.Stderr, "[pebble] "))
 
-	_, clientConfig.Socket = getEnvPaths()
-
-	cli, err := client.New(&clientConfig)
+	cli, err := client.New(config)
 	if err != nil {
 		return fmt.Errorf("cannot create client: %v", err)
 	}
@@ -353,7 +348,7 @@ func errorToMessage(e error) (normalMessage string, err error) {
 	return msg, nil
 }
 
-func getEnvPaths() (pebbleDir string, socketPath string) {
+func GetEnvPaths() (pebbleDir string, socketPath string) {
 	pebbleDir = os.Getenv("PEBBLE")
 	if pebbleDir == "" {
 		pebbleDir = defaultPebbleDir

--- a/internals/cli/cli_test.go
+++ b/internals/cli/cli_test.go
@@ -136,7 +136,7 @@ func (s *PebbleSuite) TestErrorResult(c *C) {
 	restore := fakeArgs("pebble", "warnings")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, ErrorMatches, `cannot do something`)
 }
 

--- a/internals/cli/cmd_help_test.go
+++ b/internals/cli/cmd_help_test.go
@@ -17,7 +17,6 @@ package cli_test
 import (
 	. "gopkg.in/check.v1"
 
-	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/internals/cli"
 )
 
@@ -25,7 +24,7 @@ func (s *PebbleSuite) TestHelpCommand(c *C) {
 	restore := fakeArgs("pebble", "help")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -35,7 +34,7 @@ func (s *PebbleSuite) TestHelpAll(c *C) {
 	restore := fakeArgs("pebble", "help", "--all")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*run.*help.*version.*warnings.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -45,7 +44,7 @@ func (s *PebbleSuite) TestHelpAllWithCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "help", "--all")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, ErrorMatches, `help accepts a command, or '--all', but not both.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -55,7 +54,7 @@ func (s *PebbleSuite) TestHelpMan(c *C) {
 	restore := fakeArgs("pebble", "help", "--man")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, `(?s)\.TH.*\.SH NAME.*pebble \\- Tool to interact with pebble.*`)
 	c.Check(s.Stderr(), Equals, "")
@@ -65,7 +64,7 @@ func (s *PebbleSuite) TestHelpOption(c *C) {
 	restore := fakeArgs("pebble", "--help")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -75,7 +74,7 @@ func (s *PebbleSuite) TestHelpWithCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "help")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -85,7 +84,7 @@ func (s *PebbleSuite) TestHelpWithUnknownCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "dachshund")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, ErrorMatches, `unknown command "dachshund", see 'pebble help'.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -95,7 +94,7 @@ func (s *PebbleSuite) TestHelpWithUnknownSubcommand(c *C) {
 	restore := fakeArgs("pebble", "help", "add", "dachshund")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, ErrorMatches, `unknown command "dachshund", see 'pebble help add'.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -105,7 +104,7 @@ func (s *PebbleSuite) TestCommandWithHelpOption(c *C) {
 	restore := fakeArgs("pebble", "help", "--help")
 	defer restore()
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -121,7 +120,7 @@ func (s *PebbleSuite) TestAddHelpCategory(c *C) {
 		Commands:    []string{"run", "logs"},
 	})
 
-	err := cli.Run(&client.Config{})
+	err := cli.Run(cli.ClientConfig)
 	c.Assert(err, Equals, nil)
 
 	c.Check(s.Stdout(), Matches, "(?s).*Test category: run, logs\n.*")

--- a/internals/cli/cmd_help_test.go
+++ b/internals/cli/cmd_help_test.go
@@ -17,6 +17,7 @@ package cli_test
 import (
 	. "gopkg.in/check.v1"
 
+	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/internals/cli"
 )
 
@@ -24,7 +25,7 @@ func (s *PebbleSuite) TestHelpCommand(c *C) {
 	restore := fakeArgs("pebble", "help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -34,7 +35,7 @@ func (s *PebbleSuite) TestHelpAll(c *C) {
 	restore := fakeArgs("pebble", "help", "--all")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*run.*help.*version.*warnings.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -44,7 +45,7 @@ func (s *PebbleSuite) TestHelpAllWithCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "help", "--all")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, ErrorMatches, `help accepts a command, or '--all', but not both.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -54,7 +55,7 @@ func (s *PebbleSuite) TestHelpMan(c *C) {
 	restore := fakeArgs("pebble", "help", "--man")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, `(?s)\.TH.*\.SH NAME.*pebble \\- Tool to interact with pebble.*`)
 	c.Check(s.Stderr(), Equals, "")
@@ -64,7 +65,7 @@ func (s *PebbleSuite) TestHelpOption(c *C) {
 	restore := fakeArgs("pebble", "--help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -74,7 +75,7 @@ func (s *PebbleSuite) TestHelpWithCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -84,7 +85,7 @@ func (s *PebbleSuite) TestHelpWithUnknownCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "dachshund")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, ErrorMatches, `unknown command "dachshund", see 'pebble help'.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -94,7 +95,7 @@ func (s *PebbleSuite) TestHelpWithUnknownSubcommand(c *C) {
 	restore := fakeArgs("pebble", "help", "add", "dachshund")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, ErrorMatches, `unknown command "dachshund", see 'pebble help add'.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -104,7 +105,7 @@ func (s *PebbleSuite) TestCommandWithHelpOption(c *C) {
 	restore := fakeArgs("pebble", "help", "--help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -120,7 +121,7 @@ func (s *PebbleSuite) TestAddHelpCategory(c *C) {
 		Commands:    []string{"run", "logs"},
 	})
 
-	err := cli.RunMain()
+	err := cli.Run(&client.Config{})
 	c.Assert(err, Equals, nil)
 
 	c.Check(s.Stdout(), Matches, "(?s).*Test category: run, logs\n.*")

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -142,7 +142,7 @@ func sanityCheck() error {
 func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	t0 := time.Now().Truncate(time.Millisecond)
 
-	pebbleDir, socketPath := getEnvPaths()
+	pebbleDir, socketPath := GetEnvPaths()
 	if rcmd.CreateDirs {
 		err := os.MkdirAll(pebbleDir, 0755)
 		if err != nil {

--- a/internals/cli/export_test.go
+++ b/internals/cli/export_test.go
@@ -20,9 +20,7 @@ import (
 	"github.com/canonical/pebble/client"
 )
 
-var RunMain = Run
-
-var ClientConfig = &clientConfig
+var ClientConfig *client.Config = &client.Config{}
 
 func Client() *client.Client {
 	cli, err := client.New(ClientConfig)
@@ -41,8 +39,6 @@ var (
 
 	WriteWarningTimestamp = writeWarningTimestamp
 	MaybePresentWarnings  = maybePresentWarnings
-
-	GetEnvPaths = getEnvPaths
 )
 
 func FakeIsStdoutTTY(t bool) (restore func()) {
@@ -76,7 +72,9 @@ func PebbleMain() (exitCode int) {
 			}
 		}
 	}()
-	if err := Run(); err != nil {
+	clientConfig := &client.Config{}
+	_, clientConfig.Socket = GetEnvPaths()
+	if err := Run(clientConfig); err != nil {
 		fmt.Fprintf(Stderr, "error: %v\n", err)
 		osExit(1)
 	}


### PR DESCRIPTION
This patch modifies the signature of the `cli.Run()` function so that the Pebble client config is passed to it in order to build a Pebble client for the CLI commands.  This adds the flexibility needed for external applications to override the configuration of the Pebble client.