### PR TITLE
fix: snap release job run condition

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -127,7 +127,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.test.result == 'success' && always()
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The current `if: github.event_name == 'push'` doesn't seem to be enough to make the `release` job run on `push`. I'm not entirely sure why this is, but I suspect it is because of its dependency's (`test`) run conditions.

This change makes the `release` run conditions explicit, instead of relying on the implicit behavior of `needs: [test]`.