### PR TITLE
feat(testutil): add ErrorIs and DeepUnsortedMatches checkers

### DIFF
--- a/internals/testutil/containschecker.go
+++ b/internals/testutil/containschecker.go
@@ -145,3 +145,85 @@ func (c *deepContainsChecker) Check(params []interface{}, names []string) (resul
 		return false, fmt.Sprintf("%T is not a supported container", container)
 	}
 }
+
+type deepUnsortedMatchChecker struct {
+	*check.CheckerInfo
+}
+
+// DeepUnsortedMatches checks if two containers contain the same elements in
+// the same number (but possibly different order) using DeepEqual. The container
+// can be an array, a slice or a map.
+var DeepUnsortedMatches check.Checker = &deepUnsortedMatchChecker{
+	&check.CheckerInfo{Name: "DeepUnsortedMatches", Params: []string{"container1", "container2"}},
+}
+
+func (c *deepUnsortedMatchChecker) Check(params []interface{}, _ []string) (bool, string) {
+	container1 := reflect.ValueOf(params[0])
+	container2 := reflect.ValueOf(params[1])
+
+	// if both args are nil, return true
+	if container1.Kind() == reflect.Invalid && container2.Kind() == reflect.Invalid {
+		return true, ""
+	}
+
+	if container1.Kind() == reflect.Invalid || container2.Kind() == reflect.Invalid {
+		return false, "only one container was nil"
+	}
+
+	if container1.Kind() != container2.Kind() {
+		return false, fmt.Sprintf("containers are of different types: %s != %s", container1.Kind(), container2.Kind())
+	}
+
+	if container1.Kind() != reflect.Map && container1.Kind() != reflect.Slice && container1.Kind() != reflect.Array {
+		return false, fmt.Sprintf("'%s' is not a supported type: must be slice, array, map or nil", container1.Kind().String())
+	}
+
+	if container1.Type().Comparable() && params[0] == params[1] {
+		return true, ""
+	}
+
+	if container1.Len() != container2.Len() {
+		return false, fmt.Sprintf("containers have different lengths: %d != %d", container1.Len(), container2.Len())
+	}
+
+	switch container1.Kind() {
+	case reflect.Array, reflect.Slice:
+		return deepSequenceMatch(container1, container2)
+
+	case reflect.Map:
+		map1 := container1.Interface()
+		map2 := container2.Interface()
+		if !reflect.DeepEqual(map1, map2) {
+			return false, "maps don't match"
+		}
+
+		return true, ""
+
+	default:
+		return false, fmt.Sprintf("%T is not a supported container. Must be a slice, an array or a map", container1)
+	}
+}
+
+func deepSequenceMatch(container1 reflect.Value, container2 reflect.Value) (bool, string) {
+	matched := make([]bool, container1.Len())
+
+out:
+	for i := 0; i < container1.Len(); i++ {
+		el1 := container1.Index(i).Interface()
+
+		for e := 0; e < container2.Len(); e++ {
+			el2 := container2.Index(e).Interface()
+
+			if !matched[e] && reflect.DeepEqual(el1, el2) {
+				// mark already matched elements, so that duplicate elements in
+				// one container can't be matched to the same element in the other.
+				matched[e] = true
+				continue out
+			}
+		}
+
+		return false, fmt.Sprintf("element [%d]=%s was unmatched in the second container", i, el1)
+	}
+
+	return true, ""
+}

--- a/internals/testutil/containschecker.go
+++ b/internals/testutil/containschecker.go
@@ -174,39 +174,63 @@ func (c *deepUnsortedMatchChecker) Check(params []interface{}, _ []string) (bool
 		return false, fmt.Sprintf("containers are of different types: %s != %s", container1.Kind(), container2.Kind())
 	}
 
-	if container1.Kind() != reflect.Map && container1.Kind() != reflect.Slice && container1.Kind() != reflect.Array {
-		return false, fmt.Sprintf("'%s' is not a supported type: must be slice, array, map or nil", container1.Kind().String())
-	}
-
-	if container1.Type().Comparable() && params[0] == params[1] {
-		return true, ""
-	}
-
-	if container1.Len() != container2.Len() {
-		return false, fmt.Sprintf("containers have different lengths: %d != %d", container1.Len(), container2.Len())
-	}
-
 	switch container1.Kind() {
 	case reflect.Array, reflect.Slice:
 		return deepSequenceMatch(container1, container2)
-
 	case reflect.Map:
-		map1 := container1.Interface()
-		map2 := container2.Interface()
-		if !reflect.DeepEqual(map1, map2) {
-			return false, "maps don't match"
-		}
-
-		return true, ""
-
+		return deepMapMatch(container1, container2)
 	default:
-		return false, fmt.Sprintf("%T is not a supported container. Must be a slice, an array or a map", container1)
+		return false, fmt.Sprintf("'%s' is not a supported type: must be slice, array or map", container1.Kind().String())
 	}
 }
 
-func deepSequenceMatch(container1 reflect.Value, container2 reflect.Value) (bool, string) {
-	matched := make([]bool, container1.Len())
+func deepMapMatch(container1, container2 reflect.Value) (bool, string) {
+	if valid, output := validateContainerTypesAndLengths(container1, container2); !valid {
+		return false, output
+	}
 
+	switch container1.Type().Elem().Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+	// only run the unsorted match if the map values are containers
+	default:
+		if !reflect.DeepEqual(container1.Interface(), container2.Interface()) {
+			return false, "maps don't match"
+		}
+		return true, ""
+	}
+
+	for _, key := range container1.MapKeys() {
+		el1 := container1.MapIndex(key)
+		el2 := container2.MapIndex(key)
+
+		absent := el2 == reflect.Value{}
+		if absent {
+			return false, fmt.Sprintf("key %q from one map is absent from the other map", key)
+		}
+
+		var ok bool
+		var msg string
+		switch el1.Kind() {
+		case reflect.Array, reflect.Slice:
+			ok, msg = deepSequenceMatch(el1, el2)
+		case reflect.Map:
+			ok, msg = deepMapMatch(el1, el2)
+		}
+
+		if !ok {
+			return false, msg
+		}
+	}
+
+	return true, ""
+}
+
+func deepSequenceMatch(container1, container2 reflect.Value) (bool, string) {
+	if valid, output := validateContainerTypesAndLengths(container1, container2); !valid {
+		return false, output
+	}
+
+	matched := make([]bool, container1.Len())
 out:
 	for i := 0; i < container1.Len(); i++ {
 		el1 := container1.Index(i).Interface()
@@ -223,6 +247,23 @@ out:
 		}
 
 		return false, fmt.Sprintf("element [%d]=%s was unmatched in the second container", i, el1)
+	}
+
+	return true, ""
+}
+
+func validateContainerTypesAndLengths(container1, container2 reflect.Value) (bool, string) {
+	if container1.Len() != container2.Len() {
+		return false, fmt.Sprintf("containers have different lengths: %d != %d", container1.Len(), container2.Len())
+	} else if container1.Type().Elem() != container2.Type().Elem() {
+		return false, fmt.Sprintf("containers have different element types: %s != %s", container1.Type().Elem(), container2.Type().Elem())
+	}
+
+	if container1.Kind() == reflect.Map && container2.Kind() == reflect.Map {
+		keyType1, keyType2 := container1.Type().Key(), container2.Type().Key()
+		if keyType1 != keyType2 {
+			return false, fmt.Sprintf("maps have different key types: %s != %s", keyType1, keyType2)
+		}
 	}
 
 	return true, ""

--- a/internals/testutil/containschecker_test.go
+++ b/internals/testutil/containschecker_test.go
@@ -262,6 +262,17 @@ func (*containsCheckerSuite) TestDeepUnsortedMatchesMapSuccess(c *check.C) {
 	c.Check(map2, DeepUnsortedMatches, map1)
 }
 
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapStructFail(c *check.C) {
+	map1 := map[string]example{
+		"a": {a: "a", b: map[string]int{"a": 2, "b": 1}},
+	}
+	map2 := map[string]example{
+		"a": {a: "a", b: map[string]int{"a": 1, "b": 2}},
+	}
+
+	testCheck(c, DeepUnsortedMatches, false, "maps don't match", map1, map2)
+}
+
 func (*containsCheckerSuite) TestDeepUnsortedMatchesMapUnmatchedKeyFailure(c *check.C) {
 	map1 := map[string]int{"a": 1, "c": 2}
 	map2 := map[string]int{"a": 1, "b": 2}
@@ -282,16 +293,12 @@ func (*containsCheckerSuite) TestDeepUnsortedMatchesDifferentTypeFailure(c *chec
 	testCheck(c, DeepUnsortedMatches, false, "containers are of different types: slice != array", []int{}, [1]int{})
 }
 
+func (*containsCheckerSuite) TestDeepUnsortedMatchesDifferentElementType(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "containers have different element types: int != string", []int{1}, []string{"a"})
+}
+
 func (*containsCheckerSuite) TestDeepUnsortedMatchesDifferentLengthFailure(c *check.C) {
 	testCheck(c, DeepUnsortedMatches, false, "containers have different lengths: 1 != 2", []int{1}, []int{1, 1})
-}
-
-func (*containsCheckerSuite) TestDeepUnsortedMatchesUnsupportedTypeFailure(c *check.C) {
-	testCheck(c, DeepUnsortedMatches, false, "'int' is not a supported type: must be slice, array, map or nil", 1, 2)
-}
-
-func (*containsCheckerSuite) TestDeepUnsortedMatchesUnsupportedPointerType(c *check.C) {
-	testCheck(c, DeepUnsortedMatches, false, "'ptr' is not a supported type: must be slice, array, map or nil", &[]string{"a", "b"}, &[]string{"b", "a"})
 }
 
 func (*containsCheckerSuite) TestDeepUnsortedMatchesNilArgFailure(c *check.C) {
@@ -300,4 +307,61 @@ func (*containsCheckerSuite) TestDeepUnsortedMatchesNilArgFailure(c *check.C) {
 
 func (*containsCheckerSuite) TestDeepUnsortedMatchesBothNilArgSuccess(c *check.C) {
 	c.Check(nil, DeepUnsortedMatches, nil)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesNonContainerValues(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "'string' is not a supported type: must be slice, array or map", "a", "a")
+	testCheck(c, DeepUnsortedMatches, false, "'int' is not a supported type: must be slice, array or map", 1, 2)
+	testCheck(c, DeepUnsortedMatches, false, "'bool' is not a supported type: must be slice, array or map", true, false)
+	testCheck(c, DeepUnsortedMatches, false, "'ptr' is not a supported type: must be slice, array or map", &[]string{"a", "b"}, &[]string{"a", "b"})
+	testCheck(c, DeepUnsortedMatches, false, "'func' is not a supported type: must be slice, array or map", func() {}, func() {})
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapsOfSlices(c *check.C) {
+	map1 := map[string][]string{"a": {"foo", "bar"}, "b": {"foo", "bar"}}
+	map2 := map[string][]string{"a": {"bar", "foo"}, "b": {"bar", "foo"}}
+
+	c.Check(map1, DeepUnsortedMatches, map2)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapsDifferentKeyTypes(c *check.C) {
+	map1 := map[string][]string{"a": {"foo", "bar"}}
+	map2 := map[int][]string{1: {"bar", "foo"}}
+
+	testCheck(c, DeepUnsortedMatches, false, "maps have different key types: string != int", map1, map2)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapsDifferentValueTypes(c *check.C) {
+	map1 := map[string][]string{"a": {"foo", "bar"}}
+	map2 := map[string][2]string{"a": {"foo", "bar"}}
+
+	testCheck(c, DeepUnsortedMatches, false, "containers have different element types: []string != [2]string", map1, map2)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapsDifferentLengths(c *check.C) {
+	map1 := map[string][]string{"a": {"foo", "bar"}, "b": {"foo", "bar"}}
+	map2 := map[string][]string{"a": {"bar", "foo"}}
+
+	testCheck(c, DeepUnsortedMatches, false, "containers have different lengths: 2 != 1", map1, map2)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapsMissingKey(c *check.C) {
+	map1 := map[string][]string{"a": {"foo", "bar"}}
+	map2 := map[string][]string{"b": {"bar", "foo"}}
+
+	testCheck(c, DeepUnsortedMatches, false, "key \"a\" from one map is absent from the other map", map1, map2)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesNestedMaps(c *check.C) {
+	map1 := map[string]map[string][]string{"a": {"b": []string{"foo", "bar"}}}
+	map2 := map[string]map[string][]string{"a": {"b": []string{"bar", "foo"}}}
+	c.Check(map1, DeepUnsortedMatches, map2)
+
+	map1 = map[string]map[string][]string{"a": {"b": []string{"foo", "bar"}}}
+	map2 = map[string]map[string][]string{"a": {"c": []string{"bar", "foo"}}}
+	testCheck(c, DeepUnsortedMatches, false, "key \"b\" from one map is absent from the other map", map1, map2)
+
+	map1 = map[string]map[string][]string{"a": {"b": []string{"foo", "bar"}}, "c": {"b": []string{"foo"}}}
+	map2 = map[string]map[string][]string{"a": {"b": []string{"bar", "foo"}}, "c": {"b": []string{"bar"}}}
+	testCheck(c, DeepUnsortedMatches, false, "element [0]=foo was unmatched in the second container", map1, map2)
 }

--- a/internals/testutil/containschecker_test.go
+++ b/internals/testutil/containschecker_test.go
@@ -216,3 +216,88 @@ func (*containsCheckerSuite) TestDeepContainsUncomparableType(c *check.C) {
 	testCheck(c, DeepContains, true, "", containerSlice, elem)
 	testCheck(c, DeepContains, true, "", containerMap, elem)
 }
+
+type example struct {
+	a string
+	b map[string]int
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesSliceSuccess(c *check.C) {
+	slice1 := []example{
+		{a: "one", b: map[string]int{"a": 1}},
+		{a: "two", b: map[string]int{"b": 2}},
+	}
+	slice2 := []example{
+		{a: "two", b: map[string]int{"b": 2}},
+		{a: "one", b: map[string]int{"a": 1}},
+	}
+
+	c.Check(slice1, DeepUnsortedMatches, slice2)
+	c.Check(slice2, DeepUnsortedMatches, slice1)
+	c.Check([]string{"a", "a"}, DeepUnsortedMatches, []string{"a", "a"})
+	c.Check([]string{"a", "b", "a"}, DeepUnsortedMatches, []string{"b", "a", "a"})
+	slice := [1]int{1}
+	c.Check(slice, DeepUnsortedMatches, slice)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesSliceFailure(c *check.C) {
+	slice1 := []string{"a", "a", "b"}
+	slice2 := []string{"b", "a", "c"}
+
+	testCheck(c, DeepUnsortedMatches, false, "element [1]=a was unmatched in the second container", slice1, slice2)
+	testCheck(c, DeepUnsortedMatches, false, "element [2]=c was unmatched in the second container", slice2, slice1)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapSuccess(c *check.C) {
+	map1 := map[string]example{
+		"a": {a: "a", b: map[string]int{"a": 1, "b": 2}},
+		"c": {a: "c", b: map[string]int{"c": 3, "d": 4}},
+	}
+	map2 := map[string]example{
+		"c": {a: "c", b: map[string]int{"c": 3, "d": 4}},
+		"a": {a: "a", b: map[string]int{"a": 1, "b": 2}},
+	}
+
+	c.Check(map1, DeepUnsortedMatches, map2)
+	c.Check(map2, DeepUnsortedMatches, map1)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapUnmatchedKeyFailure(c *check.C) {
+	map1 := map[string]int{"a": 1, "c": 2}
+	map2 := map[string]int{"a": 1, "b": 2}
+
+	testCheck(c, DeepUnsortedMatches, false, "maps don't match", map1, map2)
+	testCheck(c, DeepUnsortedMatches, false, "maps don't match", map2, map1)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesMapUnmatchedValueFailure(c *check.C) {
+	map1 := map[string]int{"a": 1, "b": 2}
+	map2 := map[string]int{"a": 1, "b": 3}
+
+	testCheck(c, DeepUnsortedMatches, false, "maps don't match", map1, map2)
+	testCheck(c, DeepUnsortedMatches, false, "maps don't match", map2, map1)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesDifferentTypeFailure(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "containers are of different types: slice != array", []int{}, [1]int{})
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesDifferentLengthFailure(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "containers have different lengths: 1 != 2", []int{1}, []int{1, 1})
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesUnsupportedTypeFailure(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "'int' is not a supported type: must be slice, array, map or nil", 1, 2)
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesUnsupportedPointerType(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "'ptr' is not a supported type: must be slice, array, map or nil", &[]string{"a", "b"}, &[]string{"b", "a"})
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesNilArgFailure(c *check.C) {
+	testCheck(c, DeepUnsortedMatches, false, "only one container was nil", nil, []int{1})
+}
+
+func (*containsCheckerSuite) TestDeepUnsortedMatchesBothNilArgSuccess(c *check.C) {
+	c.Check(nil, DeepUnsortedMatches, nil)
+}

--- a/internals/testutil/errorischecker.go
+++ b/internals/testutil/errorischecker.go
@@ -16,7 +16,6 @@ package testutil
 
 import (
 	"errors"
-	"fmt"
 
 	"gopkg.in/check.v1"
 )
@@ -37,12 +36,12 @@ func (*errorIsChecker) Check(params []interface{}, names []string) (result bool,
 
 	err, ok := params[0].(error)
 	if !ok {
-		return false, fmt.Sprintf("first argument must be an error")
+		return false, "first argument must be an error"
 	}
 
 	target, ok := params[1].(error)
 	if !ok {
-		return false, fmt.Sprintf("second argument must be an error")
+		return false, "second argument must be an error"
 	}
 
 	return errors.Is(err, target), ""

--- a/internals/testutil/errorischecker.go
+++ b/internals/testutil/errorischecker.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testutil
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/check.v1"
+)
+
+// ErrorIs calls errors.Is with the provided arguments.
+var ErrorIs = &errorIsChecker{
+	&check.CheckerInfo{Name: "ErrorIs", Params: []string{"error", "target"}},
+}
+
+type errorIsChecker struct {
+	*check.CheckerInfo
+}
+
+func (*errorIsChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+	if params[0] == nil {
+		return params[1] == nil, ""
+	}
+
+	err, ok := params[0].(error)
+	if !ok {
+		return false, fmt.Sprintf("first argument must be an error")
+	}
+
+	target, ok := params[1].(error)
+	if !ok {
+		return false, fmt.Sprintf("second argument must be an error")
+	}
+
+	return errors.Is(err, target), ""
+}

--- a/internals/testutil/errorischecker_test.go
+++ b/internals/testutil/errorischecker_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testutil_test
+
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+
+	. "github.com/canonical/pebble/internals/testutil"
+)
+
+type errorIsCheckerSuite struct{}
+
+var _ = Suite(&errorIsCheckerSuite{})
+
+type baseError struct{}
+
+func (baseError) Error() string { return "" }
+
+func (baseError) Is(err error) bool {
+	_, ok := err.(baseError)
+	return ok
+}
+
+type wrapperError struct {
+	err error
+}
+
+func (*wrapperError) Error() string { return "" }
+
+func (e *wrapperError) Unwrap() error { return e.err }
+
+func (*errorIsCheckerSuite) TestErrorIsCheckSucceeds(c *C) {
+	testInfo(c, ErrorIs, "ErrorIs", []string{"error", "target"})
+
+	c.Assert(baseError{}, ErrorIs, baseError{})
+	err := &wrapperError{err: baseError{}}
+	c.Assert(err, ErrorIs, baseError{})
+}
+
+func (*errorIsCheckerSuite) TestErrorIsCheckFails(c *C) {
+	c.Assert(nil, Not(ErrorIs), baseError{})
+	c.Assert(errors.New(""), Not(ErrorIs), baseError{})
+}
+
+func (*errorIsCheckerSuite) TestErrorIsWithInvalidArguments(c *C) {
+	res, errMsg := ErrorIs.Check([]interface{}{"", errors.New("")}, []string{"error", "target"})
+	c.Assert(res, Equals, false)
+	c.Assert(errMsg, Equals, "first argument must be an error")
+
+	res, errMsg = ErrorIs.Check([]interface{}{errors.New(""), ""}, []string{"error", "target"})
+	c.Assert(res, Equals, false)
+	c.Assert(errMsg, Equals, "second argument must be an error")
+
+}


### PR DESCRIPTION
This PR is made in preparation to merge the latest snapd state package changes into pebble as per the plan discussed in https://github.com/canonical/pebble/pull/259. 

Both ErrorIs and DeepUnsortedMatches checkers are used by the latest state package test suites. These are cherry-picked from the snapd repository with some minor changes (fixed Pebble linter's warnings, updated license header).


