### PR TITLE
fix(snap): drive the snap release workflow to avoid skipping tagged versions

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -3,98 +3,116 @@ name: Pebble snap
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
   release:
     types: [published]
 
 env:
   SNAP_NAME: pebble
+  DEFAULT_TRACK: latest
+  DEFAULT_RISK: edge
 
 jobs:
-  build:
+  snaps:
     runs-on: ubuntu-latest
-    outputs:
-      pebble-snap: ${{ steps.build-pebble-snap.outputs.snap }}
-
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64, ppc64el, armhf, s390x]
     steps:
       - name: Checkout Pebble repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Build Pebble Snap
-        id: build-pebble-snap
-        uses: snapcore/action-build@v1
+      - name: Set LP credentials for remote build
+        id: set-local-paths
+        run: |
+          lp_creds_path="$HOME/.local/share/snapcraft/provider/launchpad"
+          mkdir -p $lp_creds_path
+          echo '${{ secrets.LP_CREDENTIALS }}' > ${lp_creds_path}/credentials
+          git config --global user.email "${{ secrets.PEBBLE_DEV_MAILING_LIST}}"
+          git config --global user.name "pebble-dev"
 
-      - name: Attach pebble snap to GH workflow execution
-        uses: actions/upload-artifact@v2
+          echo "home=$HOME" >> $GITHUB_OUTPUT
+
+      - name: Build ${{ env.SNAP_NAME }} Snap for ${{ matrix.arch }}
+        id: build-snap
+        uses: snapcore/action-build@v1.1.3
         with:
-          name: ${{ steps.build-pebble-snap.outputs.snap }}
-          path: ${{ steps.build-pebble-snap.outputs.snap }}
+          snapcraft-args: remote-build --build-for=${{ matrix.arch }} --launchpad-accept-public-upload
 
-  test:
-    runs-on: ubuntu-latest
-    needs: [build]
-    outputs:
-      pebble-version: ${{ steps.install-pebble.outputs.version }}
-
-    steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/upload-artifact@v3
+        if: failure()
         with:
-          name: ${{ needs.build.outputs.pebble-snap }}
+          name: snapcraft-logs
+          path: |
+            ${{ steps.set-local-paths.outputs.home }}/.cache/snapcraft/log/
+            ${{ steps.set-local-paths.outputs.home }}/.local/state/snapcraft/log/
+            ${{ env.SNAP_NAME }}_*.txt
 
-      - name: Install the Pebble snap
-        id: install-pebble
+      - name: Install and test ${{ steps.build-snap.outputs.snap }}
+        # NOTE: this line can be adjusted if we start supporting multi-arch runners
+        if: ${{ matrix.arch	== 'amd64' }} 
         run: |
           set -ex
-          # Install the Pebble snap from the artifact built in the previous job
-          sudo snap install --dangerous --classic ${{ needs.build.outputs.pebble-snap }}
+          sudo snap install --dangerous --classic ${{ steps.build-snap.outputs.snap }}
 
-          # Make sure Pebble is installed
-          echo "version=$(pebble version --client)" >> "$GITHUB_OUTPUT"
+          # Make sure it is installed
+          pebble version --client
+          
+          # Run smoke test
+          pebble enter --create-dirs exec echo Hello | grep Hello
 
-      - name: Run smoke test
-        run: pebble enter --create-dirs exec echo Hello | grep Hello
+      - name: Attach ${{ steps.build-snap.outputs.snap }} to GH workflow execution
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.build-snap.outputs.snap }}
+          path: ${{ steps.build-snap.outputs.snap }}
+
+      - name: Release ${{ steps.build-snap.outputs.snap }} to ${{ env.DEFAULT_TRACK }}/${{ env.DEFAULT_RISK }}  
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build-snap.outputs.snap }}
+          release: ${{ env.DEFAULT_TRACK }}/${{ env.DEFAULT_RISK }}
 
   promote:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [snaps]
     strategy:
       fail-fast: false
       matrix:
         arch: [amd64, arm64, ppc64el, armhf, s390x]
     env:
-      TRACK: latest
-      DEFAULT_RISK: edge
+      TO_TRACK: latest
       TO_RISK: candidate
     steps:
       - name: Install Snapcraft
         run: sudo snap install snapcraft --classic
-      
-      - name: Wait for ${{ needs.test.outputs.pebble-version }} to be released
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        run: |
-          while ! `snapcraft status ${{ env.SNAP_NAME }} --track ${{ env.TRACK }} --arch ${{ matrix.arch }} \
-              | grep "${{ env.DEFAULT_RISK }}" \
-              | awk -F' ' '{print $2}' \
-              | grep -Fxq "${{ needs.test.outputs.pebble-version }}"`; do
-            echo "[${{ matrix.arch }}] Waiting for ${{ needs.test.outputs.pebble-version }} \
-          to be released to ${{ env.TRACK }}/${{ env.DEFAULT_RISK }}..."
-            sleep 10
-          done
 
-      # It would be easier to use `snapcraft promote`, but there's an error when trying
-      # to avoid the prompt with the "--yes" option: 
-      # > 'latest/edge' is not a valid set value for --from-channel when using --yes.
-      - name: Promote ${{ needs.test.outputs.pebble-version }} (${{ matrix.arch }}) to ${{ env.TO_RISK }}
+      - name: Get current ${{ matrix.arch }} ${{ env.SNAP_NAME }} snap in ${{ env.TO_TRACK }}/${{ env.TO_RISK }}
+        id: get-snap
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           revision="$(snapcraft status ${{ env.SNAP_NAME }} \
-            --track ${{ env.TRACK }} --arch ${{ matrix.arch }} \
+            --track ${{ env.DEFAULT_TRACK }} --arch ${{ matrix.arch }} \
             | grep "${{ env.DEFAULT_RISK }}" | awk -F' ' '{print $3}')"
 
+          echo "revision=$revision" >> $GITHUB_OUTPUT
+
+      # It would be easier to use `snapcraft promote`, but there's an error when trying
+      # to avoid the prompt with the "--yes" option: 
+      # > 'latest/edge' is not a valid set value for --from-channel when using --yes.
+      - name: Promote ${{ env.SNAP_NAME }} snap rev${{ steps.get-snap.outputs.revision }} to ${{ env.TO_TRACK }}/${{ env.TO_RISK }}
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
           snapcraft release ${{ env.SNAP_NAME }} \
-            $revision \
-            ${{ env.TRACK }}/${{ env.TO_RISK }}
+            ${{ steps.get-snap.outputs.revision }} \
+            ${{ env.TO_TRACK }}/${{ env.TO_RISK }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -8,6 +8,11 @@ on:
   release:
     types: [published]
 
+# We don't want this workflow to have multiple runs in parallel because
+# what could happen is that a slow-running and older execution will upload
+# an older snap to `edge`, after the newer and latest snap has already been released.
+concurrency: ${{ github.workflow }}
+
 env:
   SNAP_NAME: pebble
   DEFAULT_TRACK: latest

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
     plugin: nil
     source: .
     override-build: |
-      version="$(${CRAFT_PART_INSTALL}/bin/pebble version --client)"
+      version="$(${CRAFT_STAGE}/bin/pebble version --client)"
 
       # Set snap version
       craftctl set version="$version"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,18 +34,15 @@ parts:
     source: .
     build-snaps:
       - go/1.20/stable
-    build-environment:
-      - CGO_ENABLED: 0
-      - GOFLAGS: -trimpath -ldflags=-w -ldflags=-s
     override-build: |
       go generate ./cmd
-      craftctl default
+      CGO_ENABLED=0 go build -trimpath -ldflags=-w -ldflags=-s -o $CRAFT_PART_INSTALL/bin/pebble ./cmd/pebble
 
   pebble-release-data:
     plugin: nil
     source: .
     override-build: |
-      version="$(${CRAFT_STAGE}/bin/pebble version --client)"
+      version="$(${CRAFT_PART_INSTALL}/bin/pebble version --client)"
 
       # Set snap version
       craftctl set version="$version"


### PR DESCRIPTION
Fixes #300.

This PR addresses the issue described in #300. It includes the following changes:
 - instead of relying on the store to build the snaps, the GH workflow uses `remote-build` to drive the multi-arch builds,
 - the `snapcraft.yaml` parts were updated in order to be supported by the `remote-build` environment,
 - added a new trigger, on `push`, 
 - the resulting multi-arch snaps are uploaded to the snap store on every new GH release and push to `master`,
 - on every new GH release, it now simply takes the latest snap from `edge` to `candidate`,
 - finally, we apply concurrency to ensure 2 consecutive commits won't result in older snaps becoming the "latest" in the snap store.

## Before merging

 1. disconnect this repository from the Pebble snap "Builds" in the snap store
 2. add the following new secrets to the repo (thus why the CI is failing for this PR):
   - LP_CREDENTIALS (new and already shared with the team)
   - PEBBLE_DEV_MAILING_LIST (already shared with the team in the past)

---

This has been tested in: https://github.com/cjdcordeiro/pebble/actions/runs/6505676433 and https://github.com/cjdcordeiro/pebble/actions/runs/6505679630