### PR TITLE
docs: add snapcraft badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Pebble service manager
 
+[![pebble](https://snapcraft.io/pebble/badge.svg)](https://snapcraft.io/pebble)
+
 _Take control of your internal daemons!_
 
 **Pebble** helps you to orchestrate a set of local service processes as an organized set.


### PR DESCRIPTION
This commit adds the Snapcraft.io Github badge to the README of Pebble.

This has two benefits:
- People will immediately see that they can play with Pebble by installing it as a snap
- The repo will be picked up by https://releases.juju.is where we'll be able to tie snap revisions to commits etc.

Driveby to remove the "cute" tagline.