### PR TITLE
Introduce comments to `pebble plan` output for debug.

### DIFF
--- a/client/plan.go
+++ b/client/plan.go
@@ -56,12 +56,17 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	return err
 }
 
-type PlanOptions struct{}
+type PlanOptions struct {
+	Debug bool
+}
 
 // PlanBytes fetches the plan in YAML format.
-func (client *Client) PlanBytes(_ *PlanOptions) (data []byte, err error) {
+func (client *Client) PlanBytes(opts *PlanOptions) (data []byte, err error) {
 	query := url.Values{
 		"format": []string{"yaml"},
+	}
+	if opts.Debug {
+		query.Add("debug", "true")
 	}
 	var dataStr string
 	_, err = client.doSync("GET", "/v1/plan", query, nil, nil, &dataStr)

--- a/internals/cli/cmd_plan.go
+++ b/internals/cli/cmd_plan.go
@@ -28,6 +28,8 @@ format. Layers are combined according to the override rules defined in them.
 
 type cmdPlan struct {
 	client *client.Client
+
+	Debug bool `long:"debug"`
 }
 
 func init() {
@@ -35,6 +37,9 @@ func init() {
 		Name:        "plan",
 		Summary:     cmdPlanSummary,
 		Description: cmdPlanDescription,
+		ArgsHelp: map[string]string{
+			"--debug": "Return the plan with debug information",
+		},
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdPlan{client: opts.Client}
 		},
@@ -45,7 +50,7 @@ func (cmd *cmdPlan) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
-	planYAML, err := cmd.client.PlanBytes(&client.PlanOptions{})
+	planYAML, err := cmd.client.PlanBytes(&client.PlanOptions{Debug: cmd.Debug})
 	if err != nil {
 		return err
 	}

--- a/internals/daemon/api_plan.go
+++ b/internals/daemon/api_plan.go
@@ -30,15 +30,148 @@ func v1GetPlan(c *Command, r *http.Request, _ *UserState) Response {
 		return statusBadRequest("invalid format %q", format)
 	}
 
+	debug := false
+	debugStr := r.URL.Query().Get("debug")
+	switch debugStr {
+	case "true":
+		debug = true
+	case "", "false":
+		debug = false
+	default:
+		return statusBadRequest("invalid debug value %q", debugStr)
+	}
+
 	servmgr := overlordServiceManager(c.d.overlord)
-	plan, err := servmgr.Plan()
+	p, err := servmgr.Plan()
 	if err != nil {
 		return statusInternalError("%v", err)
 	}
-	planYAML, err := yaml.Marshal(plan)
+	planYAML, err := yaml.Marshal(p)
 	if err != nil {
 		return statusInternalError("cannot serialize plan: %v", err)
 	}
+	if !debug || len(p.Layers) == 0 {
+		return SyncResponse(string(planYAML))
+	}
+
+	py := plan.PlanYaml{}
+	err = yaml.Unmarshal(planYAML, &py)
+	if err != nil {
+		return statusInternalError("cannot deserialize plan yaml: %v", err)
+	}
+
+	for _, layer := range p.Layers {
+		for k, svc := range layer.Services {
+			sy := py.Services[k]
+			if svc.Summary != "" {
+				sy.Summary.LineComment = layer.Label
+			}
+			if svc.Description != "" {
+				sy.Description.LineComment = layer.Label
+			}
+			if svc.Startup != plan.StartupUnknown {
+				sy.Startup.LineComment = layer.Label
+			}
+			if svc.Command != "" {
+				sy.Command.LineComment = layer.Label
+			}
+
+			// Service dependencies
+			if len(svc.After) > 0 {
+				for _, w := range svc.After {
+					for k, vy := range sy.After {
+						if vy.Value == w {
+							vy.LineComment = layer.Label
+							sy.After[k] = vy
+						}
+					}
+				}
+			}
+			if len(svc.Before) > 0 {
+				for _, w := range svc.Before {
+					for k, vy := range sy.Before {
+						if vy.Value == w {
+							vy.LineComment = layer.Label
+							sy.Before[k] = vy
+						}
+					}
+				}
+			}
+			if len(svc.Requires) > 0 {
+				for _, w := range svc.Requires {
+					for k, vy := range sy.Requires {
+						if vy.Value == w {
+							vy.LineComment = layer.Label
+							sy.Requires[k] = vy
+						}
+					}
+				}
+			}
+
+			// Options for command execution
+			for k := range svc.Environment {
+				vy, ok := sy.Environment[k]
+				if !ok {
+					continue
+				}
+				vy.LineComment = layer.Label
+				sy.Environment[k] = vy
+			}
+			if svc.UserID != nil {
+				sy.UserID.LineComment = layer.Label
+			}
+			if svc.User != "" {
+				sy.User.LineComment = layer.Label
+			}
+			if svc.GroupID != nil {
+				sy.GroupID.LineComment = layer.Label
+			}
+			if svc.Group != "" {
+				sy.Group.LineComment = layer.Label
+			}
+			if svc.WorkingDir != "" {
+				sy.WorkingDir.LineComment = layer.Label
+			}
+
+			// Auto-restart and backoff functionality
+			if svc.OnSuccess != plan.ActionUnset {
+				sy.OnSuccess.LineComment = layer.Label
+			}
+			if svc.OnFailure != plan.ActionUnset {
+				sy.OnFailure.LineComment = layer.Label
+			}
+			for k := range svc.OnCheckFailure {
+				vy, ok := sy.OnCheckFailure[k]
+				if !ok {
+					continue
+				}
+				vy.LineComment = layer.Label
+				sy.OnCheckFailure[k] = vy
+			}
+			if svc.BackoffDelay.IsSet {
+				sy.BackoffDelay.LineComment = layer.Label
+			}
+			if svc.BackoffFactor.IsSet {
+				sy.BackoffFactor.LineComment = layer.Label
+			}
+			if svc.BackoffLimit.IsSet {
+				sy.BackoffLimit.LineComment = layer.Label
+			}
+			if svc.KillDelay.IsSet {
+				sy.KillDelay.LineComment = layer.Label
+			}
+		}
+	}
+
+	// TODO: handle checks
+
+	// TODO: handle log targets
+
+	planYAML, err = yaml.Marshal(py)
+	if err != nil {
+		return statusInternalError("cannot serialize plan: %v", err)
+	}
+
 	return SyncResponse(string(planYAML))
 }
 

--- a/internals/plan/annotation.go
+++ b/internals/plan/annotation.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+type PlanYaml struct {
+	Services   map[string]*ServiceYaml   `yaml:"services,omitempty"`
+	Checks     map[string]*CheckYaml     `yaml:"checks,omitempty"`
+	LogTargets map[string]*LogTargetYaml `yaml:"log-targets,omitempty"`
+}
+
+type ServiceYaml struct {
+	Summary        yaml.Node            `yaml:"summary,omitempty"`
+	Description    yaml.Node            `yaml:"description,omitempty"`
+	Startup        yaml.Node            `yaml:"startup,omitempty"`
+	Override       yaml.Node            `yaml:"override,omitempty"`
+	Command        yaml.Node            `yaml:"command,omitempty"`
+	After          []yaml.Node          `yaml:"after,omitempty"`
+	Before         []yaml.Node          `yaml:"before,omitempty"`
+	Requires       []yaml.Node          `yaml:"requires,omitempty"`
+	Environment    map[string]yaml.Node `yaml:"environment,omitempty"`
+	UserID         yaml.Node            `yaml:"user-id,omitempty"`
+	User           yaml.Node            `yaml:"user,omitempty"`
+	GroupID        yaml.Node            `yaml:"group-id,omitempty"`
+	Group          yaml.Node            `yaml:"group,omitempty"`
+	WorkingDir     yaml.Node            `yaml:"working-dir,omitempty"`
+	OnSuccess      yaml.Node            `yaml:"on-success,omitempty"`
+	OnFailure      yaml.Node            `yaml:"on-failure,omitempty"`
+	OnCheckFailure map[string]yaml.Node `yaml:"on-check-failure,omitempty"`
+	BackoffDelay   yaml.Node            `yaml:"backoff-delay,omitempty"`
+	BackoffFactor  yaml.Node            `yaml:"backoff-factor,omitempty"`
+	BackoffLimit   yaml.Node            `yaml:"backoff-limit,omitempty"`
+	KillDelay      yaml.Node            `yaml:"kill-delay,omitempty"`
+}
+
+type CheckYaml struct {
+	Override  yaml.Node      `yaml:"override,omitempty"`
+	Level     yaml.Node      `yaml:"level,omitempty"`
+	Period    yaml.Node      `yaml:"period,omitempty"`
+	Timeout   yaml.Node      `yaml:"timeout,omitempty"`
+	Threshold yaml.Node      `yaml:"threshold,omitempty"`
+	HTTP      *HTTPCheckYaml `yaml:"http,omitempty"`
+	TCP       *TCPCheckYaml  `yaml:"tcp,omitempty"`
+	Exec      *ExecCheckYaml `yaml:"exec,omitempty"`
+}
+
+type LogTargetYaml struct {
+	Type     yaml.Node            `yaml:"type"`
+	Location yaml.Node            `yaml:"location"`
+	Services []yaml.Node          `yaml:"services"`
+	Override yaml.Node            `yaml:"override,omitempty"`
+	Labels   map[string]yaml.Node `yaml:"labels,omitempty"`
+}
+
+type HTTPCheckYaml struct {
+	URL     yaml.Node            `yaml:"url,omitempty"`
+	Headers map[string]yaml.Node `yaml:"headers,omitempty"`
+}
+
+type ExecCheckYaml struct {
+	Command        yaml.Node            `yaml:"command,omitempty"`
+	ServiceContext yaml.Node            `yaml:"service-context,omitempty"`
+	Environment    map[string]yaml.Node `yaml:"environment,omitempty"`
+	UserID         yaml.Node            `yaml:"user-id,omitempty"`
+	User           yaml.Node            `yaml:"user,omitempty"`
+	GroupID        yaml.Node            `yaml:"group-id,omitempty"`
+	Group          yaml.Node            `yaml:"group,omitempty"`
+	WorkingDir     yaml.Node            `yaml:"working-dir,omitempty"`
+}
+
+type TCPCheckYaml struct {
+	Port yaml.Node `yaml:"port,omitempty"`
+	Host yaml.Node `yaml:"host,omitempty"`
+}


### PR DESCRIPTION
This is an attempt at adding in debug comments to the output of `pebble plan` with `--debug`.
Each comment is the label of the layer in which the configuration originated from.

`pebble plan --debug` output:
```
$ pebble plan --debug
services:
    srv1:
        summary: first service # first
        override: replace
        command: bash -c 'sleep 1000' # first
        after:
            - srv2 # second
        environment:
            A: a # first
            B: b # second
    srv2:
        summary: second svc # second
        override: replace
        command: bash -c 'sleep 1000' # second
```


Files:
```
$ cat 001-first.yaml
services:
  srv1:
    override: replace
    summary: first service
    command: bash -c 'sleep 1000'
    environment:
      A: a
$ cat 002-second.yaml
services:
  srv1:
    override: merge
    environment:
      B: b
    after:
      - srv2
  srv2:
    summary: second svc
    override: replace
    command: bash -c 'sleep 1000'
```
