### PR TITLE
fix(cmdstate): better error message if $HOME dir doesn't exist

### DIFF
--- a/internals/daemon/api_exec.go
+++ b/internals/daemon/api_exec.go
@@ -69,19 +69,6 @@ func v1PostExec(c *Command, req *http.Request, _ *UserState) Response {
 		return statusBadRequest("cannot find executable %q", payload.Command[0])
 	}
 
-	// Also check that the working directory exists, to avoid a confusing
-	// error message later that implies the command doesn't exist:
-	//
-	//  fork/exec /usr/local/bin/realcommand: no such file or directory
-	//
-	// Note that this check still doesn't check that the permissions are
-	// correct to use it as a working directory, but this is a good start.
-	if payload.WorkingDir != "" {
-		if !osutil.IsDir(payload.WorkingDir) {
-			return statusBadRequest("cannot find working directory %q", payload.WorkingDir)
-		}
-	}
-
 	p, err := c.d.overlord.ServiceManager().Plan()
 	if err != nil {
 		return statusBadRequest("%v", err)

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -246,6 +246,16 @@ func (s *execSuite) TestUserGroup(c *C) {
 	c.Assert(waitErr, IsNil)
 	c.Check(stdout, Equals, username+"\n"+group+"\n")
 	c.Check(stderr, Equals, "")
+
+	stdout, stderr, waitErr = s.exec(c, "", &client.ExecOptions{
+		Command:     []string{"pwd"},
+		Environment: map[string]string{"HOME": "/non/existent"},
+		User:        username,
+		Group:       group,
+	})
+	c.Assert(waitErr, IsNil)
+	c.Check(stdout, Equals, "/\n")
+	c.Check(stderr, Equals, "")
 }
 
 // See .github/workflows/tests.yml for how to run this test as root.

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -141,6 +142,25 @@ func (s *execSuite) TestWorkingDir(c *C) {
 	c.Check(stderr, Equals, "")
 }
 
+func (s *execSuite) TestWorkingDirDoesNotExist(c *C) {
+	_, err := s.client.Exec(&client.ExecOptions{
+		Command:    []string{"pwd"},
+		WorkingDir: "/non/existent",
+	})
+	c.Check(err, ErrorMatches, `.*working directory.*does not exist`)
+}
+
+func (s *execSuite) TestWorkingDirNotADirectory(c *C) {
+	path := filepath.Join(c.MkDir(), "test")
+	err := os.WriteFile(path, nil, 0o777)
+	c.Assert(err, IsNil)
+	_, err = s.client.Exec(&client.ExecOptions{
+		Command:    []string{"pwd"},
+		WorkingDir: path,
+	})
+	c.Check(err, ErrorMatches, `.*working directory.*not a directory`)
+}
+
 func (s *execSuite) TestExitError(c *C) {
 	stdout, stderr, waitErr := s.exec(c, "", &client.ExecOptions{
 		Command: []string{"/bin/sh", "-c", "echo OUT; echo ERR >&2; exit 42"},
@@ -247,15 +267,13 @@ func (s *execSuite) TestUserGroup(c *C) {
 	c.Check(stdout, Equals, username+"\n"+group+"\n")
 	c.Check(stderr, Equals, "")
 
-	stdout, stderr, waitErr = s.exec(c, "", &client.ExecOptions{
+	_, err := s.client.Exec(&client.ExecOptions{
 		Command:     []string{"pwd"},
 		Environment: map[string]string{"HOME": "/non/existent"},
 		User:        username,
 		Group:       group,
 	})
-	c.Assert(waitErr, IsNil)
-	c.Check(stdout, Equals, "/\n")
-	c.Check(stderr, Equals, "")
+	c.Assert(err, ErrorMatches, `.*home directory.*does not exist`)
 }
 
 // See .github/workflows/tests.yml for how to run this test as root.

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -117,11 +117,14 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		environment["LANG"] = "C.UTF-8"
 	}
 
-	// Set default working directory to $HOME, or / if $HOME not set.
+	// Set default working directory to $HOME, or / if $HOME not set or doesn't exist.
 	workingDir := args.WorkingDir
 	if workingDir == "" {
 		workingDir = environment["HOME"]
 		if workingDir == "" {
+			workingDir = "/"
+		} else if !osutil.IsDir(workingDir) {
+			logger.Debugf("HOME dir %q does not exist, using /", workingDir)
 			workingDir = "/"
 		}
 	}

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -17,6 +17,7 @@ package cmdstate
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
 	"strconv"
@@ -117,16 +118,9 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		environment["LANG"] = "C.UTF-8"
 	}
 
-	// Set default working directory to $HOME, or / if $HOME not set or doesn't exist.
-	workingDir := args.WorkingDir
-	if workingDir == "" {
-		workingDir = environment["HOME"]
-		if workingDir == "" {
-			workingDir = "/"
-		} else if !osutil.IsDir(workingDir) {
-			logger.Debugf("HOME dir %q does not exist, using /", workingDir)
-			workingDir = "/"
-		}
+	workingDir, err := getWorkingDir(args.WorkingDir, environment["HOME"])
+	if err != nil {
+		return nil, ExecMetadata{}, err
 	}
 
 	// Create a task for this execution (though it's not started here).
@@ -153,4 +147,31 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 	}
 
 	return task, metadata, nil
+}
+
+// getWorkingDir calculates the working directory using the working-dir
+// argument, or $HOME if that's not set, or "/" if $HOME is not set.
+func getWorkingDir(workingDir, homeDir string) (string, error) {
+	dirName := "working directory"
+	if workingDir == "" {
+		if homeDir == "" {
+			return "/", nil
+		}
+		workingDir = homeDir
+		dirName = "home directory"
+	}
+	// Check that the working directory exists, to avoid a confusing error
+	// message later that implies the command doesn't exist, for example:
+	//
+	//  fork/exec /usr/local/bin/realcommand: no such file or directory
+	st, err := os.Stat(workingDir)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "", fmt.Errorf("%s %q does not exist", dirName, workingDir)
+	case err != nil:
+		return "", fmt.Errorf("cannot stat %s %q: %w", dirName, workingDir, err)
+	case !st.IsDir():
+		return "", fmt.Errorf("%s %q not a directory", dirName, workingDir)
+	}
+	return workingDir, nil
 }


### PR DESCRIPTION
Currently if you create a user without a home directory (or a home directory that doesn't exist), `pebble exec` fails with a hard-to-understand error message which implies the executable you're trying to run doesn't exist. (As #189 points out, you can easily create a user without creating the home directory.)

For the [first version](https://github.com/canonical/pebble/pull/309/commits/ccf677e23f1ddea506abe8e043160fe7e4d72984) of this PR, we made that not fail (and use "/" as the working dir). However, as @hpidcock pointed out, that's problematic, and it probably should fail. Otherwise the caller might call `rm -rf bin` with `HOME=/home/ubuntu`, which if it doesn't exist will fall back to deleting `/bin` -- likely not what you want.

So it's better to return an error in this case. The charm or whoever's calling Pebble will need to fix their charm, by:

1) Explicitly specifying a working dir which does exist, or
2) Creating the HOME directory.

To test this, build and run Pebble with `sudo` in one terminal:

```
$ go build ./cmd/pebble
$ sudo ./pebble run
2023-09-19T05:08:20.457Z [pebble] Started daemon.
...
```

Then create a user with a non-existent home directory (I've created `tstuser` with non-existent HOME dir `/home/tstuser` for this example). Then use `sudo ./pebble exec`:

```
# BEFORE THIS PR
$ sudo ./pebble exec --user tstuser --group tstuser -- pwd
error: cannot perform the following tasks:
- exec command "pwd" (fork/exec /usr/bin/pwd: no such file or directory)

# AFTER THIS PR
$ sudo ./pebble exec --user tstuser --group tstuser -- pwd
error: cannot call exec: home directory "/home/tstuser" does not exist
```

Fixes #189