### PR TITLE
feat(stateengine): merge `StateStarterUp` interface from snapd

### DIFF
--- a/internals/overlord/stateengine_test.go
+++ b/internals/overlord/stateengine_test.go
@@ -35,9 +35,14 @@ func (ses *stateEngineSuite) TestNewAndState(c *C) {
 }
 
 type fakeManager struct {
-	name                   string
-	calls                  *[]string
-	ensureError, stopError error
+	name                      string
+	calls                     *[]string
+	ensureError, startupError error
+}
+
+func (fm *fakeManager) StartUp() error {
+	*fm.calls = append(*fm.calls, "startup:"+fm.name)
+	return fm.startupError
 }
 
 func (fm *fakeManager) Ensure() error {
@@ -54,6 +59,50 @@ func (fm *fakeManager) Wait() {
 }
 
 var _ overlord.StateManager = (*fakeManager)(nil)
+
+func (ses *stateEngineSuite) TestStartUp(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.StartUp()
+	c.Assert(err, IsNil)
+	c.Check(calls, DeepEquals, []string{"startup:mgr1", "startup:mgr2"})
+
+	// noop
+	err = se.StartUp()
+	c.Assert(err, IsNil)
+	c.Check(calls, HasLen, 2)
+}
+
+func (ses *stateEngineSuite) TestStartUpError(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	err1 := errors.New("boom1")
+	err2 := errors.New("boom2")
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls, startupError: err1}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls, startupError: err2}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.StartUp()
+	c.Check(err, ErrorMatches, `state startup errors:
+- boom1
+- boom2`)
+	c.Check(calls, DeepEquals, []string{"startup:mgr1", "startup:mgr2"})
+}
 
 func (ses *stateEngineSuite) TestEnsure(c *C) {
 	s := state.New(nil)
@@ -92,7 +141,9 @@ func (ses *stateEngineSuite) TestEnsureError(c *C) {
 	se.AddManager(mgr2)
 
 	err := se.Ensure()
-	c.Check(err.Error(), DeepEquals, "state ensure errors: [boom1 boom2]")
+	c.Check(err, ErrorMatches, `state ensure errors:
+- boom1
+- boom2`)
 	c.Check(calls, DeepEquals, []string{"ensure:mgr1", "ensure:mgr2"})
 }
 


### PR DESCRIPTION
This PR complements (or even replaces) #214. The aim is for state managers to perform expensive startup operations in a `StartUp()` method. This way, we could either:
- (a) perform validation/initalization operations in the manager constructor, or
- (b) merge #214 as well and perform validation/non-state-mutating operations in a `DryStart()` method.

The use cases are:
1. Allowing dry run scenarios for e.g. validating the plan without actually running the daemon, or in general attempt to run Pebble without actually running it so that we can ensure e.g. that Pebble is running in the proper environment prior to actually starting.
2. Move all manager initialization code that requires reading or writing manager state to `StartUp()`. Right now, Pebble assumes that the state backend is ready, but in some cases this does not hold true (e.g. we're running in a system that requires the overlord to be initialized before mounting storage). By introducing this barrier for state readiness, we can ensure (through a manager included in the overlord extension, that should be started up before the rest of the managers) that the system is ready for this.