### PR TITLE
ci(snap): cope with concurrent builds

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -51,7 +51,7 @@ jobs:
 
   remote-build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: true
       matrix:
@@ -122,7 +122,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.event_name == 'push' && needs.test.result == 'success' && always()
+    if: github.event_name != 'pull_request' && needs.test.result == 'success' && always()
     strategy:
       fail-fast: false
       matrix:
@@ -142,8 +142,9 @@ jobs:
           release: ${{ env.DEFAULT_TRACK }}/${{ env.DEFAULT_RISK }}
 
   promote:
-    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
+    needs: [release]
+    if: github.event_name == 'release' && needs.release.result == 'success' && always()
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
At the moment, the Pebble release process involves a series of 3 commits in a very short amount of time. GitHub's concurrency flag is being used to cope with this, but it is unable to wait for pending workflow runs (see the [bug](https://github.com/orgs/community/discussions/41518)), which raises the risk of a Release workflow cancelling the previous commit workflow, where the snap is being built, if the run is pending, waiting for a GH runner.

This commit forces the snap build to happen on releases also.

---
This change has been tested in https://github.com/cjdcordeiro/pebble/actions/runs/7221185730 (for regular pushes to `master`) and https://github.com/cjdcordeiro/pebble/actions/runs/7220657549 (for releases)