### PR TITLE
fix(state): set `noticeCond` correctly in `ReadState`

### DIFF
--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -416,9 +417,7 @@ func (s *noticesSuite) TestReadStateWaitNotices(c *C) {
 	marshalled, err := st.MarshalJSON()
 	c.Assert(err, IsNil)
 
-	buf := bytes.NewBuffer(marshalled)
-
-	st2, err := state.ReadState(nil, buf)
+	st2, err := state.ReadState(nil, bytes.NewBuffer(marshalled))
 	c.Assert(err, IsNil)
 	st2.Lock()
 	defer st2.Unlock()
@@ -426,7 +425,7 @@ func (s *noticesSuite) TestReadStateWaitNotices(c *C) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 	notices, err := st2.WaitNotices(ctx, nil)
-	c.Assert(err, ErrorMatches, "context deadline exceeded")
+	c.Assert(errors.Is(err, context.DeadlineExceeded), Equals, true)
 	c.Assert(notices, HasLen, 0)
 }
 

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -408,6 +408,28 @@ func (s *noticesSuite) TestWaitNoticesTimeout(c *C) {
 	c.Assert(notices, HasLen, 0)
 }
 
+func (s *noticesSuite) TestReadStateWaitNotices(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	marshalled, err := st.MarshalJSON()
+	c.Assert(err, IsNil)
+
+	buf := bytes.NewBuffer(marshalled)
+
+	st2, err := state.ReadState(nil, buf)
+	c.Assert(err, IsNil)
+	st2.Lock()
+	defer st2.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	notices, err := st2.WaitNotices(ctx, nil)
+	c.Assert(err, ErrorMatches, "context deadline exceeded")
+	c.Assert(notices, HasLen, 0)
+}
+
 func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
 	st := state.New(nil)
 	st.Lock()

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -456,5 +456,6 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 	s.backend = backend
 	s.modified = false
 	s.cache = make(map[interface{}]interface{})
+	s.noticeCond = sync.NewCond(s)
 	return s, err
 }


### PR DESCRIPTION
With the addition of support for notices in the pebble state, there was a small bug introduced in `ReadState`, which was not updated to set the new `noticeCond`. As a result, a call to `WaitNotices` from a state which was created via `ReadState` will cause a null pointer exception.

This PR adds the proper `noticeCond` initialization in `ReadState`, as well as a unit test to check that `WaitNotices` does not panic on a state which was created via `ReadState`.