### PR TITLE
chore: fix path in dot command in state-diagram.dot comment

### DIFF
--- a/internals/overlord/servstate/state-diagram.dot
+++ b/internals/overlord/servstate/state-diagram.dot
@@ -1,6 +1,6 @@
 # Create SVG with the following graphviz command:
 #
-# dot -Tsvg internal/overlord/servstate/state-diagram.dot -o ./internal/overlord/servstate/state-diagram.svg
+# dot -Tsvg internals/overlord/servstate/state-diagram.dot -o ./internals/overlord/servstate/state-diagram.svg
 
 digraph service_state_machine {
     node [penwidth=3 shape=box fontsize=24] initial


### PR DESCRIPTION
Similar fix to https://github.com/canonical/pebble/pull/304 now that `internal` moved to `internals`.