### PR TITLE
feat(client): separate HTTP transport from client

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,6 +30,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/internals/clientutil"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -70,7 +71,7 @@ func (cs *clientSuite) SetUpTest(c *C) {
 	cs.tmpDir = c.MkDir()
 	cs.socketPath = filepath.Join(cs.tmpDir, "pebble.socket")
 
-	cs.restore = client.FakeDoRetry(time.Millisecond, 10*time.Millisecond)
+	cs.restore = clientutil.FakeDoRetry(time.Millisecond, 10*time.Millisecond)
 }
 
 func (cs *clientSuite) TearDownTest(c *C) {
@@ -318,7 +319,7 @@ func (cs *clientSuite) TestNonExistentSocketErrors(c *C) {
 
 	_, err = cli.SysInfo()
 	c.Check(err, NotNil)
-	var notFoundErr *client.SocketNotFoundError
+	var notFoundErr *clientutil.SocketNotFoundError
 	c.Check(errors.As(err, &notFoundErr), Equals, true)
 
 	c.Check(notFoundErr.Path, Equals, "/tmp/not-the-droids-you-are-looking-for")

--- a/client/exec.go
+++ b/client/exec.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/canonical/pebble/internals/clientutil"
 	"github.com/canonical/pebble/internals/wsutil"
 )
 
@@ -106,7 +107,7 @@ type ExecProcess struct {
 	client      *Client
 	timeout     time.Duration
 	writesDone  chan struct{}
-	controlConn jsonWriter
+	controlConn clientutil.JSONWriter
 	stdinDone   chan bool // only used by tests
 }
 
@@ -178,7 +179,7 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	stdoutDone := wsutil.WebsocketRecvStream(stdout, ioConn)
 
 	// Handle stderr separately if needed.
-	var stderrConn clientWebsocket
+	var stderrConn clientutil.Websocket
 	var stderrDone chan bool
 	if opts.Stderr != nil {
 		stderrConn, err = client.getTaskWebsocket(taskID, "stderr")

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -27,6 +27,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/internals/clientutil"
 )
 
 type execSuite struct {
@@ -46,7 +47,7 @@ func (s *execSuite) SetUpTest(c *C) {
 	s.stdioWs = &testWebsocket{}
 	s.controlWs = &testWebsocket{}
 	s.stderrWs = &testWebsocket{}
-	s.cli.SetGetWebsocket(func(url string) (client.ClientWebsocket, error) {
+	s.cli.SetGetWebsocket(func(url string) (clientutil.Websocket, error) {
 		matches := websocketRegexp.FindStringSubmatch(url)
 		if matches == nil {
 			return nil, fmt.Errorf("invalid websocket URL %q", url)

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+
+	"github.com/canonical/pebble/internals/clientutil"
 )
 
 var (
@@ -25,12 +27,12 @@ var (
 	CalculateFileMode = calculateFileMode
 )
 
-func (client *Client) SetDoer(d doer) {
-	client.doer = d
+func (client *Client) SetDoer(d clientutil.Doer) {
+	client.transport.Doer = d
 }
 
 func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
-	return client.do(method, path, query, nil, body, v)
+	return client.transport.Do(method, path, query, nil, body, v)
 }
 
 func (client *Client) FakeAsyncRequest() (changeId string, err error) {
@@ -50,5 +52,3 @@ func (client *Client) SetGetWebsocket(f getWebsocketFunc) {
 func (p *ExecProcess) WaitStdinDone() {
 	<-p.stdinDone
 }
-
-type ClientWebsocket = clientWebsocket

--- a/client/logs.go
+++ b/client/logs.go
@@ -73,7 +73,7 @@ func (client *Client) logs(ctx context.Context, opts *LogsOptions, follow bool) 
 	if follow {
 		query.Set("follow", "true")
 	}
-	res, err := client.raw(ctx, "GET", "/v1/logs", query, nil, nil)
+	res, err := client.transport.Raw(ctx, "GET", "/v1/logs", query, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cli_test.go
+++ b/internals/cli/cli_test.go
@@ -136,7 +136,7 @@ func (s *PebbleSuite) TestErrorResult(c *C) {
 	restore := fakeArgs("pebble", "warnings")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, ErrorMatches, `cannot do something`)
 }
 

--- a/internals/cli/cmd_add_test.go
+++ b/internals/cli/cmd_add_test.go
@@ -90,7 +90,7 @@ services:
 				args = append(args, "--combine")
 			}
 			args = append(args, "foo", path)
-			rest, err := cli.Parser(cli.Client()).ParseArgs(args)
+			rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs(args)
 
 			if path == layerPath {
 				c.Assert(err, check.IsNil)
@@ -106,7 +106,7 @@ services:
 		}
 
 		args = append(args, "extra", "arguments", "invalid")
-		_, err = cli.Parser(cli.Client()).ParseArgs(args)
+		_, err = cli.Parser(cli.Client(), cli.Transport()).ParseArgs(args)
 		c.Assert(err, check.Equals, cli.ErrExtraArgs)
 	}
 }

--- a/internals/cli/cmd_autostart_test.go
+++ b/internals/cli/cmd_autostart_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (s *PebbleSuite) TestAutostartExtraArgs(c *check.C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"autostart", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"autostart", "extra", "args"})
 	c.Assert(err, check.Equals, cli.ErrExtraArgs)
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -67,7 +67,7 @@ func (s *PebbleSuite) TestAutostart(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"autostart"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"autostart"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -91,7 +91,7 @@ func (s *PebbleSuite) TestAutostartFailsNoDefaultServices(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"autostart"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"autostart"})
 	c.Assert(err, check.ErrorMatches, "no default services")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -117,7 +117,7 @@ func (s *PebbleSuite) TestAutostartNoWait(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"autostart", "--no-wait"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"autostart", "--no-wait"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "42\n")
@@ -148,7 +148,7 @@ func (s *PebbleSuite) TestAutostartFailsGetChange(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"autostart"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"autostart"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func (s *PebbleSuite) TestChangesExtraArgs(c *check.C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"changes", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"changes", "extra", "args"})
 	c.Assert(err, check.Equals, cli.ErrExtraArgs)
 	c.Check(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -39,7 +39,7 @@ func (s *PebbleSuite) TestChangesExtraArgs(c *check.C) {
 }
 
 func (s *PebbleSuite) TestChangesAllDigitsSuggestion(c *check.C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"changes", "42"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"changes", "42"})
 	c.Assert(err, check.ErrorMatches, `'pebble changes' command expects a service name, try 'pebble tasks 42'`)
 	c.Check(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -54,7 +54,7 @@ func (s *PebbleSuite) TestNoChanges(c *check.C) {
 		fmt.Fprintln(w, `{"type":"sync", "result": []}"`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"changes", "svc1"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"changes", "svc1"})
 	c.Assert(err, check.ErrorMatches, "no changes found")
 	c.Check(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -69,7 +69,7 @@ func (s *PebbleSuite) TestGetChangesFails(c *check.C) {
 		fmt.Fprintln(w, `{"type":"error", "result": {"message": "could not foo"}}"`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"changes", "svc1"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"changes", "svc1"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Check(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -91,7 +91,7 @@ one +Do +2016-03-21 +2016-03-21 +...
 two +Do +2016-04-21 +2016-04-21 +...
 `
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"changes"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"changes"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Matches, expectedChanges)
@@ -107,7 +107,7 @@ func (s *PebbleSuite) TestChangesUnknownMaintenance(c *check.C) {
 		fmt.Fprintln(w, json)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"changes"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"changes"})
 	c.Assert(err, check.ErrorMatches, "unknown maintenance reason")
 	c.Check(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Matches, "")
@@ -140,7 +140,7 @@ func (s *PebbleSuite) TestChangeSimple(c *check.C) {
 	expectedChange := `(?ms)Status +Spawn +Ready +Summary
 Do +2016-04-21T01:02:03Z +- +some summary
 `
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--abs-time", "42"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Matches, expectedChange)
@@ -154,7 +154,7 @@ func (s *PebbleSuite) TestChangeSimpleFails(c *check.C) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "could not bar"}}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--abs-time", "42"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--abs-time", "42"})
 	c.Assert(err, check.ErrorMatches, "could not bar")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Matches, "")
@@ -175,7 +175,7 @@ func (s *PebbleSuite) TestChangeSimpleRebooting(c *check.C) {
 		n++
 	})
 
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "42"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "42"})
 	c.Assert(err, check.IsNil)
 	c.Check(s.Stderr(), check.Equals, "WARNING: pebble is about to reboot the system\n")
 }
@@ -187,7 +187,7 @@ func (s *PebbleSuite) TestChangeSimpleUnknownMaintenance(c *check.C) {
 		fmt.Fprintln(w, strings.Replace(fakeChangeJSON, `"type": "sync"`, `"type": "sync", "maintenance": {"kind": "dachshund", "message": "unknown maintenance reason"}`, 1))
 	})
 
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "42"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "42"})
 	c.Assert(err, check.ErrorMatches, "unknown maintenance reason")
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -247,13 +247,13 @@ func (s *PebbleSuite) TestTasksLast(c *check.C) {
 	expectedChange := `(?ms)Status +Spawn +Ready +Summary
 Do +2016-04-21T01:02:03Z +- +some summary
 `
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--abs-time", "--last=install"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--abs-time", "--last=install"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, expectedChange)
 	c.Check(s.Stderr(), check.Equals, "")
 
-	_, err = cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--abs-time", "--last=foobar"})
+	_, err = cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--abs-time", "--last=foobar"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `no changes of type "foobar" found`)
 }
@@ -274,13 +274,13 @@ func (s *PebbleSuite) TestTasksLastQuestionmark(c *check.C) {
 		}
 	})
 	for i := 0; i < 2; i++ {
-		rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--last=foobar?"})
+		rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--last=foobar?"})
 		c.Assert(err, check.IsNil)
 		c.Assert(rest, check.DeepEquals, []string{})
 		c.Check(s.Stdout(), check.Matches, "")
 		c.Check(s.Stderr(), check.Equals, "")
 
-		_, err = cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--last=foobar"})
+		_, err = cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--last=foobar"})
 		if i == 0 {
 			c.Assert(err, check.ErrorMatches, `no changes found`)
 		} else {
@@ -292,11 +292,11 @@ func (s *PebbleSuite) TestTasksLastQuestionmark(c *check.C) {
 }
 
 func (s *PebbleSuite) TestTasksSyntaxError(c *check.C) {
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--abs-time", "--last=install", "42"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--abs-time", "--last=install", "42"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `cannot use change ID and type together`)
 
-	_, err = cli.Parser(cli.Client()).ParseArgs([]string{"tasks"})
+	_, err = cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks"})
 	c.Assert(err, check.NotNil)
 	c.Assert(err, check.ErrorMatches, `please provide change ID or type with --last=<type>`)
 }
@@ -326,7 +326,7 @@ func (s *PebbleSuite) TestChangeProgress(c *check.C) {
 
 		n++
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"tasks", "--abs-time", "42"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"tasks", "--abs-time", "42"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.DeepEquals, []string{})
 	c.Check(s.Stdout(), check.Matches, `(?ms)Status +Spawn +Ready +Summary

--- a/internals/cli/cmd_checks_test.go
+++ b/internals/cli/cmd_checks_test.go
@@ -39,7 +39,7 @@ func (s *PebbleSuite) TestChecks(c *check.C) {
 	]
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"checks"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"checks"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
@@ -62,7 +62,7 @@ func (s *PebbleSuite) TestPlanNoChecks(c *check.C) {
     "result": []
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"checks"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"checks"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -80,7 +80,7 @@ func (s *PebbleSuite) TestNoMatchingChecks(c *check.C) {
     "result": []
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"checks", "--level=alive", "chk1", "chk3"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"checks", "--level=alive", "chk1", "chk3"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -101,7 +101,7 @@ func (s *PebbleSuite) TestChecksFiltering(c *check.C) {
 	]
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"checks", "--level=alive", "chk1", "chk3"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"checks", "--level=alive", "chk1", "chk3"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
@@ -122,7 +122,7 @@ func (s *PebbleSuite) TestChecksFails(c *check.C) {
     "result": {"message": "could not bar"}
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"checks"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"checks"})
 	c.Assert(err, check.ErrorMatches, "could not bar")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/go-flags"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/internals/clientutil"
 	"github.com/canonical/pebble/internals/logger"
 )
 
@@ -47,8 +48,9 @@ These subcommands are currently supported:
 `
 
 type cmdEnter struct {
-	client *client.Client
-	parser *flags.Parser
+	client    *client.Client
+	transport *clientutil.Transport
+	parser    *flags.Parser
 
 	sharedRunEnterOpts
 	Run        bool `long:"run"`
@@ -63,7 +65,11 @@ func init() {
 		Summary:     cmdEnterSummary,
 		Description: cmdEnterDescription,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdEnter{client: opts.Client, parser: opts.Parser}
+			return &cmdEnter{
+				client:    opts.Client,
+				transport: opts.Transport,
+				parser:    opts.Parser,
+			}
 		},
 		ArgsHelp: merge(sharedRunEnterArgsHelp, map[string]string{
 			"--run": "Start default services before executing subcommand",
@@ -123,7 +129,7 @@ func (cmd *cmdEnter) Execute(args []string) error {
 		extraArgs []string
 	)
 
-	parser := Parser(cmd.client)
+	parser := Parser(cmd.client, cmd.transport)
 	parser.CommandHandler = func(c flags.Commander, a []string) error {
 		commander = c
 		extraArgs = a

--- a/internals/cli/cmd_help_test.go
+++ b/internals/cli/cmd_help_test.go
@@ -24,7 +24,7 @@ func (s *PebbleSuite) TestHelpCommand(c *C) {
 	restore := fakeArgs("pebble", "help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -34,7 +34,7 @@ func (s *PebbleSuite) TestHelpAll(c *C) {
 	restore := fakeArgs("pebble", "help", "--all")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*run.*help.*version.*warnings.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -44,7 +44,7 @@ func (s *PebbleSuite) TestHelpAllWithCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "help", "--all")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, ErrorMatches, `help accepts a command, or '--all', but not both.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -54,7 +54,7 @@ func (s *PebbleSuite) TestHelpMan(c *C) {
 	restore := fakeArgs("pebble", "help", "--man")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, `(?s)\.TH.*\.SH NAME.*pebble \\- Tool to interact with pebble.*`)
 	c.Check(s.Stderr(), Equals, "")
@@ -64,7 +64,7 @@ func (s *PebbleSuite) TestHelpOption(c *C) {
 	restore := fakeArgs("pebble", "--help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Pebble lets you control services.*Commands can be classified as follows.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -74,7 +74,7 @@ func (s *PebbleSuite) TestHelpWithCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -84,7 +84,7 @@ func (s *PebbleSuite) TestHelpWithUnknownCommand(c *C) {
 	restore := fakeArgs("pebble", "help", "dachshund")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, ErrorMatches, `unknown command "dachshund", see 'pebble help'.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -94,7 +94,7 @@ func (s *PebbleSuite) TestHelpWithUnknownSubcommand(c *C) {
 	restore := fakeArgs("pebble", "help", "add", "dachshund")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, ErrorMatches, `unknown command "dachshund", see 'pebble help add'.`)
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
@@ -104,7 +104,7 @@ func (s *PebbleSuite) TestCommandWithHelpOption(c *C) {
 	restore := fakeArgs("pebble", "help", "--help")
 	defer restore()
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 	c.Check(s.Stdout(), Matches, "(?s)Usage.*pebble help.*The help command.*help command options.*")
 	c.Check(s.Stderr(), Equals, "")
@@ -120,7 +120,7 @@ func (s *PebbleSuite) TestAddHelpCategory(c *C) {
 		Commands:    []string{"run", "logs"},
 	})
 
-	err := cli.RunMain()
+	err := cli.Run()
 	c.Assert(err, Equals, nil)
 
 	c.Check(s.Stdout(), Matches, "(?s).*Test category: run, logs\n.*")

--- a/internals/cli/cmd_logs_test.go
+++ b/internals/cli/cmd_logs_test.go
@@ -37,7 +37,7 @@ func (s *PebbleSuite) TestLogsText(c *C) {
 {"time":"2021-05-03T03:55:50.076800988Z","service":"thing","message":"the third"}
 `[1:])
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `
@@ -61,7 +61,7 @@ func (s *PebbleSuite) TestLogsJSON(c *C) {
 {"time":"2021-05-03T03:55:50.076800988Z","service":"thing","message":"the third"}
 `[1:])
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs", "--format", "json"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs", "--format", "json"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `
@@ -73,7 +73,7 @@ func (s *PebbleSuite) TestLogsJSON(c *C) {
 }
 
 func (s *PebbleSuite) TestLogsInvalidFormat(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs", "--format", "invalid"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs", "--format", "invalid"})
 	c.Assert(err.Error(), Equals, `invalid output format (expected "json" or "text", not "invalid")`)
 	c.Assert(rest, HasLen, 1)
 }
@@ -90,7 +90,7 @@ func (s *PebbleSuite) TestLogsN(c *C) {
 {"time":"2021-05-03T03:55:49.654334232Z","service":"snappass","message":"log two"}
 `[1:])
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs", "-n2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs", "-n2"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `
@@ -112,7 +112,7 @@ func (s *PebbleSuite) TestLogsAll(c *C) {
 {"time":"2021-05-03T03:55:49.654334232Z","service":"snappass","message":"log two"}
 `[1:])
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs", "-nall"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs", "-nall"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `
@@ -123,7 +123,7 @@ func (s *PebbleSuite) TestLogsAll(c *C) {
 }
 
 func (s *PebbleSuite) TestLogsInvalidNumber(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs", "-ninvalid"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs", "-ninvalid"})
 	c.Assert(err.Error(), Equals, `expected n to be a non-negative integer or "all", not "invalid"`)
 	c.Assert(rest, HasLen, 1)
 }
@@ -142,7 +142,7 @@ func (s *PebbleSuite) TestLogsFollow(c *C) {
 {"time":"2021-05-03T03:55:49.360994155Z","service":"thing","message":"log 1"}
 `[1:])
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"logs", "-f"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"logs", "-f"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `

--- a/internals/cli/cmd_ls_test.go
+++ b/internals/cli/cmd_ls_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (s *PebbleSuite) TestLsExtraArgs(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"ls", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"ls", "extra", "args"})
 	c.Assert(err, Equals, cli.ErrExtraArgs)
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -53,7 +53,7 @@ func (s *PebbleSuite) TestLsDirectory(c *C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"ls", "-d", "/"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"ls", "-d", "/"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 
@@ -96,7 +96,7 @@ func (s *PebbleSuite) TestLsLongFormat(c *C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"ls", "-l", "/"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"ls", "-l", "/"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 
@@ -113,7 +113,7 @@ func (s *PebbleSuite) TestLsFails(c *C) {
 		c.Assert(r.URL.Query(), DeepEquals, url.Values{"path": {"/"}, "action": {"list"}, "itself": {"true"}})
 		fmt.Fprintln(w, `{"type":"error","result":{"message":"could not foo"}}`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"ls", "-d", "/"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"ls", "-d", "/"})
 	c.Assert(err, ErrorMatches, "could not foo")
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -128,7 +128,7 @@ func (s *PebbleSuite) TestLsPattern(c *C) {
 		fmt.Fprintln(w, `{"type":"sync","result":[]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"ls", "/foo/bar.*"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"ls", "/foo/bar.*"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -136,7 +136,7 @@ func (s *PebbleSuite) TestLsPattern(c *C) {
 }
 
 func (s *PebbleSuite) TestLsInvalidPattern(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"ls", "/foo/ba[rz]/fail"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"ls", "/foo/ba[rz]/fail"})
 	c.Assert(err, ErrorMatches, "can only use globs on the last path element")
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")

--- a/internals/cli/cmd_mkdir_test.go
+++ b/internals/cli/cmd_mkdir_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (s *PebbleSuite) TestMkdirExtraArgs(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "/foo", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "/foo", "extra", "args"})
 	c.Assert(err, Equals, cli.ErrExtraArgs)
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -57,7 +57,7 @@ func (s *PebbleSuite) TestMkdir(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "/foo"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "/foo"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -65,7 +65,7 @@ func (s *PebbleSuite) TestMkdir(c *C) {
 }
 
 func (s *PebbleSuite) TestMkdirFailsParsingPermissions(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "-m", "foobar", "/foo"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "-m", "foobar", "/foo"})
 	c.Assert(err, ErrorMatches, `invalid mode for directory: "foobar"`)
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -96,7 +96,7 @@ func (s *PebbleSuite) TestMkdirMakeParents(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo/bar"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "-p", "/foo/bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "-p", "/foo/bar"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -127,7 +127,7 @@ func (s *PebbleSuite) TestMkdirPermissions(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo/bar"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "-m", "755", "/foo/bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "-m", "755", "/foo/bar"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -158,7 +158,7 @@ func (s *PebbleSuite) TestMkdirOwnerIDs(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo/bar"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "--uid", "1000", "--gid", "1000", "/foo/bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "--uid", "1000", "--gid", "1000", "/foo/bar"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -189,7 +189,7 @@ func (s *PebbleSuite) TestMkdirOwnerNames(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo/bar"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "--user", "root", "--group", "wheel", "/foo/bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "--user", "root", "--group", "wheel", "/foo/bar"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -220,7 +220,7 @@ func (s *PebbleSuite) TestMkdirFails(c *C) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "could not foo"}}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "/foo"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "/foo"})
 	c.Assert(err, ErrorMatches, "could not foo")
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -261,7 +261,7 @@ func (s *PebbleSuite) TestMkdirFailsOnDirectory(c *C) {
 		}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"mkdir", "/foobar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"mkdir", "/foobar"})
 
 	clientErr, ok := err.(*client.Error)
 	c.Assert(ok, Equals, true)

--- a/internals/cli/cmd_plan_test.go
+++ b/internals/cli/cmd_plan_test.go
@@ -36,7 +36,7 @@ func (s *PebbleSuite) TestGetPlan(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"plan"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"plan"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Assert(s.Stdout(), check.Equals, `
@@ -59,7 +59,7 @@ func (s *PebbleSuite) TestGetPlanFails(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"plan"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"plan"})
 	c.Assert(err.Error(), check.Equals, "could not do the thing")
 	c.Assert(rest, check.HasLen, 1)
 	c.Assert(s.Stdout(), check.Equals, ``)
@@ -67,7 +67,7 @@ func (s *PebbleSuite) TestGetPlanFails(c *check.C) {
 }
 
 func (s *PebbleSuite) TestPlanExtraArgs(c *check.C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"plan", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"plan", "extra", "args"})
 	c.Assert(err, check.Equals, cli.ErrExtraArgs)
 	c.Check(rest, check.HasLen, 1)
 }

--- a/internals/cli/cmd_replan_test.go
+++ b/internals/cli/cmd_replan_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (s *PebbleSuite) TestReplanExtraArgs(c *check.C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"replan", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"replan", "extra", "args"})
 	c.Assert(err, check.Equals, cli.ErrExtraArgs)
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -67,7 +67,7 @@ func (s *PebbleSuite) TestReplan(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"replan"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"replan"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -91,7 +91,7 @@ func (s *PebbleSuite) TestReplanFailsNoDefaultServices(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"replan"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"replan"})
 	c.Assert(err, check.ErrorMatches, "no default services")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -117,7 +117,7 @@ func (s *PebbleSuite) TestReplanNoWait(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"replan", "--no-wait"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"replan", "--no-wait"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "43\n")
@@ -148,7 +148,7 @@ func (s *PebbleSuite) TestReplanFailsGetChange(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"replan"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"replan"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_restart_test.go
+++ b/internals/cli/cmd_restart_test.go
@@ -59,7 +59,7 @@ func (s *PebbleSuite) TestRestart(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"restart", "srv1", "srv2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"restart", "srv1", "srv2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -80,7 +80,7 @@ func (s *PebbleSuite) TestRestartFails(c *check.C) {
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"restart", "srv1", "srv3"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"restart", "srv1", "srv3"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -106,7 +106,7 @@ func (s *PebbleSuite) TestRestartNoWait(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"restart", "srv1", "srv2", "--no-wait"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"restart", "srv1", "srv2", "--no-wait"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "44\n")
@@ -137,7 +137,7 @@ func (s *PebbleSuite) TestRestartFailsGetChange(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"restart", "srv1", "srv2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"restart", "srv1", "srv2"})
 	c.Assert(err, check.ErrorMatches, "could not bar")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_rm_test.go
+++ b/internals/cli/cmd_rm_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (s *PebbleSuite) TestRmExtraArgs(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"rm", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"rm", "extra", "args"})
 	c.Assert(err, Equals, cli.ErrExtraArgs)
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -51,7 +51,7 @@ func (s *PebbleSuite) TestRm(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo/bar.baz"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"rm", "/foo/bar.baz"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"rm", "/foo/bar.baz"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -77,7 +77,7 @@ func (s *PebbleSuite) TestRmRecursive(c *C) {
 		fmt.Fprintln(w, `{"type": "sync", "result": [{"path": "/foo/bar"}]}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"rm", "-r", "/foo/bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"rm", "-r", "/foo/bar"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, "")
@@ -103,7 +103,7 @@ func (s *PebbleSuite) TestRmFails(c *C) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "could not foo"}}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"rm", "/foo/bar.baz"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"rm", "/foo/bar.baz"})
 	c.Assert(err, ErrorMatches, "could not foo")
 	c.Assert(rest, HasLen, 1)
 	c.Check(s.Stdout(), Equals, "")
@@ -139,7 +139,7 @@ func (s *PebbleSuite) TestRmFailsOnPath(c *C) {
 		}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"rm", "-r", "/foo/bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"rm", "-r", "/foo/bar"})
 
 	clientErr, ok := err.(*client.Error)
 	c.Assert(ok, Equals, true)

--- a/internals/cli/cmd_services_test.go
+++ b/internals/cli/cmd_services_test.go
@@ -39,7 +39,7 @@ func (s *PebbleSuite) TestServices(c *check.C) {
 	]
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"services"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"services"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
@@ -62,7 +62,7 @@ func (s *PebbleSuite) TestPlanNoServices(c *check.C) {
     "result": []
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"services"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"services"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -80,7 +80,7 @@ func (s *PebbleSuite) TestNoMatchingServices(c *check.C) {
     "result": []
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"services", "foo", "bar"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"services", "foo", "bar"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -101,7 +101,7 @@ func (s *PebbleSuite) TestServicesNames(c *check.C) {
 	]
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"services", "foo", "bar", "--abs-time"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"services", "foo", "bar", "--abs-time"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
@@ -122,7 +122,7 @@ func (s *PebbleSuite) TestServicesFail(c *check.C) {
     "result": {"message": "could not foo"}
 }`)
 	})
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"services"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"services"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_signal_test.go
+++ b/internals/cli/cmd_signal_test.go
@@ -39,7 +39,7 @@ func (s *PebbleSuite) TestSignalShortName(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"signal", "HUP", "s1"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"signal", "HUP", "s1"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 }
@@ -60,7 +60,7 @@ func (s *PebbleSuite) TestSignalFullName(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"signal", "SIGHUP", "s2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"signal", "SIGHUP", "s2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 }
@@ -81,13 +81,13 @@ func (s *PebbleSuite) TestSignalMultipleServices(c *check.C) {
 }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"signal", "SIGHUP", "s1", "s2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"signal", "SIGHUP", "s1", "s2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 }
 
 func (s *PebbleSuite) TestSignalErrorLowercase(c *check.C) {
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"signal", "hup", "s1"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"signal", "hup", "s1"})
 	c.Assert(err, check.ErrorMatches, "signal name must be uppercase, for example HUP")
 }
 
@@ -108,6 +108,6 @@ func (s *PebbleSuite) TestSignalServerError(c *check.C) {
 		}`)
 	})
 
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"signal", "HUP", "s1"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"signal", "HUP", "s1"})
 	c.Assert(err, check.ErrorMatches, `invalid signal name "SIGFOO"`)
 }

--- a/internals/cli/cmd_start_test.go
+++ b/internals/cli/cmd_start_test.go
@@ -59,7 +59,7 @@ func (s *PebbleSuite) TestStart(c *check.C) {
  }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"start", "srv1", "srv2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"start", "srv1", "srv2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -80,7 +80,7 @@ func (s *PebbleSuite) TestStartFails(c *check.C) {
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"start", "srv1", "srv3"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"start", "srv1", "srv3"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -106,7 +106,7 @@ func (s *PebbleSuite) TestStartNoWait(c *check.C) {
  }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"start", "srv1", "srv2", "--no-wait"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"start", "srv1", "srv2", "--no-wait"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "45\n")
@@ -137,7 +137,7 @@ func (s *PebbleSuite) TestStartFailsGetChange(c *check.C) {
  }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"start", "srv1", "srv2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"start", "srv1", "srv2"})
 	c.Assert(err, check.ErrorMatches, "could not bar")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_stop_test.go
+++ b/internals/cli/cmd_stop_test.go
@@ -59,7 +59,7 @@ func (s *PebbleSuite) TestStop(c *check.C) {
  }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"stop", "srv1", "srv2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"stop", "srv1", "srv2"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -80,7 +80,7 @@ func (s *PebbleSuite) TestStopFails(c *check.C) {
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"stop", "srv1", "srv3"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"stop", "srv1", "srv3"})
 	c.Assert(err, check.ErrorMatches, "could not foo")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")
@@ -106,7 +106,7 @@ func (s *PebbleSuite) TestStopNoWait(c *check.C) {
  }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"stop", "srv1", "srv2", "--no-wait"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"stop", "srv1", "srv2", "--no-wait"})
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "46\n")
@@ -137,7 +137,7 @@ func (s *PebbleSuite) TestStopFailsGetChange(c *check.C) {
  }`)
 	})
 
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"stop", "srv1", "srv2"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"stop", "srv1", "srv2"})
 	c.Assert(err, check.ErrorMatches, "could not bar")
 	c.Assert(rest, check.HasLen, 1)
 	c.Check(s.Stdout(), check.Equals, "")

--- a/internals/cli/cmd_version_test.go
+++ b/internals/cli/cmd_version_test.go
@@ -31,7 +31,7 @@ func (s *PebbleSuite) TestVersion(c *C) {
 	restore := fakeVersion("4.56")
 	defer restore()
 
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"version"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "client  4.56\nserver  7.89\n")
 	c.Check(s.Stderr(), Equals, "")
@@ -41,14 +41,14 @@ func (s *PebbleSuite) TestVersionClientOnly(c *C) {
 	restore := fakeVersion("v1.2.3")
 	defer restore()
 
-	_, err := cli.Parser(cli.Client()).ParseArgs([]string{"version", "--client"})
+	_, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"version", "--client"})
 	c.Assert(err, IsNil)
 	c.Check(s.Stdout(), Equals, "v1.2.3\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 
 func (s *PebbleSuite) TestVersionExtraArgs(c *C) {
-	rest, err := cli.Parser(cli.Client()).ParseArgs([]string{"version", "extra", "args"})
+	rest, err := cli.Parser(cli.Client(), cli.Transport()).ParseArgs([]string{"version", "extra", "args"})
 	c.Assert(err, Equals, cli.ErrExtraArgs)
 	c.Assert(rest, HasLen, 1)
 }

--- a/internals/cli/export_test.go
+++ b/internals/cli/export_test.go
@@ -18,18 +18,21 @@ import (
 	"fmt"
 
 	"github.com/canonical/pebble/client"
+	"github.com/canonical/pebble/internals/clientutil"
 )
-
-var RunMain = Run
 
 var ClientConfig = &clientConfig
 
 func Client() *client.Client {
-	cli, err := client.New(ClientConfig)
+	return client.NewFromTransport(Transport())
+}
+
+func Transport() *clientutil.Transport {
+	t, err := clientutil.NewTransport(ClientConfig.Socket, ClientConfig.UserAgent)
 	if err != nil {
-		panic("cannot create client:" + err.Error())
+		panic("cannot create transport: " + err.Error())
 	}
-	return cli
+	return t
 }
 
 var (

--- a/internals/clientutil/clientutil.go
+++ b/internals/clientutil/clientutil.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clientutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/canonical/pebble/internals/wsutil"
+)
+
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type Websocket interface {
+	wsutil.MessageReader
+	wsutil.MessageWriter
+	io.Closer
+	JSONWriter
+}
+
+type JSONWriter interface {
+	WriteJSON(v interface{}) error
+}
+
+// RequestError is returned when there's an error processing the request.
+type RequestError struct{ error }
+
+func (e RequestError) Error() string {
+	return fmt.Sprintf("cannot build request: %v", e.error)
+}
+
+// ConnectionError represents a connection or communication error.
+type ConnectionError struct {
+	error
+}
+
+func (e ConnectionError) Error() string {
+	return fmt.Sprintf("cannot communicate with server: %v", e.error)
+}
+
+func (e ConnectionError) Unwrap() error {
+	return e.error
+}
+
+var (
+	doRetry   = 250 * time.Millisecond
+	doTimeout = 5 * time.Second
+)
+
+// FakeDoRetry fakes the delays used by the do retry loop (intended for
+// testing). Calling restore will revert the changes.
+func FakeDoRetry(retry, timeout time.Duration) (restore func()) {
+	oldRetry := doRetry
+	oldTimeout := doTimeout
+	doRetry = retry
+	doTimeout = timeout
+	return func() {
+		doRetry = oldRetry
+		doTimeout = oldTimeout
+	}
+}
+
+// raw performs a request and returns the resulting http.Response and
+// error you usually only need to call this directly if you expect the
+// response to not be JSON, otherwise you'd call Do(...) instead.
+func (t *Transport) Raw(ctx context.Context, method, urlpath string, query url.Values, headers map[string]string, body io.Reader) (*http.Response, error) {
+	// fake a url to keep http.Client happy
+	p, err := url.Parse(urlpath)
+	if err != nil {
+		return nil, RequestError{err}
+	}
+	u := t.BaseURL.ResolveReference(p)
+	u.RawQuery = query.Encode()
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
+	if err != nil {
+		return nil, RequestError{err}
+	}
+	if t.UserAgent != "" {
+		req.Header.Set("User-Agent", t.UserAgent)
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	rsp, err := t.Doer.Do(req)
+	if err != nil {
+		return nil, ConnectionError{err}
+	}
+
+	return rsp, nil
+}
+
+// do performs a request and decodes the resulting json into the given
+// value. It's low-level, for testing/experimenting only; you should
+// usually use a higher level interface that builds on this.
+func (t *Transport) Do(method, path string, query url.Values, headers map[string]string, body io.Reader, v interface{}) error {
+	retry := time.NewTicker(doRetry)
+	defer retry.Stop()
+	timeout := time.After(doTimeout)
+	var rsp *http.Response
+	var err error
+	for {
+		rsp, err = t.Raw(context.Background(), method, path, query, headers, body)
+		if err == nil || method != "GET" {
+			break
+		}
+		select {
+		case <-retry.C:
+			continue
+		case <-timeout:
+		}
+		break
+	}
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+
+	if v != nil {
+		if err := decodeInto(rsp.Body, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeInto(reader io.Reader, v interface{}) error {
+	dec := json.NewDecoder(reader)
+	if err := dec.Decode(v); err != nil {
+		r := dec.Buffered()
+		buf, err1 := ioutil.ReadAll(r)
+		if err1 != nil {
+			buf = []byte(fmt.Sprintf("error reading buffered response body: %s", err1))
+		}
+		return fmt.Errorf("cannot decode %q: %w", buf, err)
+	}
+	return nil
+}

--- a/internals/clientutil/transport.go
+++ b/internals/clientutil/transport.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clientutil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// SocketNotFoundError is the error type returned when the client fails
+// to find a unix socket at the specified path.
+type SocketNotFoundError struct {
+	// Err is the wrapped error.
+	Err error
+
+	// Path is the path of the non-existent socket.
+	Path string
+}
+
+func (s SocketNotFoundError) Error() string {
+	if s.Path == "" && s.Err != nil {
+		return s.Err.Error()
+	}
+	return fmt.Sprintf("socket %q not found", s.Path)
+}
+
+func (s SocketNotFoundError) Unwrap() error {
+	return s.Err
+}
+
+// Transport contains an HTTP client and information about it that can be used
+// to create Client instances that are connection-detail agnostic.
+type Transport struct {
+	// Doer is an HTTP client instance to be used to perform requests.
+	Doer Doer
+	// BaseURL is needed to capture the scheme and hostname of the server.
+	BaseURL url.URL
+	// UserAgent will be passed alongside every request to identify the Client.
+	UserAgent string
+
+	client *http.Client
+}
+
+// NewTransport creates a new Transport instance with the specified connection
+// details. When specifying the connection address, either a URL or a local
+// Unix socket path can be specified.
+func NewTransport(address string, userAgent string) (*Transport, error) {
+	var httpTransport *http.Transport
+	baseURL, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse base URL: %w", err)
+	}
+
+	if baseURL.Scheme == "" {
+		// Talk over a Unix socket.
+		baseURL = &url.URL{Scheme: "http", Host: "localhost"}
+		httpTransport = &http.Transport{
+			Dial: func(_, _ string) (net.Conn, error) {
+				_, err := os.Stat(address)
+				if errors.Is(err, os.ErrNotExist) {
+					return nil, &SocketNotFoundError{Err: err, Path: address}
+				} else if err != nil {
+					return nil, fmt.Errorf("cannot stat %q: %w", address, err)
+				}
+
+				return net.Dial("unix", address)
+			},
+		}
+	} else {
+		// Talk regular HTTP over TCP.
+		httpTransport = &http.Transport{}
+	}
+
+	client := &http.Client{Transport: httpTransport}
+	return &Transport{
+		Doer:      client,
+		BaseURL:   *baseURL,
+		UserAgent: userAgent,
+		client:    client,
+	}, nil
+}
+
+func (t *Transport) GetWebsocket(url string) (Websocket, error) {
+	httpTransport := t.client.Transport.(*http.Transport)
+	dialer := websocket.Dialer{
+		NetDial:          httpTransport.Dial,
+		Proxy:            httpTransport.Proxy,
+		TLSClientConfig:  httpTransport.TLSClientConfig,
+		HandshakeTimeout: 5 * time.Second,
+	}
+	conn, _, err := dialer.Dial(url, nil)
+	return conn, err
+}
+
+func (t *Transport) CloseIdleConnections() {
+	t.client.CloseIdleConnections()
+}


### PR DESCRIPTION
This PR exposes client connection information (such as the base URL, the HTTP request `Doer` and common HTTP utility functions for extended Pebble clients) under the `Transport` struct of new `clientutil` package.

This allows external applications to extend the Pebble client and perform HTTP requests to the underlying daemon without exposing the internal state of the client to third-party applications that use the `client` package to call Pebble APIs.

The `clientutil` package is not intended for these applications, but for software that extends Pebble.

The client API stays exactly the same, with the difference of Pebble and applications extending Pebble using new internal APIs to construct a client:

```go
/* Example 1: Creating a client for extending the CLI. */
package main

import (
    "github.com/canonical/pebble/client"
    "github.com/canonical/pebble/internals/clientutil"
)

func main() {
    // Create a client transport instance (DoSync*)
    transport, err := clientutil.NewTransport(&clientutil.TransportOptions{
        Address: "https://localhost:3000",  // Either base URL or socket path.
        UserAgent: "MyApplication/0.1",
    })
    if err != nil { /* ... */ }
    
    // Create a Pebble client
    client := client.NewFromTransport(transport)

    // Pass in the client and the transport
    if err := cli.Run(client, transport); err != nil {
        /* ... */
    }
}
```

Pebble CLI will pass the client and transport through `CmdOptions`:
```go
// CmdOptions exposes state made accessible during command execution.
type CmdOptions struct {
	Client    *client.Client
	Transport *clientutil.Transport
	Parser    *flags.Parser
}
```
Extending a Pebble client could be done in the following manner:
```go
package xclient

import (
	"github.com/canonical/pebble/client"
	"github.com/canonical/pebble/internals/clientutil"
)

// Client is a Pebble-compatible gateway for talking to the X daemon.
// All APIs that Pebble supports are available, in addition to X-specific
// ones.
type Client struct {
	*client.Client
	transport *clientutil.Transport
}

func New(client *client.Client, transport *clientutil.Transport) *Client {
	return &Client{Client: client, transport: transport}
}

func (c *Client) Foo() {
        /* The Do(), DoSync(), DoAsync() APIs are prone to change -- WIP */ 
	c.transport.Do("POST", "/v1/foo", nil, nil, nil, nil)
}
```



And extended application's commands could be constructed the following way:
```go
func init() {
	cli.AddCommand(&cli.CmdInfo{
		Name:        "foo",
		/* ... */
		New: func(opts *cli.CmdOptions) flags.Commander {
			return &cmdFoo{client: xclient.New(opts.Client, opts.Transport)}
		},
	})
}
```