### PR TITLE
feat: make shutdown action return meaningful exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ If the configuration of `requires`, `before`, and `after` for a service results 
 Pebble's service manager automatically restarts services that exit unexpectedly. By default, this is done whether the exit code is zero or non-zero, but you can change this using the `on-success` and `on-failure` fields in a configuration layer. The possible values for these fields are:
 
 * `restart`: restart the service and enter a restart-backoff loop (the default behaviour).
-* `shutdown`: shut down and exit the Pebble daemon
+* `shutdown`: shut down and exit the Pebble daemon (with exit code 0 if the service exits successfully, exit code 10 otherwise)
+  - `success-shutdown`: shut down, ensuring exit code 0 (valid only for `on-failure`)
+  - `failure-shutdown`: shut down, ensuring exit code 10 (valid only for `on-success`)
 * `ignore`: ignore the service exiting and do nothing further
 
 In `restart` mode, the first time a service exits, Pebble waits the `backoff-delay`, which defaults to half a second. If the service exits again, Pebble calculates the next backoff delay by multiplying the current delay by `backoff-factor`, which defaults to 2.0 (doubling). The increasing delay is capped at `backoff-limit`, which defaults to 30 seconds.
@@ -691,21 +693,29 @@ services:
         working-dir: <directory>
 
         # (Optional) Defines what happens when the service exits with a zero
-        # exit code. Possible values are: "restart" (default) which restarts
-        # the service after the backoff delay, "shutdown" which shuts down and
-        # exits the Pebble server, and "ignore" which does nothing further.
-        on-success: restart | shutdown | ignore
+        # exit code. Possible values are:
+        #
+        # - restart (default): restart the service after the backoff delay
+        # - shutdown: shut down and exit the Pebble daemon (with exit code 0)
+        # - failure-shutdown: shut down and exit Pebble, ensuring exit code 10
+        # - ignore: do nothing further
+        on-success: restart | shutdown | failure-shutdown | ignore
 
         # (Optional) Defines what happens when the service exits with a nonzero
-        # exit code. Possible values are: "restart" (default) which restarts
-        # the service after the backoff delay, "shutdown" which shuts down and
-        # exits the Pebble server, and "ignore" which does nothing further.
-        on-failure: restart | shutdown | ignore
+        # exit code. Possible values are:
+        #
+        # - restart (default): restart the service after the backoff delay
+        # - shutdown: shut down and exit the Pebble daemon (with exit code 10)
+        # - success-shutdown: shut down and exit Pebble, ensuring exit code 0
+        # - ignore: do nothing further
+        on-failure: restart | shutdown | success-shutdown | ignore
 
         # (Optional) Defines what happens when each of the named health checks
-        # fail. Possible values are: "restart" (default) which restarts
-        # the service once, "shutdown" which shuts down and exits the Pebble
-        # server, and "ignore" which does nothing further.
+        # fail. Possible values are:
+        #
+        # - restart (default): restart the service once
+        # - shutdown: shut down and exit the Pebble daemon
+        # - ignore: do nothing further
         on-check-failure:
             <check name>: restart | shutdown | ignore
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ services:
     server:
         override: merge
         on-check-failure:
-            test: restart   # can also be "shutdown" or "ignore" (the default)
+            # can also be "shutdown", "success-shutdown", or "ignore" (the default)
+            test: restart
 ```
 
 You can view check status using the `pebble checks` command. This reports the checks along with their status (`up` or `down`) and number of failures. For example:
@@ -714,10 +715,11 @@ services:
         # fail. Possible values are:
         #
         # - restart (default): restart the service once
-        # - shutdown: shut down and exit the Pebble daemon
+        # - shutdown: shut down and exit the Pebble daemon (with exit code 11)
+        # - success-shutdown: shut down and exit Pebble, ensuring exit code 0
         # - ignore: do nothing further
         on-check-failure:
-            <check name>: restart | shutdown | ignore
+            <check name>: restart | shutdown | success-shutdown | ignore
 
         # (Optional) Initial backoff delay for the "restart" exit action.
         # Default is half a second ("500ms").

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ Pebble's service manager automatically restarts services that exit unexpectedly.
 
 * `restart`: restart the service and enter a restart-backoff loop (the default behaviour).
 * `shutdown`: shut down and exit the Pebble daemon (with exit code 0 if the service exits successfully, exit code 10 otherwise)
-  - `success-shutdown`: shut down, ensuring exit code 0 (valid only for `on-failure`)
-  - `failure-shutdown`: shut down, ensuring exit code 10 (valid only for `on-success`)
+  - `success-shutdown`: shut down with exit code 0 (valid only for `on-failure`)
+  - `failure-shutdown`: shut down with exit code 10 (valid only for `on-success`)
 * `ignore`: ignore the service exiting and do nothing further
 
 In `restart` mode, the first time a service exits, Pebble waits the `backoff-delay`, which defaults to half a second. If the service exits again, Pebble calculates the next backoff delay by multiplying the current delay by `backoff-factor`, which defaults to 2.0 (doubling). The increasing delay is capped at `backoff-limit`, which defaults to 30 seconds.
@@ -698,7 +698,7 @@ services:
         #
         # - restart (default): restart the service after the backoff delay
         # - shutdown: shut down and exit the Pebble daemon (with exit code 0)
-        # - failure-shutdown: shut down and exit Pebble, ensuring exit code 10
+        # - failure-shutdown: shut down and exit Pebble with exit code 10
         # - ignore: do nothing further
         on-success: restart | shutdown | failure-shutdown | ignore
 
@@ -707,7 +707,7 @@ services:
         #
         # - restart (default): restart the service after the backoff delay
         # - shutdown: shut down and exit the Pebble daemon (with exit code 10)
-        # - success-shutdown: shut down and exit Pebble, ensuring exit code 0
+        # - success-shutdown: shut down and exit Pebble with exit code 0
         # - ignore: do nothing further
         on-failure: restart | shutdown | success-shutdown | ignore
 
@@ -716,7 +716,7 @@ services:
         #
         # - restart (default): restart the service once
         # - shutdown: shut down and exit the Pebble daemon (with exit code 11)
-        # - success-shutdown: shut down and exit Pebble, ensuring exit code 0
+        # - success-shutdown: shut down and exit Pebble with exit code 0
         # - ignore: do nothing further
         on-check-failure:
             <check name>: restart | shutdown | success-shutdown | ignore

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -100,8 +100,11 @@ func (rcmd *cmdRun) run(ready chan<- func()) {
 			// This exit code must be in system'd SuccessExitStatus.
 			panic(&exitStatus{42})
 		case errors.Is(err, daemon.ErrRestartServiceFailure):
-			// Daemon returns this exit code for service-failure shutdown.
+			// Daemon returns distinct code for service-failure shutdown.
 			panic(&exitStatus{10})
+		case errors.Is(err, daemon.ErrRestartCheckFailure):
+			// Daemon returns distinct code for check-failure shutdown.
+			panic(&exitStatus{11})
 		}
 		fmt.Fprintf(os.Stderr, "cannot run daemon: %v\n", err)
 		panic(&exitStatus{1})

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -527,25 +527,25 @@ func (d *Daemon) Start() error {
 
 // HandleRestart implements overlord.RestartBehavior.
 func (d *Daemon) HandleRestart(t restart.RestartType) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	// die when asked to restart (systemd should get us back up!) etc
 	switch t {
 	case restart.RestartDaemon, restart.RestartSocket,
 		restart.RestartServiceFailure, restart.RestartCheckFailure:
+		d.mu.Lock()
 		d.requestedRestart = t
+		d.mu.Unlock()
 	case restart.RestartSystem:
 		// try to schedule a fallback slow reboot already here,
 		// in case we get stuck shutting down
 		if err := rebootHandler(rebootWaitTimeout); err != nil {
 			logger.Noticef("%s", err)
 		}
+		d.mu.Lock()
 		d.requestedRestart = t
+		d.mu.Unlock()
 	default:
 		logger.Noticef("Internal error: restart handler called with unknown restart type: %v", t)
 	}
-
 	d.tomb.Kill(nil)
 }
 

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -527,6 +527,11 @@ func (d *Daemon) Start() error {
 
 // HandleRestart implements overlord.RestartBehavior.
 func (d *Daemon) HandleRestart(t restart.RestartType) {
+	if !d.tomb.Alive() {
+		// Already shutting down, do nothing.
+		return
+	}
+
 	// die when asked to restart (systemd should get us back up!) etc
 	switch t {
 	case restart.RestartDaemon, restart.RestartSocket,

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -49,6 +49,7 @@ import (
 var (
 	ErrRestartSocket         = fmt.Errorf("daemon stop requested to wait for socket activation")
 	ErrRestartServiceFailure = fmt.Errorf("daemon stop requested due to service failure")
+	ErrRestartCheckFailure   = fmt.Errorf("daemon stop requested due to check failure")
 
 	systemdSdNotify = systemd.SdNotify
 	sysGetuid       = sys.Getuid
@@ -531,7 +532,8 @@ func (d *Daemon) HandleRestart(t restart.RestartType) {
 
 	// die when asked to restart (systemd should get us back up!) etc
 	switch t {
-	case restart.RestartDaemon, restart.RestartServiceFailure, restart.RestartSocket:
+	case restart.RestartDaemon, restart.RestartSocket,
+		restart.RestartServiceFailure, restart.RestartCheckFailure:
 		d.requestedRestart = t
 	case restart.RestartSystem:
 		// try to schedule a fallback slow reboot already here,
@@ -638,6 +640,8 @@ func (d *Daemon) Stop(sigCh chan<- os.Signal) error {
 		return ErrRestartSocket
 	case restart.RestartServiceFailure:
 		return ErrRestartServiceFailure
+	case restart.RestartCheckFailure:
+		return ErrRestartCheckFailure
 	}
 
 	return nil

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -779,7 +779,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 
 	defer func() {
 		d.mu.Lock()
-		d.restartType = restart.RestartUnset
+		d.requestedRestart = restart.RestartUnset
 		d.mu.Unlock()
 	}()
 
@@ -790,7 +790,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 	}
 
 	d.mu.Lock()
-	restartType := d.restartType
+	restartType := d.requestedRestart
 	d.mu.Unlock()
 
 	c.Check(restartType, Equals, restart.RestartSystem)
@@ -1052,7 +1052,7 @@ func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *C) {
 	}
 	err := d.Stop(nil)
 	c.Check(err, Equals, ErrRestartSocket)
-	c.Check(d.restartType, Equals, restart.RestartSocket)
+	c.Check(d.requestedRestart, Equals, restart.RestartSocket)
 }
 
 func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *C) {
@@ -1095,7 +1095,7 @@ func (s *daemonSuite) TestRestartIntoSocketModePendingChanges(c *C) {
 	// when the daemon got a pending change it just restarts
 	err := d.Stop(nil)
 	c.Check(err, IsNil)
-	c.Check(d.restartType, Equals, restart.RestartUnset)
+	c.Check(d.requestedRestart, Equals, restart.RestartDaemon)
 }
 
 func (s *daemonSuite) TestRestartServiceFailure(c *C) {

--- a/internals/overlord/restart/restart.go
+++ b/internals/overlord/restart/restart.go
@@ -37,6 +37,7 @@ const (
 	// RestartSystemPoweroffNow will shutdown --poweroff the system asap
 	RestartSystemPoweroffNow
 	RestartServiceFailure
+	RestartCheckFailure
 )
 
 // Handler can handle restart requests and whether expected reboots happen.

--- a/internals/overlord/restart/restart.go
+++ b/internals/overlord/restart/restart.go
@@ -36,6 +36,7 @@ const (
 	RestartSystemHaltNow
 	// RestartSystemPoweroffNow will shutdown --poweroff the system asap
 	RestartSystemPoweroffNow
+	RestartServiceFailure
 )
 
 // Handler can handle restart requests and whether expected reboots happen.

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -801,7 +801,11 @@ func (s *serviceData) checkFailed(action plan.ServiceAction) {
 			logger.Debugf("Service %q %s action is %q, remaining in current state", s.config.Name, onType, action)
 
 		case plan.ActionShutdown:
-			logger.Noticef("Service %q %s action is %q, triggering server exit", s.config.Name, onType, action)
+			logger.Noticef("Service %q %s action is %q, triggering failure shutdown", s.config.Name, onType, action)
+			s.manager.restarter.HandleRestart(restart.RestartCheckFailure)
+
+		case plan.ActionSuccessShutdown:
+			logger.Noticef("Service %q %s action is %q, triggering success shutdown", s.config.Name, onType, action)
 			s.manager.restarter.HandleRestart(restart.RestartDaemon)
 
 		case plan.ActionRestart:

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -294,6 +294,9 @@ const (
 	ActionRestart  ServiceAction = "restart"
 	ActionShutdown ServiceAction = "shutdown"
 	ActionIgnore   ServiceAction = "ignore"
+
+	ActionFailureShutdown ServiceAction = "failure-shutdown"
+	ActionSuccessShutdown ServiceAction = "success-shutdown"
 )
 
 // Check specifies configuration for a single health check.
@@ -649,12 +652,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 				Message: fmt.Sprintf("plan service %q command invalid: %v", name, err),
 			}
 		}
-		if !validServiceAction(service.OnSuccess) {
+		if !(validServiceAction(service.OnSuccess) || service.OnSuccess == ActionFailureShutdown) {
 			return nil, &FormatError{
 				Message: fmt.Sprintf("plan service %q on-success action %q invalid", name, service.OnSuccess),
 			}
 		}
-		if !validServiceAction(service.OnFailure) {
+		if !(validServiceAction(service.OnFailure) || service.OnFailure == ActionSuccessShutdown) {
 			return nil, &FormatError{
 				Message: fmt.Sprintf("plan service %q on-failure action %q invalid", name, service.OnFailure),
 			}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -665,7 +665,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			}
 		}
 		for _, action := range service.OnCheckFailure {
-			if !validServiceAction(action) {
+			if !validServiceAction(action, ActionSuccessShutdown) {
 				return nil, &FormatError{
 					Message: fmt.Sprintf("plan service %q on-check-failure action %q invalid", name, action),
 				}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -441,6 +441,26 @@ var planTests = []planTest{{
 				on-success: foo
 	`},
 }, {
+	summary: `Invalid success-shutdown`,
+	error:   `plan service "svc1" on-success action "success-shutdown" invalid`,
+	input: []string{`
+		services:
+			"svc1":
+				override: replace
+				command: cmd
+				on-success: success-shutdown
+	`},
+}, {
+	summary: `Invalid failure-shutdown`,
+	error:   `plan service "svc1" on-failure action "failure-shutdown" invalid`,
+	input: []string{`
+		services:
+			"svc1":
+				override: replace
+				command: cmd
+				on-failure: failure-shutdown
+	`},
+}, {
 	summary: `Invalid backoff-delay duration`,
 	error:   `cannot parse layer "layer-0": invalid duration "foo"`,
 	input: []string{`

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -441,7 +441,7 @@ var planTests = []planTest{{
 				on-success: foo
 	`},
 }, {
-	summary: `Invalid success-shutdown`,
+	summary: `Invalid on-success success-shutdown`,
 	error:   `plan service "svc1" on-success action "success-shutdown" invalid`,
 	input: []string{`
 		services:
@@ -451,7 +451,7 @@ var planTests = []planTest{{
 				on-success: success-shutdown
 	`},
 }, {
-	summary: `Invalid failure-shutdown`,
+	summary: `Invalid on-failure failure-shutdown`,
 	error:   `plan service "svc1" on-failure action "failure-shutdown" invalid`,
 	input: []string{`
 		services:
@@ -459,6 +459,22 @@ var planTests = []planTest{{
 				override: replace
 				command: cmd
 				on-failure: failure-shutdown
+	`},
+}, {
+	summary: `Invalid on-check-failure failure-shutdown`,
+	error:   `plan service "svc1" on-check-failure action "failure-shutdown" invalid`,
+	input: []string{`
+		services:
+			"svc1":
+				override: replace
+				command: cmd
+				on-check-failure:
+					test: failure-shutdown
+		checks:
+			test:
+				override: replace
+				http:
+					url: https://example.com/foo
 	`},
 }, {
 	summary: `Invalid backoff-delay duration`,


### PR DESCRIPTION
This PR makes Pebble shutdowns due to `on-failure: shutdown` return exit code 10 instead of always returning exit code 0. The code 10 was chosen to keep it "a few away" from other Pebble exit codes.

Similarly, if `on-check-failure` is used with `shutdown`, return exit code 11 instead of always returning code 0. (The 11 to distinguish a "check failure" shutdown from a "service failure" shutdown.

It also adds support for `on-failure: success-shutdown` (also for `on-check-failure`) and `on-success: failure-shutdown`, which reverses the "polarity" of the exit code for those cases.

Both of these are as per spec [DA062](https://docs.google.com/document/d/1OYSjmL2_1Na9HTwYmYo4KWvlQC9fcusXdMPzpHRBP8k/edit).

Fixes #324.