### PR TITLE
feat: implement PEBBLE_IMPORT to load layers from other locations

### DIFF
--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -280,7 +280,7 @@ func Run() error {
 
 	logger.SetLogger(logger.New(os.Stderr, fmt.Sprintf("[%s] ", cmd.ProgramName)))
 
-	_, clientConfig.Socket = getEnvPaths()
+	_, clientConfig.Socket, _ = getEnvPaths()
 
 	cli, err := client.New(&clientConfig)
 	if err != nil {
@@ -363,7 +363,7 @@ func errorToMessage(e error) (normalMessage string, err error) {
 	return msg, nil
 }
 
-func getEnvPaths() (pebbleDir string, socketPath string) {
+func getEnvPaths() (pebbleDir string, socketPath string, pebbleImports []string) {
 	pebbleDir = os.Getenv("PEBBLE")
 	if pebbleDir == "" {
 		pebbleDir = defaultPebbleDir
@@ -372,7 +372,10 @@ func getEnvPaths() (pebbleDir string, socketPath string) {
 	if socketPath == "" {
 		socketPath = filepath.Join(pebbleDir, ".pebble.socket")
 	}
-	return pebbleDir, socketPath
+	if imports := os.Getenv("PEBBLE_IMPORT"); imports != "" {
+		pebbleImports = strings.Split(imports, ":")
+	}
+	return
 }
 
 type cliState struct {
@@ -391,7 +394,7 @@ func loadCLIState() (*cliState, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, socketPath := getEnvPaths()
+	_, socketPath, _ := getEnvPaths()
 	st, ok := fullState.Pebble[socketPath]
 	if !ok {
 		return &cliState{}, nil
@@ -426,7 +429,7 @@ func saveCLIState(state *cliState) error {
 		return err
 	}
 
-	_, socketPath := getEnvPaths()
+	_, socketPath, _ := getEnvPaths()
 	fullState.Pebble[socketPath] = state
 
 	data, err := json.Marshal(fullState)

--- a/internals/cli/cli_test.go
+++ b/internals/cli/cli_test.go
@@ -159,31 +159,31 @@ func (s *PebbleSuite) TestGetEnvPaths(c *C) {
 	os.Setenv("PEBBLE", "")
 	os.Setenv("PEBBLE_SOCKET", "")
 	os.Setenv("PEBBLE_IMPORT", "")
-	pebbleDir, socketPath, pebbleImportDirs := cli.GetEnvPaths()
-	c.Assert(pebbleDir, Equals, "/var/lib/pebble/default")
-	c.Assert(socketPath, Equals, "/var/lib/pebble/default/.pebble.socket")
-	c.Assert(pebbleImportDirs, HasLen, 0)
+	paths := cli.GetEnvPaths()
+	c.Assert(paths.PebbleDir, Equals, "/var/lib/pebble/default")
+	c.Assert(paths.SocketPath, Equals, "/var/lib/pebble/default/.pebble.socket")
+	c.Assert(paths.ImportDirs, HasLen, 0)
 
 	os.Setenv("PEBBLE", "/foo")
-	pebbleDir, socketPath, pebbleImportDirs = cli.GetEnvPaths()
-	c.Assert(pebbleDir, Equals, "/foo")
-	c.Assert(socketPath, Equals, "/foo/.pebble.socket")
-	c.Assert(pebbleImportDirs, HasLen, 0)
+	paths = cli.GetEnvPaths()
+	c.Assert(paths.PebbleDir, Equals, "/foo")
+	c.Assert(paths.SocketPath, Equals, "/foo/.pebble.socket")
+	c.Assert(paths.ImportDirs, HasLen, 0)
 
 	os.Setenv("PEBBLE", "/bar")
 	os.Setenv("PEBBLE_SOCKET", "/path/to/socket")
-	pebbleDir, socketPath, pebbleImportDirs = cli.GetEnvPaths()
-	c.Assert(pebbleDir, Equals, "/bar")
-	c.Assert(socketPath, Equals, "/path/to/socket")
-	c.Assert(pebbleImportDirs, HasLen, 0)
+	paths = cli.GetEnvPaths()
+	c.Assert(paths.PebbleDir, Equals, "/bar")
+	c.Assert(paths.SocketPath, Equals, "/path/to/socket")
+	c.Assert(paths.ImportDirs, HasLen, 0)
 
 	os.Setenv("PEBBLE_IMPORT", "/a:/b")
-	_, _, pebbleImportDirs = cli.GetEnvPaths()
-	c.Assert(pebbleImportDirs, DeepEquals, []string{"/a", "/b"})
+	paths = cli.GetEnvPaths()
+	c.Assert(paths.ImportDirs, DeepEquals, []string{"/a", "/b"})
 
 	os.Setenv("PEBBLE_IMPORT", "/a")
-	_, _, pebbleImportDirs = cli.GetEnvPaths()
-	c.Assert(pebbleImportDirs, DeepEquals, []string{"/a"})
+	paths = cli.GetEnvPaths()
+	c.Assert(paths.ImportDirs, DeepEquals, []string{"/a"})
 }
 
 func (s *PebbleSuite) readCLIState(c *C) map[string]any {
@@ -198,19 +198,19 @@ func (s *PebbleSuite) readCLIState(c *C) map[string]any {
 		c.Fatalf("expected socket map, got %#v", fullState["pebble"])
 	}
 
-	_, socketPath, _ := cli.GetEnvPaths()
-	v, ok := socketMap[socketPath]
+	paths := cli.GetEnvPaths()
+	v, ok := socketMap[paths.SocketPath]
 	if !ok {
-		c.Fatalf("expected state map, got %#v", socketMap[socketPath])
+		c.Fatalf("expected state map, got %#v", socketMap[paths.SocketPath])
 	}
 	return v.(map[string]any)
 }
 
 func (s *PebbleSuite) writeCLIState(c *C, st map[string]any) {
-	_, socketPath, _ := cli.GetEnvPaths()
+	paths := cli.GetEnvPaths()
 	fullState := map[string]any{
 		"pebble": map[string]any{
-			socketPath: st,
+			paths.SocketPath: st,
 		},
 	}
 	err := os.MkdirAll(filepath.Dir(s.cliStatePath), 0o700)

--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -152,7 +152,7 @@ func (s *PebbleSuite) TestEnterExecListDir(c *C) {
 		}
 	}
 
-	restore := fakeArgs("pebble", "enter", "exec", "ls", s.pebbleDir)
+	restore := fakeArgs("pebble", "enter", "exec", "-T", "-I", "--", "ls", "-C", "-1", s.pebbleDir)
 	defer restore()
 
 	exitCode := cli.PebbleMain()
@@ -170,7 +170,7 @@ func (s *PebbleSuite) TestEnterExecReadServiceOutputFile(c *C) {
 		cat msg1
 		cat msg2
 	`
-	cmd := []string{"pebble", "enter", "--run", "exec", "--",
+	cmd := []string{"pebble", "enter", "--run", "exec", "-T", "-I", "--",
 		"bash", "-c", script, "bash", s.pebbleDir}
 	restore := fakeArgs(cmd...)
 	defer restore()

--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -152,6 +152,9 @@ func (s *PebbleSuite) TestEnterExecListDir(c *C) {
 		}
 	}
 
+	// Pass -T and -I to exec to prevent different behaviour depending on test environment.
+	// Pass -C and -1 to ensure the ls implementation only prints one column of files like the
+	// expected output.
 	restore := fakeArgs("pebble", "enter", "exec", "-T", "-I", "--", "ls", "-C", "-1", s.pebbleDir)
 	defer restore()
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -150,7 +150,7 @@ func sanityCheck() error {
 func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	t0 := time.Now().Truncate(time.Millisecond)
 
-	pebbleDir, socketPath := getEnvPaths()
+	pebbleDir, socketPath, pebbleImports := getEnvPaths()
 	if rcmd.CreateDirs {
 		err := os.MkdirAll(pebbleDir, 0755)
 		if err != nil {
@@ -159,6 +159,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	}
 	dopts := daemon.Options{
 		Dir:        pebbleDir,
+		ImportDirs: pebbleImports,
 		SocketPath: socketPath,
 	}
 	if rcmd.Verbose {

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -150,17 +150,17 @@ func sanityCheck() error {
 func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	t0 := time.Now().Truncate(time.Millisecond)
 
-	pebbleDir, socketPath, pebbleImports := getEnvPaths()
+	paths := getEnvPaths()
 	if rcmd.CreateDirs {
-		err := os.MkdirAll(pebbleDir, 0755)
+		err := os.MkdirAll(paths.PebbleDir, 0755)
 		if err != nil {
 			return err
 		}
 	}
 	dopts := daemon.Options{
-		Dir:        pebbleDir,
-		ImportDirs: pebbleImports,
-		SocketPath: socketPath,
+		Dir:        paths.PebbleDir,
+		ImportDirs: paths.ImportDirs,
+		SocketPath: paths.SocketPath,
 	}
 	if rcmd.Verbose {
 		dopts.ServiceOutput = os.Stdout

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -60,6 +60,10 @@ type Options struct {
 	// Dir is the pebble directory where all setup is found. Defaults to /var/lib/pebble/default.
 	Dir string
 
+	// ImportDirs is a list of directories similar to Dir (e.g. /var/lib/pebble/default) which contain
+	// layers to be imported.
+	ImportDirs []string
+
 	// SocketPath is an optional path for the unix socket used for the client
 	// to communicate with the daemon. Defaults to a hidden (dotted) name inside
 	// the pebble directory.
@@ -865,10 +869,11 @@ func New(opts *Options) (*Daemon, error) {
 	}
 
 	ovldOptions := overlord.Options{
-		PebbleDir:      opts.Dir,
-		RestartHandler: d,
-		ServiceOutput:  opts.ServiceOutput,
-		Extension:      opts.OverlordExtension,
+		PebbleDir:        opts.Dir,
+		PebbleImportDirs: opts.ImportDirs,
+		RestartHandler:   d,
+		ServiceOutput:    opts.ServiceOutput,
+		Extension:        opts.OverlordExtension,
 	}
 
 	ovld, err := overlord.New(&ovldOptions)

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -869,11 +869,11 @@ func New(opts *Options) (*Daemon, error) {
 	}
 
 	ovldOptions := overlord.Options{
-		PebbleDir:        opts.Dir,
-		PebbleImportDirs: opts.ImportDirs,
-		RestartHandler:   d,
-		ServiceOutput:    opts.ServiceOutput,
-		Extension:        opts.OverlordExtension,
+		Dir:            opts.Dir,
+		ImportDirs:     opts.ImportDirs,
+		RestartHandler: d,
+		ServiceOutput:  opts.ServiceOutput,
+		Extension:      opts.OverlordExtension,
 	}
 
 	ovld, err := overlord.New(&ovldOptions)

--- a/internals/overlord/managers_test.go
+++ b/internals/overlord/managers_test.go
@@ -42,7 +42,7 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	s.dir = c.MkDir()
 
-	o, err := overlord.New(&overlord.Options{PebbleDir: s.dir})
+	o, err := overlord.New(&overlord.Options{Dir: s.dir})
 	c.Assert(err, IsNil)
 	err = o.StartUp()
 	c.Assert(err, IsNil)

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -59,6 +59,8 @@ type Extension interface {
 type Options struct {
 	// PebbleDir is the path to the pebble directory. It must be provided.
 	PebbleDir string
+	// PebbleImportDirs is an optional ordered list of directory paths like PebbleDir to import data from.
+	PebbleImportDirs []string
 	// RestartHandler is an optional structure to handle restart requests.
 	RestartHandler restart.Handler
 	// ServiceOutput is an optional output for the logging manager.
@@ -70,8 +72,9 @@ type Options struct {
 // Overlord is the central manager of the system, keeping track
 // of all available state managers and related helpers.
 type Overlord struct {
-	pebbleDir string
-	stateEng  *StateEngine
+	pebbleDir        string
+	pebbleImportDirs []string
+	stateEng         *StateEngine
 
 	// ensure loop
 	loopTomb    *tomb.Tomb
@@ -95,12 +98,12 @@ type Overlord struct {
 
 // New creates an Overlord with all its state managers.
 func New(opts *Options) (*Overlord, error) {
-
 	o := &Overlord{
-		pebbleDir: opts.PebbleDir,
-		loopTomb:  new(tomb.Tomb),
-		inited:    true,
-		extension: opts.Extension,
+		pebbleDir:        opts.PebbleDir,
+		pebbleImportDirs: opts.PebbleImportDirs,
+		loopTomb:         new(tomb.Tomb),
+		inited:           true,
+		extension:        opts.Extension,
 	}
 
 	if !filepath.IsAbs(o.pebbleDir) {
@@ -135,6 +138,7 @@ func New(opts *Options) (*Overlord, error) {
 		s,
 		o.runner,
 		o.pebbleDir,
+		o.pebbleImportDirs,
 		opts.ServiceOutput,
 		opts.RestartHandler,
 		o.logMgr)

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -58,7 +58,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	restore := patch.Fake(42, 2, nil)
 	defer restore()
 
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
 
@@ -91,7 +91,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -119,7 +119,7 @@ func (ovs *overlordSuite) TestNewWithInvalidState(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	_, err = overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, ErrorMatches, "cannot read state: EOF")
 }
 
@@ -138,7 +138,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 	err := ioutil.WriteFile(ovs.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	state := o.State()
@@ -189,7 +189,7 @@ func (wm *witnessManager) Ensure() error {
 }
 
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	err = o.StartUp()
@@ -202,7 +202,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 }
 
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	// unknown tasks are ignored and succeed
@@ -521,7 +521,7 @@ func (ovs *overlordSuite) TestCheckpoint(c *C) {
 	oldUmask := syscall.Umask(0)
 	defer syscall.Umask(oldUmask)
 
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	s := o.State()
@@ -762,7 +762,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 }
 
 func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir})
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -795,7 +795,7 @@ func (rb *testRestartHandler) RebootIsMissing(_ *state.State) error {
 func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 	rb := &testRestartHandler{}
 
-	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	o, err := overlord.New(&overlord.Options{Dir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	st := o.State()
@@ -814,7 +814,7 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{Dir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -827,7 +827,7 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{Dir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -841,7 +841,7 @@ func (ovs *overlordSuite) TestVerifyRebootOKButError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{Dir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "as-expected")
@@ -857,7 +857,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{Dir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
@@ -874,7 +874,7 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissingError(c *C) {
 	e := errors.New("boom")
 	rb := &testRestartHandler{rebootVerifiedErr: e}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	_, err = overlord.New(&overlord.Options{Dir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, Equals, e)
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -124,7 +124,7 @@ func (m *ServiceManager) updatePlan(p *plan.Plan) {
 }
 
 func (m *ServiceManager) reloadPlan() error {
-	p, err := plan.Read(m.dir, m.importDirs)
+	p, err := plan.ReadAll(m.dir, m.importDirs)
 	if err != nil {
 		return err
 	}

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -124,7 +124,9 @@ func (m *ServiceManager) updatePlan(p *plan.Plan) {
 }
 
 func (m *ServiceManager) reloadPlan() error {
-	p, err := plan.ReadAll(m.dir, m.importDirs)
+	dirs := append([]string(nil), m.importDirs...)
+	dirs = append(dirs, m.dir)
+	p, err := plan.ReadAll(dirs)
 	if err != nil {
 		return err
 	}

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -1863,7 +1863,14 @@ func (s *S) setupDefaultServiceManager(c *C) {
 	err = ioutil.WriteFile(filepath.Join(layers, "002-two.yaml"), []byte(planLayer2), 0644)
 	c.Assert(err, IsNil)
 
-	s.manager, err = servstate.NewManager(s.st, s.runner, s.dir, nil, s.logOutput, testRestarter{s.stopDaemon}, fakeLogManager{})
+	s.manager, err = servstate.NewManager(&servstate.Options{
+		Dir:           s.dir,
+		State:         s.st,
+		Runner:        s.runner,
+		Restarter:     testRestarter{s.stopDaemon},
+		LogManager:    fakeLogManager{},
+		ServiceOutput: s.logOutput,
+	})
 	c.Assert(err, IsNil)
 }
 
@@ -1884,7 +1891,15 @@ func (s *S) setupMultiImportServiceManager(c *C) {
 	err = ioutil.WriteFile(filepath.Join(layers, "001-two.yaml"), []byte(planLayer2), 0644)
 	c.Assert(err, IsNil)
 
-	s.manager, err = servstate.NewManager(s.st, s.runner, s.dir, []string{importDir}, s.logOutput, testRestarter{s.stopDaemon}, fakeLogManager{})
+	s.manager, err = servstate.NewManager(&servstate.Options{
+		Dir:           s.dir,
+		ImportDirs:    []string{importDir},
+		State:         s.st,
+		Runner:        s.runner,
+		Restarter:     testRestarter{s.stopDaemon},
+		LogManager:    fakeLogManager{},
+		ServiceOutput: s.logOutput,
+	})
 	c.Assert(err, IsNil)
 }
 
@@ -1894,7 +1909,12 @@ func (s *S) setupEmptyServiceManager(c *C) {
 	dir := c.MkDir()
 	err := os.Mkdir(filepath.Join(dir, "layers"), 0755)
 	c.Assert(err, IsNil)
-	s.manager, err = servstate.NewManager(s.st, s.runner, dir, nil, nil, nil, fakeLogManager{})
+	s.manager, err = servstate.NewManager(&servstate.Options{
+		Dir:        s.dir,
+		State:      s.st,
+		Runner:     s.runner,
+		LogManager: fakeLogManager{},
+	})
 	c.Assert(err, IsNil)
 }
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1093,15 +1093,13 @@ func (lr *layerReader) ReadDir(dirname string) ([]*Layer, error) {
 }
 
 // ReadAll reads the configuration layers from the "layers" sub-directory in
-// dir, and returns the resulting Plan. If the "layers" sub-directory doesn't
-// exist, it returns a valid Plan with no layers.
-// If importDirs are passed, "layers" sub-directories of each of those
-// importDirs are read before the final dir.
-func ReadAll(dir string, importDirs []string) (*Plan, error) {
+// each directory in dirs, and returns the resulting Plan. If the "layers"
+// sub-directory doesn't exist, no layers are loaded from that directory.
+// Each directory in dirs is loaded in the order they are passed.
+func ReadAll(dirs []string) (*Plan, error) {
 	var layers []*Layer
 
 	lr := &layerReader{}
-	dirs := append(importDirs, dir)
 	for _, dir := range dirs {
 		layersDir := filepath.Join(dir, "layers")
 		_, err := os.Stat(layersDir)

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1424,7 +1424,7 @@ func (s *S) TestPlanRead(c *C) {
 			err := ioutil.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%03d-layer-%d.yaml", i, i)), reindent(yml), 0644)
 			c.Assert(err, IsNil)
 		}
-		sup, err := plan.Read(pebbleDir, nil)
+		sup, err := plan.ReadAll(pebbleDir, nil)
 		if err == nil {
 			var result *plan.Layer
 			result, err = plan.CombineLayers(sup.Layers...)
@@ -1474,7 +1474,7 @@ func (s *S) TestPlanReadMultiImport(c *C) {
 
 			dirs = append(dirs, pebbleDir)
 		}
-		sup, err := plan.Read(dirs[len(dirs)-1], dirs[:len(dirs)-1])
+		sup, err := plan.ReadAll(dirs[len(dirs)-1], dirs[:len(dirs)-1])
 		if err == nil {
 			var result *plan.Layer
 			result, err = plan.CombineLayers(sup.Layers...)
@@ -1526,8 +1526,8 @@ func (s *S) TestPlanReadBadNames(c *C) {
 		fpath := filepath.Join(layersDir, fname)
 		err := ioutil.WriteFile(fpath, []byte("<ignore>"), 0644)
 		c.Assert(err, IsNil)
-		_, err = plan.Read(pebbleDir, nil)
-		c.Assert(err.Error(), Equals, fmt.Sprintf("invalid layer filename: %q (must look like \"123-some-label.yaml\")", fname))
+		_, err = plan.ReadAll(pebbleDir, nil)
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid layer filename: ".*%s" .must look like "123-some-label.yaml".`, fname))
 		err = os.Remove(fpath)
 		c.Assert(err, IsNil)
 	}
@@ -1550,8 +1550,8 @@ func (s *S) TestPlanReadDupNames(c *C) {
 			err := ioutil.WriteFile(fpath, []byte("summary: ignore"), 0644)
 			c.Assert(err, IsNil)
 		}
-		_, err = plan.Read(pebbleDir, nil)
-		c.Assert(err.Error(), Equals, fmt.Sprintf("invalid layer filename: %q not unique (have %q already with same %s)", fnames[1], fnames[0], fnames[2]))
+		_, err = plan.ReadAll(pebbleDir, nil)
+		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid layer filename: ".*%s" not unique .have ".*%s" already with same %s.`, fnames[1], fnames[0], fnames[2]))
 		for _, fname := range fnames {
 			fpath := filepath.Join(layersDir, fname)
 			err = os.Remove(fpath)
@@ -1581,7 +1581,7 @@ func (s *S) TestPlanReadDupLabelsMultiImport(c *C) {
 	err = ioutil.WriteFile(filepath.Join(layersDir, "003-foo.yaml"), []byte("summary: ignore"), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = plan.Read(pebbleDir, []string{importDir})
+	_, err = plan.ReadAll(pebbleDir, []string{importDir})
 	c.Assert(err.Error(), Equals, fmt.Sprintf("invalid layer filename: %q not unique (have %q already with same label \"foo\")",
 		"003-foo.yaml", filepath.Join(importLayersDir, "002-foo.yaml")))
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1424,7 +1424,7 @@ func (s *S) TestPlanRead(c *C) {
 			err := ioutil.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%03d-layer-%d.yaml", i, i)), reindent(yml), 0644)
 			c.Assert(err, IsNil)
 		}
-		sup, err := plan.ReadAll(pebbleDir, nil)
+		sup, err := plan.ReadAll([]string{pebbleDir})
 		if err == nil {
 			var result *plan.Layer
 			result, err = plan.CombineLayers(sup.Layers...)
@@ -1474,7 +1474,7 @@ func (s *S) TestPlanReadMultiImport(c *C) {
 
 			dirs = append(dirs, pebbleDir)
 		}
-		sup, err := plan.ReadAll(dirs[len(dirs)-1], dirs[:len(dirs)-1])
+		sup, err := plan.ReadAll(dirs)
 		if err == nil {
 			var result *plan.Layer
 			result, err = plan.CombineLayers(sup.Layers...)
@@ -1526,7 +1526,7 @@ func (s *S) TestPlanReadBadNames(c *C) {
 		fpath := filepath.Join(layersDir, fname)
 		err := ioutil.WriteFile(fpath, []byte("<ignore>"), 0644)
 		c.Assert(err, IsNil)
-		_, err = plan.ReadAll(pebbleDir, nil)
+		_, err = plan.ReadAll([]string{pebbleDir})
 		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid layer filename: ".*%s" .must look like "123-some-label.yaml".`, fname))
 		err = os.Remove(fpath)
 		c.Assert(err, IsNil)
@@ -1550,7 +1550,7 @@ func (s *S) TestPlanReadDupNames(c *C) {
 			err := ioutil.WriteFile(fpath, []byte("summary: ignore"), 0644)
 			c.Assert(err, IsNil)
 		}
-		_, err = plan.ReadAll(pebbleDir, nil)
+		_, err = plan.ReadAll([]string{pebbleDir})
 		c.Assert(err, ErrorMatches, fmt.Sprintf(`invalid layer filename: ".*%s" not unique .have ".*%s" already with same %s.`, fnames[1], fnames[0], fnames[2]))
 		for _, fname := range fnames {
 			fpath := filepath.Join(layersDir, fname)
@@ -1581,7 +1581,7 @@ func (s *S) TestPlanReadDupLabelsMultiImport(c *C) {
 	err = ioutil.WriteFile(filepath.Join(layersDir, "003-foo.yaml"), []byte("summary: ignore"), 0644)
 	c.Assert(err, IsNil)
 
-	_, err = plan.ReadAll(pebbleDir, []string{importDir})
+	_, err = plan.ReadAll([]string{importDir, pebbleDir})
 	c.Assert(err.Error(), Equals, fmt.Sprintf("invalid layer filename: %q not unique (have %q already with same label \"foo\")",
 		"003-foo.yaml", filepath.Join(importLayersDir, "002-foo.yaml")))
 }


### PR DESCRIPTION
This PR proposes a way for Pebble to load layers from multiple sources first, before then loading from the `$PEBBLE` directory. This is required when pebble is run as a non-root user in a container with pebble layers already defined at the default `$PEBBLE` location of `/var/lib/pebble/default`.

By setting `$PEBBLE` to a directory writeable by a non-root user, while also setting `$PEBBLE_IMPORT` to `/var/lib/pebble/default`, the pebble daemon is able to load layers previously defined in the default directory by a container image author.

`$PEBBLE_IMPORT` can be a colon (`:`) delimited ordered list of paths to directories in the format of the pebble data directory (`$PEBBLE`). Each directory will have a `layers/` sub-directory.

It is expected that the following pebble invocation, 
`PEBBLE=/var/lib/pebble/charm PEBBLE_IMPORT=/var/lib/pebble/default:/var/lib/pebble/intermediate
pebble run;` would load layers like so:
- /var/lib/pebble/default/layers/001-my-first-layer.yaml
- /var/lib/pebble/default/layers/002-my-second-layer.yaml
- /var/lib/pebble/intermediate/layers/001-extra-first-layer.yaml
- /var/lib/pebble/intermediate/layers/002-extra-second-layer.yaml
- /var/lib/pebble/charm/layers/001-jujus-first-layer.yaml
- /var/lib/pebble/charm/layers/002-jujus-second-layer.yaml

NOTE: order numbers can be re-used globally, but labels must be unique globally.

For tooling to determine where configuration originated from, see https://github.com/canonical/pebble/pull/342

[JU090](https://docs.google.com/document/d/1NWV4QsYq1NldS_V_YlafpJQyNAV-WS46VsIKGBrin_s/edit)