### PR TITLE
fix(daemon): add-notice API shouldn't error if no data is provided

### DIFF
--- a/internals/daemon/api_notices.go
+++ b/internals/daemon/api_notices.go
@@ -136,9 +136,11 @@ func v1PostNotices(c *Command, r *http.Request, _ *UserState) Response {
 		return statusBadRequest("total size of data must be %d bytes or less", maxNoticeDataSize)
 	}
 	var data map[string]string
-	err = json.Unmarshal(payload.DataJSON, &data)
-	if err != nil {
-		return statusBadRequest("cannot decode notice data: %v", err)
+	if len(payload.DataJSON) > 0 {
+		err = json.Unmarshal(payload.DataJSON, &data)
+		if err != nil {
+			return statusBadRequest("cannot decode notice data: %v", err)
+		}
 	}
 
 	st := c.d.overlord.State()


### PR DESCRIPTION
During code review of #296, when I'd switched the add-notice API endpoint to use `json.RawMessage` for the data field, it no longer handled the case where the data field wasn't present (which is perfectly valid if you don't have data to attach). This made `pebble notify` fail like so:

```
$ pebble notify example.com/fizzbuzz
error: cannot decode notice data: unexpected end of JSON input
```

However, it does this work if you provide one or more data keys/values:

```
$ pebble notify example.com/fizzbuzz kee=valyou
Recorded notice 1
```

This PR is a trivial fix for the (first) no-data case, and also adds a test case for the no-data case.