### PR TITLE
feat: add StateStarterUp to move expensive init ops to dedicated methods

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -190,7 +190,9 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	}
 
 	d.Version = cmd.Version
-	d.Start()
+	if err := d.Start(); err != nil {
+		return err
+	}
 
 	watchdog, err := runWatchdog(d)
 	if err != nil {

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -59,6 +59,9 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	d, err := New(&Options{Dir: s.pebbleDir})
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
+
+	c.Assert(d.overlord.StartUp(), check.IsNil)
+
 	s.d = d
 	return d
 }

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -130,7 +130,8 @@ func (s *daemonSuite) TestExternalManager(c *C) {
 		OverlordExtension: &fakeExtension{},
 	})
 	c.Assert(err, IsNil)
-
+	err = d.overlord.StartUp()
+	c.Assert(err, IsNil)
 	err = d.overlord.StateEngine().Ensure()
 	c.Assert(err, IsNil)
 	extension, ok := d.overlord.Extension().(*fakeExtension)
@@ -185,7 +186,7 @@ func (s *daemonSuite) TestAddCommand(c *C) {
 
 	d := s.newDaemon(c)
 	d.Init()
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	defer d.Stop(nil)
 
 	result := d.router.Get(endpoint).GetHandler()
@@ -197,7 +198,7 @@ func (s *daemonSuite) TestExplicitPaths(c *C) {
 
 	d := s.newDaemon(c)
 	d.Init()
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	defer d.Stop(nil)
 
 	info, err := os.Stat(s.socketPath)
@@ -553,7 +554,7 @@ func (s *daemonSuite) TestStartStop(c *C) {
 	untrustedAccept := make(chan struct{})
 	d.untrustedListener = &witnessAcceptListener{Listener: l2, accept: untrustedAccept}
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 
 	generalDone := make(chan struct{})
 	go func() {
@@ -594,7 +595,7 @@ func (s *daemonSuite) TestRestartWiring(c *C) {
 	untrustedAccept := make(chan struct{})
 	d.untrustedListener = &witnessAcceptListener{Listener: l, accept: untrustedAccept}
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	defer d.Stop(nil)
 
 	generalDone := make(chan struct{})
@@ -661,7 +662,7 @@ func (s *daemonSuite) TestGracefulStop(c *C) {
 	untrustedAccept := make(chan struct{})
 	d.untrustedListener = &witnessAcceptListener{Listener: untrustedL, accept: untrustedAccept}
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 
 	generalAccepting := make(chan struct{})
 	go func() {
@@ -728,7 +729,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 	untrustedAccept := make(chan struct{})
 	d.untrustedListener = &witnessAcceptListener{Listener: l, accept: untrustedAccept}
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	defer d.Stop(nil)
 
 	st := d.overlord.State()
@@ -875,7 +876,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *C) {
 	d := s.newDaemon(c)
 	makeDaemonListeners(c, d)
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	st := d.overlord.State()
 
 	st.Lock()
@@ -907,7 +908,7 @@ func (s *daemonSuite) TestRestartShutdown(c *C) {
 	d := s.newDaemon(c)
 	makeDaemonListeners(c, d)
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	st := d.overlord.State()
 
 	st.Lock()
@@ -954,7 +955,7 @@ func (s *daemonSuite) TestRestartExpectedRebootIsMissing(c *C) {
 	c.Check(err, IsNil)
 	c.Check(n, Equals, 1)
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 
 	c.Check(s.notified, DeepEquals, []string{"READY=1"})
 
@@ -1030,11 +1031,11 @@ func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *C) {
 	d := s.newDaemon(c)
 	makeDaemonListeners(c, d)
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 
 	// pretend some ensure happened
 	for i := 0; i < 5; i++ {
-		d.overlord.StateEngine().Ensure()
+		c.Check(d.overlord.StateEngine().Ensure(), IsNil)
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -1066,10 +1067,10 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *C) {
 
 	st := d.overlord.State()
 
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	// pretend some ensure happened
 	for i := 0; i < 5; i++ {
-		d.overlord.StateEngine().Ensure()
+		c.Check(d.overlord.StateEngine().Ensure(), IsNil)
 		time.Sleep(5 * time.Millisecond)
 	}
 
@@ -1152,7 +1153,7 @@ func (s *daemonSuite) TestHTTPAPI(c *C) {
 	s.httpAddress = ":0" // Go will choose port (use listener.Addr() to find it)
 	d := s.newDaemon(c)
 	d.Init()
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 	port := d.httpListener.Addr().(*net.TCPAddr).Port
 
 	request, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/v1/health", port), nil)
@@ -1195,7 +1196,7 @@ services:
 	d := s.newDaemon(c)
 	err := d.Init()
 	c.Assert(err, IsNil)
-	d.Start()
+	c.Assert(d.Start(), IsNil)
 
 	// Start the test service.
 	payload := bytes.NewBufferString(`{"action": "start", "services": ["test1"]}`)

--- a/internals/overlord/managers_test.go
+++ b/internals/overlord/managers_test.go
@@ -44,6 +44,8 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	o, err := overlord.New(&overlord.Options{PebbleDir: s.dir})
 	c.Assert(err, IsNil)
+	err = o.StartUp()
+	c.Assert(err, IsNil)
 	s.o = o
 }
 

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -169,6 +169,12 @@ type witnessManager struct {
 	expectedEnsure int
 	ensureCalled   chan struct{}
 	ensureCallback func(s *state.State) error
+	startedUp      int
+}
+
+func (wm *witnessManager) StartUp() error {
+	wm.startedUp++
+	return nil
 }
 
 func (wm *witnessManager) Ensure() error {
@@ -184,6 +190,9 @@ func (wm *witnessManager) Ensure() error {
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	c.Assert(err, IsNil)
+
+	err = o.StartUp()
 	c.Assert(err, IsNil)
 
 	o.Loop()
@@ -224,6 +233,9 @@ func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	}
 	o.AddManager(witness)
 
+	err := o.StartUp()
+	c.Assert(err, IsNil)
+
 	o.Loop()
 	defer o.Stop()
 
@@ -235,8 +247,10 @@ func (ovs *overlordSuite) TestEnsureLoopRunAndStop(c *C) {
 	}
 	c.Check(time.Since(t0) >= 10*time.Millisecond, Equals, true)
 
-	err := o.Stop()
+	err = o.Stop()
 	c.Assert(err, IsNil)
+
+	c.Check(witness.startedUp, Equals, 1)
 }
 
 func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeImmediate(c *C) {
@@ -256,6 +270,8 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeImmediate(c *C) {
 		ensureCallback: ensure,
 	}
 	o.AddManager(witness)
+
+	c.Assert(o.StartUp(), IsNil)
 
 	o.Loop()
 	defer o.Stop()
@@ -284,6 +300,8 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBefore(c *C) {
 		ensureCallback: ensure,
 	}
 	o.AddManager(witness)
+
+	c.Assert(o.StartUp(), IsNil)
 
 	o.Loop()
 	defer o.Stop()
@@ -314,6 +332,9 @@ func (ovs *overlordSuite) TestEnsureBeforeSleepy(c *C) {
 	}
 	o.AddManager(witness)
 
+	err := o.StartUp()
+	c.Assert(err, IsNil)
+
 	o.Loop()
 	defer o.Stop()
 
@@ -343,6 +364,8 @@ func (ovs *overlordSuite) TestEnsureBeforeLater(c *C) {
 	}
 	o.AddManager(witness)
 
+	c.Assert(o.StartUp(), IsNil)
+
 	o.Loop()
 	defer o.Stop()
 
@@ -371,6 +394,8 @@ func (ovs *overlordSuite) TestEnsureLoopMediatedEnsureBeforeOutsideEnsure(c *C) 
 		ensureCallback: ensure,
 	}
 	o.AddManager(witness)
+
+	c.Assert(o.StartUp(), IsNil)
 
 	o.Loop()
 	defer o.Stop()
@@ -427,6 +452,8 @@ func (ovs *overlordSuite) TestEnsureLoopPrune(c *C) {
 		ensureCallback: waitForPrune,
 	}
 	o.AddManager(witness)
+
+	c.Assert(o.StartUp(), IsNil)
 
 	o.Loop()
 
@@ -863,6 +890,8 @@ func (ovs *overlordSuite) TestOverlordCanStandby(c *C) {
 		ensureCalled:   make(chan struct{}),
 	}
 	o.AddManager(witness)
+
+	c.Assert(o.StartUp(), IsNil)
 
 	// can only standby after loop ran once
 	c.Assert(o.CanStandby(), Equals, false)

--- a/internals/overlord/stateengine.go
+++ b/internals/overlord/stateengine.go
@@ -30,6 +30,13 @@ type StateManager interface {
 	Ensure() error
 }
 
+// StateStarterUp is optionally implemented by StateManager that have expensive
+// initialization to perform before the main Overlord loop.
+type StateStarterUp interface {
+	// StartUp asks manager to perform any expensive initialization.
+	StartUp() error
+}
+
 // StateWaiter is optionally implemented by StateManagers that have running
 // activities that can be waited.
 type StateWaiter interface {
@@ -53,8 +60,9 @@ type StateStopper interface {
 // cope with Ensure calls in any order, coordinating among themselves
 // solely via the state.
 type StateEngine struct {
-	state   *state.State
-	stopped bool
+	state     *state.State
+	stopped   bool
+	startedUp bool
 	// managers in use
 	mgrLock  sync.Mutex
 	managers []StateManager
@@ -70,6 +78,37 @@ func NewStateEngine(s *state.State) *StateEngine {
 // State returns the current system state.
 func (se *StateEngine) State() *state.State {
 	return se.state
+}
+
+type startupError struct {
+	errs []error
+}
+
+func (e *startupError) Error() string {
+	return fmt.Sprintf("state startup errors: %v", e.errs)
+}
+
+// StartUp asks all managers to perform any expensive initialization. It is a noop after the first invocation.
+func (se *StateEngine) StartUp() error {
+	se.mgrLock.Lock()
+	defer se.mgrLock.Unlock()
+	if se.startedUp {
+		return nil
+	}
+	se.startedUp = true
+	var errs []error
+	for _, m := range se.managers {
+		if starterUp, ok := m.(StateStarterUp); ok {
+			err := starterUp.StartUp()
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if len(errs) != 0 {
+		return &startupError{errs}
+	}
+	return nil
 }
 
 type ensureError struct {
@@ -91,6 +130,9 @@ func (e *ensureError) Error() string {
 func (se *StateEngine) Ensure() error {
 	se.mgrLock.Lock()
 	defer se.mgrLock.Unlock()
+	if !se.startedUp {
+		return fmt.Errorf("state engine skipped startup")
+	}
 	if se.stopped {
 		return fmt.Errorf("state engine already stopped")
 	}

--- a/internals/overlord/stateengine_test.go
+++ b/internals/overlord/stateengine_test.go
@@ -35,9 +35,14 @@ func (ses *stateEngineSuite) TestNewAndState(c *C) {
 }
 
 type fakeManager struct {
-	name                   string
-	calls                  *[]string
-	ensureError, stopError error
+	name                      string
+	calls                     *[]string
+	ensureError, startupError error
+}
+
+func (fm *fakeManager) StartUp() error {
+	*fm.calls = append(*fm.calls, "startup:"+fm.name)
+	return fm.startupError
 }
 
 func (fm *fakeManager) Ensure() error {
@@ -55,6 +60,48 @@ func (fm *fakeManager) Wait() {
 
 var _ overlord.StateManager = (*fakeManager)(nil)
 
+func (ses *stateEngineSuite) TestStartUp(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.StartUp()
+	c.Assert(err, IsNil)
+	c.Check(calls, DeepEquals, []string{"startup:mgr1", "startup:mgr2"})
+
+	// noop
+	err = se.StartUp()
+	c.Assert(err, IsNil)
+	c.Check(calls, HasLen, 2)
+}
+
+func (ses *stateEngineSuite) TestStartUpError(c *C) {
+	s := state.New(nil)
+	se := overlord.NewStateEngine(s)
+
+	calls := []string{}
+
+	err1 := errors.New("boom1")
+	err2 := errors.New("boom2")
+
+	mgr1 := &fakeManager{name: "mgr1", calls: &calls, startupError: err1}
+	mgr2 := &fakeManager{name: "mgr2", calls: &calls, startupError: err2}
+
+	se.AddManager(mgr1)
+	se.AddManager(mgr2)
+
+	err := se.StartUp()
+	c.Check(err.Error(), DeepEquals, "state startup errors: [boom1 boom2]")
+	c.Check(calls, DeepEquals, []string{"startup:mgr1", "startup:mgr2"})
+}
+
 func (ses *stateEngineSuite) TestEnsure(c *C) {
 	s := state.New(nil)
 	se := overlord.NewStateEngine(s)
@@ -68,6 +115,11 @@ func (ses *stateEngineSuite) TestEnsure(c *C) {
 	se.AddManager(mgr2)
 
 	err := se.Ensure()
+	c.Check(err, ErrorMatches, "state engine skipped startup")
+	c.Assert(se.StartUp(), IsNil)
+	calls = []string{}
+
+	err = se.Ensure()
 	c.Assert(err, IsNil)
 	c.Check(calls, DeepEquals, []string{"ensure:mgr1", "ensure:mgr2"})
 
@@ -91,6 +143,9 @@ func (ses *stateEngineSuite) TestEnsureError(c *C) {
 	se.AddManager(mgr1)
 	se.AddManager(mgr2)
 
+	c.Assert(se.StartUp(), IsNil)
+	calls = []string{}
+
 	err := se.Ensure()
 	c.Check(err.Error(), DeepEquals, "state ensure errors: [boom1 boom2]")
 	c.Check(calls, DeepEquals, []string{"ensure:mgr1", "ensure:mgr2"})
@@ -107,6 +162,9 @@ func (ses *stateEngineSuite) TestStop(c *C) {
 
 	se.AddManager(mgr1)
 	se.AddManager(mgr2)
+
+	c.Assert(se.StartUp(), IsNil)
+	calls = []string{}
 
 	se.Stop()
 	c.Check(calls, DeepEquals, []string{"stop:mgr1", "stop:mgr2"})


### PR DESCRIPTION
This PR introduces the StateStarterUp interface alongside its implementations for Overlord and StateEngine.

These changes were ported and adopted for pebble from the original snapd PR: https://github.com/snapcore/snapd/pull/7132

See also: https://github.com/canonical/pebble/pull/327