### PR TITLE
feat(client): allow tests to assign a fake requester

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -190,6 +190,12 @@ func (client *Client) Requester() Requester {
 	return client.requester
 }
 
+// SetRequester allows derived projects that extend the client to test the
+// extended client code by supplying a fake requester interface.
+func (client *Client) SetRequester(rq Requester) {
+	client.requester = rq
+}
+
 func (client *Client) getTaskWebsocket(taskID, websocketID string) (clientWebsocket, error) {
 	url := fmt.Sprintf("ws://localhost/v1/tasks/%s/websocket/%s", taskID, websocketID)
 	return client.getWebsocket(url)


### PR DESCRIPTION
The client test suite used by all client command tests fakes the ```doer``` today, which is a private internal ```Requester``` implementation detail. Derived projects using the client ```Requester``` for extended commands needs to fake the Requester interface.

This PR adds a client method ```SetRequester(rw Requester)``` to allow test code to fake the requester. This has to be public to allow an external package to fake this.

Pending work remain to properly refactor the existing client test code to Fake the ```Requester``` instead of the ```doer```. This is captured as an outstanding issue here: https://github.com/canonical/pebble/issues/315