### PR TITLE
chore(state): cross-port latest changes from snapd's overlord/state

### DIFF
--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -690,7 +690,7 @@ func (d *Daemon) rebootDelay() (time.Duration, error) {
 	// see whether a reboot had already been scheduled
 	var rebootAt time.Time
 	err := d.state.Get("daemon-system-restart-at", &rebootAt)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return 0, err
 	}
 	rebootDelay := 1 * time.Minute
@@ -832,7 +832,7 @@ var errExpectedReboot = errors.New("expected reboot did not happen")
 func (d *Daemon) RebootIsMissing(st *state.State) error {
 	var nTentative int
 	err := st.Get("daemon-system-restart-tentative", &nTentative)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	nTentative++

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -991,8 +991,8 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *C) {
 	defer st.Unlock()
 	var v interface{}
 	// these were cleared
-	c.Check(st.Get("daemon-system-restart-at", &v), Equals, state.ErrNoState)
-	c.Check(st.Get("system-restart-from-boot-id", &v), Equals, state.ErrNoState)
+	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *C) {
@@ -1015,9 +1015,9 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *C) {
 	defer st.Unlock()
 	var v interface{}
 	// these were cleared
-	c.Check(st.Get("daemon-system-restart-at", &v), Equals, state.ErrNoState)
-	c.Check(st.Get("system-restart-from-boot-id", &v), Equals, state.ErrNoState)
-	c.Check(st.Get("daemon-system-restart-tentative", &v), Equals, state.ErrNoState)
+	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
+	c.Check(st.Get("daemon-system-restart-tentative", &v), testutil.ErrorIs, state.ErrNoState)
 }
 
 func (s *daemonSuite) TestRestartIntoSocketModeNoNewChanges(c *C) {

--- a/internals/overlord/export_test.go
+++ b/internals/overlord/export_test.go
@@ -40,6 +40,14 @@ func FakePruneInterval(prunei, prunew, abortw time.Duration) (restore func()) {
 	}
 }
 
+func FakePruneTicker(f func(t *time.Ticker) <-chan time.Time) (restore func()) {
+	old := pruneTickerC
+	pruneTickerC = f
+	return func() {
+		pruneTickerC = old
+	}
+}
+
 // FakeEnsureNext sets o.ensureNext for tests.
 func FakeEnsureNext(o *Overlord, t time.Time) {
 	o.ensureNext = t
@@ -48,4 +56,12 @@ func FakeEnsureNext(o *Overlord, t time.Time) {
 // Engine exposes the state engine in an Overlord for tests.
 func (o *Overlord) Engine() *StateEngine {
 	return o.stateEng
+}
+
+func FakeTimeNow(f func() time.Time) (restore func()) {
+	old := timeNow
+	timeNow = f
+	return func() {
+		timeNow = old
+	}
 }

--- a/internals/overlord/patch/patch.go
+++ b/internals/overlord/patch/patch.go
@@ -20,6 +20,7 @@
 package patch
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/canonical/pebble/internals/logger"
@@ -43,12 +44,12 @@ var patches = make(map[int][]PatchFunc)
 func Init(s *state.State) {
 	s.Lock()
 	defer s.Unlock()
-	if s.Get("patch-level", new(int)) != state.ErrNoState {
+	if err := s.Get("patch-level", new(int)); !errors.Is(err, state.ErrNoState) {
 		panic("internal error: expected empty state, attempting to override patch-level without actual patching")
 	}
 	s.Set("patch-level", Level)
 
-	if s.Get("patch-sublevel", new(int)) != state.ErrNoState {
+	if err := s.Get("patch-sublevel", new(int)); !errors.Is(err, state.ErrNoState) {
 		panic("internal error: expected empty state, attempting to override patch-sublevel without actual patching")
 	}
 	s.Set("patch-sublevel", Sublevel)
@@ -76,12 +77,12 @@ func Apply(s *state.State) error {
 	var stateLevel, stateSublevel int
 	s.Lock()
 	err := s.Get("patch-level", &stateLevel)
-	if err == nil || err == state.ErrNoState {
+	if err == nil || errors.Is(err, state.ErrNoState) {
 		err = s.Get("patch-sublevel", &stateSublevel)
 	}
 	s.Unlock()
 
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 

--- a/internals/overlord/restart/restart.go
+++ b/internals/overlord/restart/restart.go
@@ -16,6 +16,8 @@
 package restart
 
 import (
+	"errors"
+
 	"github.com/canonical/pebble/internals/overlord/state"
 )
 
@@ -63,7 +65,7 @@ func Init(st *state.State, curBootID string, h Handler) error {
 	}
 	var fromBootID string
 	err := st.Get("system-restart-from-boot-id", &fromBootID)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
 	st.Cache(restartStateKey{}, rs)

--- a/internals/overlord/restart/restart_test.go
+++ b/internals/overlord/restart/restart_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/canonical/pebble/internals/overlord/restart"
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/testutil"
 )
 
 func TestRestart(t *testing.T) { TestingT(t) }
@@ -134,5 +135,5 @@ func (s *restartSuite) TestRequestRestartSystemAndVerifyReboot(c *C) {
 	err = restart.Init(st, "boot-id-2", h2)
 	c.Assert(err, IsNil)
 	c.Check(h2.rebootAsExpected, Equals, true)
-	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), Equals, state.ErrNoState)
+	c.Check(st.Get("system-restart-from-boot-id", &fromBootID), testutil.ErrorIs, state.ErrNoState)
 }

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -1,6 +1,7 @@
 package servstate
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,7 +29,7 @@ import (
 func TaskServiceRequest(task *state.Task) (*ServiceRequest, error) {
 	req := &ServiceRequest{}
 	err := task.Get("service-request", req)
-	if err != nil && err != state.ErrNoState {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return nil, err
 	}
 	if err == nil {

--- a/internals/overlord/state/change_test.go
+++ b/internals/overlord/state/change_test.go
@@ -1,25 +1,21 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2016 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package state_test
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -68,7 +64,7 @@ func (cs *changeSuite) TestReadyTime(c *C) {
 }
 
 func (cs *changeSuite) TestStatusString(c *C) {
-	for s := state.Status(0); s < state.ErrorStatus+1; s++ {
+	for s := state.Status(0); s < state.WaitStatus+1; s++ {
 		c.Assert(s.String(), Matches, ".+")
 	}
 }
@@ -86,6 +82,21 @@ func (cs *changeSuite) TestGetSet(c *C) {
 	err := chg.Get("a", &v)
 	c.Assert(err, IsNil)
 	c.Check(v, Equals, 1)
+}
+
+func (cs *changeSuite) TestHas(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("install", "...")
+	c.Check(chg.Has("a"), Equals, false)
+
+	chg.Set("a", 1)
+	c.Check(chg.Has("a"), Equals, true)
+
+	chg.Set("a", nil)
+	c.Check(chg.Has("a"), Equals, false)
 }
 
 // TODO Better testing of full change roundtripping via JSON.
@@ -227,9 +238,13 @@ func (cs *changeSuite) TestStatusDerivedFromTasks(c *C) {
 
 	tasks := make(map[state.Status]*state.Task)
 
-	for s := state.DefaultStatus + 1; s < state.ErrorStatus+1; s++ {
+	for s := state.DefaultStatus + 1; s < state.WaitStatus+1; s++ {
 		t := st.NewTask("download", s.String())
-		t.SetStatus(s)
+		if s == state.WaitStatus {
+			t.SetToWait(state.DoneStatus)
+		} else {
+			t.SetStatus(s)
+		}
 		chg.AddTask(t)
 		tasks[s] = t
 	}
@@ -240,6 +255,7 @@ func (cs *changeSuite) TestStatusDerivedFromTasks(c *C) {
 		state.UndoStatus,
 		state.DoingStatus,
 		state.DoStatus,
+		state.WaitStatus,
 		state.ErrorStatus,
 		state.UndoneStatus,
 		state.DoneStatus,
@@ -252,7 +268,11 @@ func (cs *changeSuite) TestStatusDerivedFromTasks(c *C) {
 			if s == s2 {
 				break
 			}
-			tasks[s2].SetStatus(s)
+			if s == state.WaitStatus {
+				tasks[s2].SetToWait(state.DoneStatus)
+			} else {
+				tasks[s2].SetStatus(s)
+			}
 		}
 		c.Assert(chg.Status(), Equals, s)
 	}
@@ -432,9 +452,13 @@ func (cs *changeSuite) TestAbort(c *C) {
 
 	chg := st.NewChange("install", "...")
 
-	for s := state.DefaultStatus + 1; s < state.ErrorStatus+1; s++ {
+	for s := state.DefaultStatus + 1; s < state.WaitStatus+1; s++ {
 		t := st.NewTask("download", s.String())
-		t.SetStatus(s)
+		if s == state.WaitStatus {
+			t.SetToWait(state.DoneStatus)
+		} else {
+			t.SetStatus(s)
+		}
 		t.Set("old-status", s)
 		chg.AddTask(t)
 	}
@@ -451,7 +475,7 @@ func (cs *changeSuite) TestAbort(c *C) {
 		switch s {
 		case state.DoStatus:
 			c.Assert(t.Status(), Equals, state.HoldStatus)
-		case state.DoneStatus:
+		case state.DoneStatus, state.WaitStatus:
 			c.Assert(t.Status(), Equals, state.UndoStatus)
 		case state.DoingStatus:
 			c.Assert(t.Status(), Equals, state.AbortStatus)
@@ -526,11 +550,13 @@ func (cs *changeSuite) TestAbortKⁿ(c *C) {
 
 // Task wait order:
 //
-//	            => t21 => t22
-//	          /               \
-//	t11 => t12                 => t41 => t42
-//	          \               /
-//	            => t31 => t32
+//	  => t21 => t22
+//	/               \
+//
+// t11 => t12                 => t41 => t42
+//
+//	\               /
+//	  => t31 => t32
 //
 // setup and result lines are <task>:<status>[:<lane>,...]
 //
@@ -577,6 +603,10 @@ var abortLanesTests = []struct {
 		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
 		abort:  []int{2},
 		result: "t21:hold t22:hold t41:hold t42:hold *:do",
+	}, {
+		setup:  "t11:done:1 t12:wait:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		abort:  []int{2},
+		result: "t21:hold t22:hold t41:hold t42:hold t11:done t12:wait *:do",
 	}, {
 		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
 		abort:  []int{3},
@@ -660,7 +690,7 @@ func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
 		c.Logf("Testing setup: %s", test.setup)
 
 		statuses := make(map[string]state.Status)
-		for s := state.DefaultStatus; s <= state.ErrorStatus; s++ {
+		for s := state.DefaultStatus; s <= state.WaitStatus; s++ {
 			statuses[strings.ToLower(s.String())] = s
 		}
 
@@ -680,7 +710,11 @@ func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
 			}
 			seen[parts[0]] = true
 			task := tasks[parts[0]]
-			task.SetStatus(statuses[parts[1]])
+			if statuses[parts[1]] == state.WaitStatus {
+				task.SetToWait(state.DoneStatus)
+			} else {
+				task.SetStatus(statuses[parts[1]])
+			}
 			if len(parts) > 2 {
 				lanes := strings.Split(parts[2], ",")
 				for _, lane := range lanes {
@@ -722,4 +756,692 @@ func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
 
 		c.Assert(strings.Join(obtained, " "), Equals, strings.Join(expected, " "), Commentf("setup: %s", test.setup))
 	}
+}
+
+// setup and result lines are <task>:<status>[:<lane>,...]
+// order is <task1>-><task2> (implies task2 waits for task 1)
+// "*" as task name means "all remaining".
+var abortUnreadyLanesTests = []struct {
+	setup  string
+	order  string
+	result string
+}{
+
+	// Some basics.
+	{
+		setup:  "*:do",
+		result: "*:hold",
+	}, {
+		setup:  "*:wait",
+		result: "*:undo",
+	}, {
+		setup:  "*:done",
+		result: "*:done",
+	}, {
+		setup:  "*:error",
+		result: "*:error",
+	},
+
+	// t11 (1) => t12 (1) => t21 (1) => t22 (1)
+	// t31 (2) => t32 (2) => t41 (2) => t42 (2)
+	{
+		setup:  "t11:do:1 t12:do:1 t21:do:1 t22:do:1 t31:do:2 t32:do:2 t41:do:2 t42:do:2",
+		order:  "t11->t12 t12->t21 t21->t22 t31->t32 t32->t41 t41->t42",
+		result: "*:hold",
+	}, {
+		setup:  "t11:done:1 t12:done:1 t21:done:1 t22:done:1 t31:do:2 t32:do:2 t41:do:2 t42:do:2",
+		order:  "t11->t12 t12->t21 t21->t22 t31->t32 t32->t41 t41->t42",
+		result: "t11:done t12:done t21:done t22:done t31:hold t32:hold t41:hold t42:hold",
+	}, {
+		setup:  "t11:done:1 t12:done:1 t21:done:1 t22:done:1 t31:done:2 t32:done:2 t41:done:2 t42:do:2",
+		order:  "t11->t12 t12->t21 t21->t22 t31->t32 t32->t41 t41->t42",
+		result: "t11:done t12:done t21:done t22:done t31:undo t32:undo t41:undo t42:hold",
+	},
+	//                          => t21 (2) => t22 (2)
+	//                        /                       \
+	// t11 (2,3) => t12 (2,3)                           => t41 (4) => t42 (4)
+	//                        \                       /
+	//                          => t31 (3) => t32 (3)
+	{
+		setup:  "t11:do:2,3 t12:do:2,3 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		order:  "t11->t12 t12->t21 t12->t31 t21->t22 t31->t32 t22->t41 t32->t41 t41->t42",
+		result: "*:hold",
+	}, {
+		setup: "t11:done:2,3 t12:done:2,3 t21:done:2 t22:done:2 t31:doing:3 t32:do:3 t41:do:4 t42:do:4",
+		order: "t11->t12 t12->t21 t12->t31 t21->t22 t31->t32 t22->t41 t32->t41 t41->t42",
+		// lane 2 is fully complete so it does not get aborted
+		result: "t11:done t12:done t21:done t22:done t31:abort t32:hold t41:hold t42:hold *:undo",
+	}, {
+		setup: "t11:done:2,3 t12:done:2,3 t21:done:2 t22:done:2 t31:wait:3 t32:do:3 t41:do:4 t42:do:4",
+		order: "t11->t12 t12->t21 t12->t31 t21->t22 t31->t32 t22->t41 t32->t41 t41->t42",
+		// lane 2 is fully complete so it does not get aborted
+		result: "t11:done t12:done t21:done t22:done t31:undo t32:hold t41:hold t42:hold *:undo",
+	}, {
+		setup:  "t11:done:2,3 t12:done:2,3 t21:doing:2 t22:do:2 t31:doing:3 t32:do:3 t41:do:4 t42:do:4",
+		order:  "t11->t12 t12->t21 t12->t31 t21->t22 t31->t32 t22->t41 t32->t41 t41->t42",
+		result: "t21:abort t22:hold t31:abort t32:hold t41:hold t42:hold *:undo",
+	},
+
+	// t11 (1) => t12 (1)
+	// t21 (2) => t22 (2)
+	// t31 (3) => t32 (3)
+	// t41 (4) => t42 (4)
+	{
+		setup:  "t11:do:1 t12:do:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		order:  "t11->t12 t21->t22 t31->t32 t41->t42",
+		result: "*:hold",
+	}, {
+		setup:  "t11:do:1 t12:do:1 t21:doing:2 t22:do:2 t31:done:3 t32:doing:3 t41:undone:4 t42:error:4",
+		order:  "t11->t12 t21->t22 t31->t32 t41->t42",
+		result: "t11:hold t12:hold t21:abort t22:hold t31:undo t32:abort t41:undone t42:error",
+	},
+	// auto refresh like arrangement
+	//
+	//                                                  (apps)
+	//                                            => t31 (3) => t32 (3)
+	//     (snapd)               (base)         /
+	// t11 (1) => t12 (1) => t21 (2) => t22 (2)
+	//                                          \
+	//                                            => t41 (4) => t42 (4)
+	{
+		setup:  "t11:done:1 t12:done:1 t21:done:2 t22:done:2 t31:doing:3 t32:do:3 t41:do:4 t42:do:4",
+		order:  "t11->t12 t12->t21 t21->t22 t22->t31 t22->t41 t31->t32 t41->t42",
+		result: "t11:done t12:done t21:done t22:done t31:abort *:hold",
+	}, {
+		//
+		setup:  "t11:done:1 t12:done:1 t21:done:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		order:  "t11->t12 t12->t21 t21->t22 t22->t31 t22->t41 t31->t32 t41->t42",
+		result: "t11:done t12:done t21:undo *:hold",
+	},
+	// arrangement with a cyclic dependency between tasks
+	//
+	//                        /-----------------------------------------\
+	//                        |                                         |
+	//                        |                   => t31 (3) => t32 (3) /
+	//     (snapd)            v  (base)         /
+	// t11 (1) => t12 (1) => t21 (2) => t22 (2)
+	//                                          \
+	//                                            => t41 (4) => t42 (4)
+	{
+		setup:  "t11:done:1 t12:done:1 t21:do:2 t22:do:2 t31:do:3 t32:do:3 t41:do:4 t42:do:4",
+		order:  "t11->t12 t12->t21 t21->t22 t22->t31 t22->t41 t31->t32 t41->t42 t32->t21",
+		result: "t11:done t12:done *:hold",
+	},
+}
+
+func (ts *taskRunnerSuite) TestAbortUnreadyLanes(c *C) {
+
+	names := strings.Fields("t11 t12 t21 t22 t31 t32 t41 t42")
+
+	for i, test := range abortUnreadyLanesTests {
+		sb := &stateBackend{}
+		st := state.New(sb)
+		r := state.NewTaskRunner(st)
+		defer r.Stop()
+
+		st.Lock()
+		defer st.Unlock()
+
+		c.Assert(len(st.Tasks()), Equals, 0)
+
+		chg := st.NewChange("install", "...")
+		tasks := make(map[string]*state.Task)
+		for _, name := range names {
+			tasks[name] = st.NewTask("do", name)
+			chg.AddTask(tasks[name])
+		}
+
+		c.Logf("----- %v", i)
+		c.Logf("Testing setup: %s", test.setup)
+
+		for _, wp := range strings.Fields(test.order) {
+			pair := strings.Split(wp, "->")
+			c.Assert(pair, HasLen, 2)
+			// task 2 waits for task 1 is denoted as:
+			// task1->task2
+			tasks[pair[1]].WaitFor(tasks[pair[0]])
+		}
+
+		statuses := make(map[string]state.Status)
+		for s := state.DefaultStatus; s <= state.WaitStatus; s++ {
+			statuses[strings.ToLower(s.String())] = s
+		}
+
+		items := strings.Fields(test.setup)
+		seen := make(map[string]bool)
+		for i := 0; i < len(items); i++ {
+			item := items[i]
+			parts := strings.Split(item, ":")
+			if parts[0] == "*" {
+				c.Assert(i, Equals, len(items)-1, Commentf("*: can only be used as the last entry"))
+				for _, name := range names {
+					if !seen[name] {
+						parts[0] = name
+						items = append(items, strings.Join(parts, ":"))
+					}
+				}
+				continue
+			}
+			seen[parts[0]] = true
+			task := tasks[parts[0]]
+			if statuses[parts[1]] == state.WaitStatus {
+				task.SetToWait(state.DoneStatus)
+			} else {
+				task.SetStatus(statuses[parts[1]])
+			}
+			if len(parts) > 2 {
+				lanes := strings.Split(parts[2], ",")
+				for _, lane := range lanes {
+					n, err := strconv.Atoi(lane)
+					c.Assert(err, IsNil)
+					task.JoinLane(n)
+				}
+			}
+		}
+
+		c.Logf("Aborting")
+
+		chg.AbortUnreadyLanes()
+
+		c.Logf("Expected result: %s", test.result)
+
+		seen = make(map[string]bool)
+		var expected = strings.Fields(test.result)
+		var obtained []string
+		for i := 0; i < len(expected); i++ {
+			item := expected[i]
+			parts := strings.Split(item, ":")
+			if parts[0] == "*" {
+				c.Assert(i, Equals, len(expected)-1, Commentf("*: can only be used as the last entry"))
+				var expanded []string
+				for _, name := range names {
+					if !seen[name] {
+						parts[0] = name
+						expanded = append(expanded, strings.Join(parts, ":"))
+					}
+				}
+				expected = append(expected[:i], append(expanded, expected[i+1:]...)...)
+				i--
+				continue
+			}
+			name := parts[0]
+			seen[parts[0]] = true
+			obtained = append(obtained, name+":"+strings.ToLower(tasks[name].Status().String()))
+		}
+
+		c.Assert(strings.Join(obtained, " "), Equals, strings.Join(expected, " "), Commentf("setup: %s", test.setup))
+	}
+}
+
+// setup is a list of tasks "<task1> <task2>", order is <task1>-><task2>
+// (implies task2 waits for task 1)
+var cyclicDependencyTests = []struct {
+	setup  string
+	order  string
+	err    string
+	errIDs []string
+}{
+
+	// Some basics.
+	{
+		setup: "t1",
+	}, {
+		setup: "",
+	}, {
+		// independent tasks
+		setup: "t1 t2 t3",
+	}, {
+		// some independent and some ordered tasks
+		setup: "t1 t2 t3 t4",
+		order: "t2->t3",
+	},
+	// some independent, dependencies as if added by WaitAll()
+	// t1 => t2
+	// t1,t2 => t3
+	// t1,t2,t3 => t4
+	{
+		setup: "t1 t2 t3 t4",
+		order: "t1->t2 t1->t3 t2->t3 t1->t4 t2->t4 t3->t4",
+	}, {
+		// simple loop
+		setup:  "t1 t2",
+		order:  "t1->t2 t2->t1",
+		err:    `dependency cycle involving tasks \[1:t1 2:t2\]`,
+		errIDs: []string{"1", "2"},
+	},
+
+	// t1 => t2 => t3 => t4
+	// t5 => t6 => t7 => t8
+	{
+		setup: "t1 t2 t3 t4 t5 t6 t7 t8",
+		order: "t1->t2 t2->t3 t3->t4 t5->t6 t6->t7 t7->t8",
+	},
+	//               => t21 => t22
+	//             /               \
+	// t11 => t12                    => t41 => t42
+	//             \               /
+	//               => t31 => t32
+	{
+		setup: "t11 t12 t21 t22 t31 t32 t41 t42",
+		order: "t11->t12 t12->t21 t12->t31 t21->t22 t31->t32 t22->t41 t32->t41 t41->t42",
+	},
+	// t11 (1) => t12 (1)
+	// t21 (2) => t22 (2)
+	// t31 (3) => t32 (3)
+	// t41 (4) => t42 (4)
+	{
+		setup: "t11 t12 t21 t22 t31 t32 t41 t42",
+		order: "t11->t12 t21->t22 t31->t32 t41->t42",
+	},
+	// auto refresh like arrangement
+	//
+	//                                                  (apps)
+	//                                            => t31 (3) => t32 (3)
+	//     (snapd)               (base)         /
+	// t11 (1) => t12 (1) => t21 (2) => t22 (2)
+	//                                          \
+	//                                            => t41 (4) => t42 (4)
+	{
+		setup: "t11 t12 t21 t22 t31 t32 t41 t42",
+		order: "t11->t12 t12->t21 t21->t22 t22->t31 t22->t41 t31->t32 t41->t42",
+	},
+	// arrangement with a cyclic dependency between tasks
+	//
+	//                        /-----------------------------------------\
+	//                        |                                         |
+	//                        |                   => t31 (3) => t32 (3) /
+	//     (snapd)            v  (base)         /
+	// t11 (1) => t12 (1) => t21 (2) => t22 (2)
+	//                                          \
+	//                                            => t41 (4) => t42 (4)
+	{
+		setup:  "t11 t12 t21 t22 t31 t32 t41 t42",
+		order:  "t11->t12 t12->t21 t21->t22 t22->t31 t22->t41 t31->t32 t41->t42 t32->t21",
+		err:    `dependency cycle involving tasks \[3:t21 4:t22 5:t31 6:t32 7:t41 8:t42\]`,
+		errIDs: []string{"3", "4", "5", "6", "7", "8"},
+	},
+	// t1 => t2 => t3 => t4 --> t6
+	// t5 => t6 => t7 => t8 --> t2
+	{
+		setup:  "t1 t2 t3 t4 t5 t6 t7 t8",
+		order:  "t1->t2 t2->t3 t3->t4 t4->t6 t5->t6 t6->t7 t7->t8 t8->t2",
+		err:    `dependency cycle involving tasks \[2:t2 3:t3 4:t4 6:t6 7:t7 8:t8\]`,
+		errIDs: []string{"2", "3", "4", "6", "7", "8"},
+	},
+}
+
+func (ts *taskRunnerSuite) TestCheckTaskDependencies(c *C) {
+
+	for i, test := range cyclicDependencyTests {
+		names := strings.Fields(test.setup)
+		sb := &stateBackend{}
+		st := state.New(sb)
+		r := state.NewTaskRunner(st)
+		defer r.Stop()
+
+		st.Lock()
+		defer st.Unlock()
+
+		c.Assert(len(st.Tasks()), Equals, 0)
+
+		chg := st.NewChange("install", "...")
+		tasks := make(map[string]*state.Task)
+		for _, name := range names {
+			tasks[name] = st.NewTask(name, name)
+			chg.AddTask(tasks[name])
+		}
+
+		c.Logf("----- %v", i)
+		c.Logf("Testing setup: %s", test.setup)
+
+		for _, wp := range strings.Fields(test.order) {
+			pair := strings.Split(wp, "->")
+			c.Assert(pair, HasLen, 2)
+			// task 2 waits for task 1 is denoted as:
+			// task1->task2
+			tasks[pair[1]].WaitFor(tasks[pair[0]])
+		}
+
+		err := chg.CheckTaskDependencies()
+
+		if test.err != "" {
+			c.Assert(err, ErrorMatches, test.err)
+			c.Assert(errors.Is(err, &state.TaskDependencyCycleError{}), Equals, true)
+			errTasksDepCycle := err.(*state.TaskDependencyCycleError)
+			c.Assert(errTasksDepCycle.IDs, DeepEquals, test.errIDs)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
+func (cs *changeSuite) TestIsWaitingStatusOrderWithWaits(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+	t2 := st.NewTask("task2", "...")
+	t3 := st.NewTask("task3", "...")
+	t4 := st.NewTask("wait-task", "...")
+	t1.WaitFor(t2)
+	t1.WaitFor(t3)
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+	chg.AddTask(t4)
+
+	// Set the wait-task into WaitStatus, to ensure we trigger the isWaiting
+	// logic and that it doesn't return WaitStatus for statuses which are in
+	// higher order
+	t4.SetToWait(state.DoneStatus)
+
+	// Test the following sequences:
+	// task1 (do) => task2 (done) => task3 (doing)
+	t2.SetToWait(state.DoneStatus)
+	t3.SetStatus(state.DoingStatus)
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+
+	// task1 (done) => task2 (done) => task3 (undoing)
+	t1.SetToWait(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	t3.SetStatus(state.UndoingStatus)
+	c.Check(chg.Status(), Equals, state.UndoingStatus)
+
+	// task1 (done) => task2 (done) => task3 (abort)
+	t1.SetToWait(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	t3.SetStatus(state.AbortStatus)
+	c.Check(chg.Status(), Equals, state.AbortStatus)
+}
+
+func (cs *changeSuite) TestIsWaitingSingle(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+
+	chg.AddTask(t1)
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	t1.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+}
+
+func (cs *changeSuite) TestIsWaitingTwoTasks(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+	t2 := st.NewTask("task2", "...")
+	t3 := st.NewTask("wait-task", "...")
+	t2.WaitFor(t1)
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+
+	// Put t3 into wait-status to trigger the isWaiting logic each time
+	// for the change.
+	t3.SetToWait(state.DoneStatus)
+
+	// task1 (do) => task2 (do) no reboot
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// task1 (done) => task2 (do) no reboot
+	t1.SetStatus(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// task1 (wait) => task2 (do) means need a reboot
+	t1.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (done) => task2 (wait) means need a reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+}
+
+func (cs *changeSuite) TestIsWaitingCircularDependency(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+	t2 := st.NewTask("task2", "...")
+	t3 := st.NewTask("task3", "...")
+	t4 := st.NewTask("wait-task", "...")
+
+	// Setup circular dependency between t1,t2 and t3, they should
+	// still act normally.
+	t2.WaitFor(t1)
+	t3.WaitFor(t2)
+	t1.WaitFor(t3)
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+	chg.AddTask(t4)
+
+	// To trigger the cyclic dependency check, we must trigger the isWaiting logic
+	// and we do this by putting t4 into WaitStatus.
+	t4.SetToWait(state.DoneStatus)
+
+	// task1 (do) => task2 (do) => task3 (do) no reboot
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// task1 (done) => task2 (do) => task3 (do) no reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetStatus(state.DoingStatus)
+	c.Check(chg.Status(), Equals, state.DoingStatus)
+
+	// task1 (wait) => task2 (do) => task3 (do) means need a reboot
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (done) => task2 (wait) => task3 (do) means need a reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+}
+
+func (cs *changeSuite) TestIsWaitingMultipleDependencies(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+	t2 := st.NewTask("task2", "...")
+	t3 := st.NewTask("task3", "...")
+	t4 := st.NewTask("wait-task", "...")
+	t3.WaitFor(t1)
+	t3.WaitFor(t2)
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+	chg.AddTask(t4)
+
+	// Put t4 into wait-status to trigger the isWaiting logic each time
+	// for the change.
+	t4.SetToWait(state.DoneStatus)
+
+	// task1 (do) + task2 (do) => task3 (do) no reboot
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// task1 (done) + task2 (done) => task3 (do) no reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetStatus(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// task1 (done) + task2 (do) => task3 (do) no reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetStatus(state.DoStatus)
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// For the next two cases we are testing that a task with dependencies
+	// which have completed, but in a non-successful way is handled correctly.
+	// task1 (error) + task2 (wait) => task3 (do) means need reboot
+	// to finalize task2
+	t1.SetStatus(state.ErrorStatus)
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (wait) + task2 (error) => task3 (do) means need reboot
+	// to finalize task1
+	t1.SetToWait(state.DoneStatus)
+	t2.SetStatus(state.ErrorStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (done) + task2 (wait) => task3 (do) means need a reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (wait) + task2 (wait) => task3 (do) means need a reboot
+	t1.SetToWait(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (done) + task2 (done) => task3 (wait) means need a reboot
+	t1.SetStatus(state.DoneStatus)
+	t2.SetStatus(state.DoneStatus)
+	t3.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (wait) + task2 (abort) => task3 (do)
+	t1.SetToWait(state.DoneStatus)
+	t2.SetStatus(state.AbortStatus)
+	t3.SetStatus(state.DoStatus)
+	c.Check(chg.Status(), Equals, state.AbortStatus)
+}
+
+func (cs *changeSuite) TestIsWaitingUndoTwoTasks(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+	t2 := st.NewTask("task2", "...")
+	t3 := st.NewTask("wait-task", "...")
+	t2.WaitFor(t1)
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+
+	// Put t3 into wait-status to trigger the isWaiting logic each time
+	// for the change.
+	t3.SetToWait(state.DoneStatus)
+
+	// we use <=| to denote the reverse dependence relationship
+	// followed by undo logic
+
+	// task1 (undo) <=| task2 (undo) no reboot
+	t1.SetStatus(state.UndoStatus)
+	t2.SetStatus(state.UndoStatus)
+	c.Check(chg.Status(), Equals, state.UndoStatus)
+
+	// task1 (undo) <=| task2 (undone) no reboot
+	t1.SetStatus(state.UndoStatus)
+	t2.SetStatus(state.UndoneStatus)
+	c.Check(chg.Status(), Equals, state.UndoStatus)
+
+	// task1 (undo) <=| task2 (wait) means need a reboot
+	t1.SetStatus(state.UndoStatus)
+	t2.SetToWait(state.DoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (wait) <=| task2 (undone) means need a reboot
+	t1.SetToWait(state.DoneStatus)
+	t2.SetStatus(state.UndoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+}
+
+func (cs *changeSuite) TestIsWaitingUndoMultipleDependencies(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+
+	t1 := st.NewTask("task1", "...")
+	t2 := st.NewTask("task2", "...")
+	t3 := st.NewTask("task3", "...")
+	t4 := st.NewTask("task4", "...")
+	t5 := st.NewTask("wait-task", "...")
+	t3.WaitFor(t1)
+	t3.WaitFor(t2)
+	t4.WaitFor(t1)
+	t4.WaitFor(t2)
+
+	chg.AddTask(t1)
+	chg.AddTask(t2)
+	chg.AddTask(t3)
+	chg.AddTask(t4)
+	chg.AddTask(t5)
+
+	// Put t5 into wait-status to trigger the isWaiting logic each time
+	// for the change.
+	t5.SetToWait(state.DoneStatus)
+
+	// task1 (undo) + task2 (undo) <=| task3 (undo) no reboot
+	t1.SetStatus(state.UndoStatus)
+	t2.SetStatus(state.UndoStatus)
+	t3.SetStatus(state.UndoStatus)
+	c.Check(chg.Status(), Equals, state.UndoStatus)
+
+	// task1 (undo) + task2 (undo) <=| task3 (undone) no reboot
+	t1.SetStatus(state.UndoStatus)
+	t2.SetStatus(state.UndoStatus)
+	t3.SetStatus(state.UndoneStatus)
+	c.Check(chg.Status(), Equals, state.UndoStatus)
+
+	// task1 (undo) + task2 (undo) <=| task3 (wait) + task4 (error) means
+	// need reboot to continue undoing 1 and 2
+	t3.SetStatus(state.ErrorStatus)
+	t4.SetToWait(state.UndoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (undo) + task2 (undo) => task3 (error) + task4 (wait) means
+	// need reboot to continue undoing 1 and 2
+	t3.SetToWait(state.UndoneStatus)
+	t4.SetStatus(state.ErrorStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (wait) + task2 (wait) <=| task3 (undone) + task4 (undo) no reboot
+	t1.SetToWait(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	t3.SetStatus(state.UndoneStatus)
+	t4.SetStatus(state.UndoStatus)
+	c.Check(chg.Status(), Equals, state.UndoStatus)
+
+	// task1 (wait) + task2 (done) <=| task3 (undone) + task4 (undone) means need a reboot
+	t1.SetToWait(state.DoneStatus)
+	t2.SetStatus(state.DoneStatus)
+	t3.SetStatus(state.UndoneStatus)
+	t4.SetStatus(state.UndoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
+
+	// task1 (wait) + task2 (wait) <=| task3 (undone) + task4 (undone) means need a reboot
+	t1.SetToWait(state.DoneStatus)
+	t2.SetToWait(state.DoneStatus)
+	t3.SetStatus(state.UndoneStatus)
+	t4.SetStatus(state.UndoneStatus)
+	c.Check(chg.Status(), Equals, state.WaitStatus)
 }

--- a/internals/overlord/state/export_test.go
+++ b/internals/overlord/state/export_test.go
@@ -1,21 +1,16 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2016 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package state
 

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Canonical Ltd
+// Copyright (c) 2024 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -11,7 +11,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 package state_test
 
 import (
@@ -448,7 +447,7 @@ func (s *noticesSuite) TestDeleteExpired(c *C) {
 	addNotice(c, st, nil, state.CustomNotice, "foo.com/z", nil)
 
 	c.Assert(st.NumNotices(), Equals, 4)
-	st.Prune(0, 0, 0)
+	st.Prune(time.Now(), 0, 0, 0)
 	c.Assert(st.NumNotices(), Equals, 2)
 
 	notices := st.Notices(nil)

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -1,21 +1,16 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2016 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Package state implements the representation of system state.
 package state
@@ -46,7 +41,7 @@ type customData map[string]*json.RawMessage
 func (data customData) get(key string, value interface{}) error {
 	entryJSON := data[key]
 	if entryJSON == nil {
-		return ErrNoState
+		return &NoStateError{Key: key}
 	}
 	err := json.Unmarshal(*entryJSON, value)
 	if err != nil {
@@ -88,6 +83,9 @@ type State struct {
 	lastChangeId int
 	lastLaneId   int
 	lastNoticeId int
+	// lastHandlerId is not serialized, it's only used during runtime
+	// for registering runtime callbacks
+	lastHandlerId int
 
 	backend  Backend
 	data     customData
@@ -101,19 +99,28 @@ type State struct {
 	modified bool
 
 	cache map[interface{}]interface{}
+
+	pendingChangeByAttr map[string]func(*Change) bool
+
+	// task/changes observing
+	taskHandlers   map[int]func(t *Task, old, new Status)
+	changeHandlers map[int]func(chg *Change, old, new Status)
 }
 
 // New returns a new empty state.
 func New(backend Backend) *State {
 	st := &State{
-		backend:  backend,
-		data:     make(customData),
-		changes:  make(map[string]*Change),
-		tasks:    make(map[string]*Task),
-		warnings: make(map[string]*Warning),
-		notices:  make(map[noticeKey]*Notice),
-		modified: true,
-		cache:    make(map[interface{}]interface{}),
+		backend:             backend,
+		data:                make(customData),
+		changes:             make(map[string]*Change),
+		tasks:               make(map[string]*Task),
+		warnings:            make(map[string]*Warning),
+		notices:             make(map[noticeKey]*Notice),
+		modified:            true,
+		cache:               make(map[interface{}]interface{}),
+		pendingChangeByAttr: make(map[string]func(*Change) bool),
+		taskHandlers:        make(map[int]func(t *Task, old Status, new Status)),
+		changeHandlers:      make(map[int]func(chg *Change, old Status, new Status)),
 	}
 	st.noticeCond = sync.NewCond(st) // use State.Lock and State.Unlock
 	return st
@@ -221,6 +228,15 @@ var (
 	unlockCheckpointRetryInterval = 3 * time.Second
 )
 
+// Unlocker returns a closure that will unlock and checkpoint the state and
+// in turn return a function to relock it.
+func (s *State) Unlocker() (unlock func() (relock func())) {
+	return func() func() {
+		s.Unlock()
+		return s.Lock
+	}
+}
+
 // Unlock releases the state lock and checkpoints the state.
 // It does not return until the state is correctly checkpointed.
 // After too many unsuccessful checkpoint attempts, it panics.
@@ -254,12 +270,40 @@ func (s *State) EnsureBefore(d time.Duration) {
 // ErrNoState represents the case of no state entry for a given key.
 var ErrNoState = errors.New("no state entry for key")
 
+// NoStateError represents the case where no state could be found for a given key.
+type NoStateError struct {
+	// Key is the key for which no state could be found.
+	Key string
+}
+
+func (e *NoStateError) Error() string {
+	var keyMsg string
+	if e.Key != "" {
+		keyMsg = fmt.Sprintf(" %q", e.Key)
+	}
+
+	return fmt.Sprintf("no state entry for key%s", keyMsg)
+}
+
+// Is returns true if the error is of type *NoStateError or equal to ErrNoState.
+// NoStateError's key isn't compared between errors.
+func (e *NoStateError) Is(err error) bool {
+	_, ok := err.(*NoStateError)
+	return ok || errors.Is(err, ErrNoState)
+}
+
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
 // It returns ErrNoState if there is no entry for key.
 func (s *State) Get(key string, value interface{}) error {
 	s.reading()
 	return s.data.get(key, value)
+}
+
+// Has returns whether the provided key has an associated value.
+func (s *State) Has(key string) bool {
+	s.reading()
+	return s.data.has(key)
 }
 
 // Set associates value with key for future consulting by managers.
@@ -370,15 +414,25 @@ func (s *State) tasksIn(tids []string) []*Task {
 	return res
 }
 
+// RegisterPendingChangeByAttr registers predicates that will be invoked by
+// Prune on changes with the specified attribute set to check whether even if
+// they meet the time criteria they must not be aborted yet.
+func (s *State) RegisterPendingChangeByAttr(attr string, f func(*Change) bool) {
+	s.pendingChangeByAttr[attr] = f
+}
+
 // Prune does several cleanup tasks to the in-memory state:
 //
 //   - it removes changes that became ready for more than pruneWait and aborts
-//     tasks spawned for more than abortWait.
+//     tasks spawned for more than abortWait unless prevented by predicates
+//     registered with RegisterPendingChangeByAttr.
+//
 //   - it removes tasks unlinked to changes after pruneWait. When there are more
 //     changes than the limit set via "maxReadyChanges" those changes in ready
 //     state will also removed even if they are below the pruneWait duration.
-//   - it removes expired warnings and notices
-func (s *State) Prune(pruneWait, abortWait time.Duration, maxReadyChanges int) {
+//
+//   - it removes expired warnings and notices.
+func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Duration, maxReadyChanges int) {
 	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)
 	abortLimit := now.Add(-abortWait)
@@ -411,15 +465,24 @@ func (s *State) Prune(pruneWait, abortWait time.Duration, maxReadyChanges int) {
 		}
 	}
 
+NextChange:
 	for _, chg := range changes {
-		spawnTime := chg.SpawnTime()
 		readyTime := chg.ReadyTime()
+		spawnTime := chg.SpawnTime()
+		if spawnTime.Before(startOfOperation) {
+			spawnTime = startOfOperation
+		}
 		if readyTime.IsZero() {
 			if spawnTime.Before(pruneLimit) && len(chg.Tasks()) == 0 {
 				chg.Abort()
 				delete(s.changes, chg.ID())
 			} else if spawnTime.Before(abortLimit) {
-				chg.Abort()
+				for attr, pending := range s.pendingChangeByAttr {
+					if chg.Has(attr) && pending(chg) {
+						continue NextChange
+					}
+				}
+				chg.AbortUnreadyLanes()
 			}
 			continue
 		}
@@ -443,6 +506,75 @@ func (s *State) Prune(pruneWait, abortWait time.Duration, maxReadyChanges int) {
 	}
 }
 
+// GetMaybeTimings implements timings.GetSaver
+func (s *State) GetMaybeTimings(timings interface{}) error {
+	if err := s.Get("timings", timings); err != nil && !errors.Is(err, ErrNoState) {
+		return err
+	}
+	return nil
+}
+
+// AddTaskStatusChangedHandler adds a callback function that will be invoked
+// whenever tasks change status.
+// NOTE: Callbacks registered this way may be invoked in the context
+// of the taskrunner, so the callbacks should be as simple as possible, and return
+// as quickly as possible, and should avoid the use of i/o code or blocking, as this
+// will stop the entire task system.
+func (s *State) AddTaskStatusChangedHandler(f func(t *Task, old, new Status)) (id int) {
+	// We are reading here as we want to ensure access to the state is serialized,
+	// and not writing as we are not changing the part of state that goes on the disk.
+	s.reading()
+	id = s.lastHandlerId
+	s.lastHandlerId++
+	s.taskHandlers[id] = f
+	return id
+}
+
+func (s *State) RemoveTaskStatusChangedHandler(id int) {
+	s.reading()
+	delete(s.taskHandlers, id)
+}
+
+func (s *State) notifyTaskStatusChangedHandlers(t *Task, old, new Status) {
+	s.reading()
+	for _, f := range s.taskHandlers {
+		f(t, old, new)
+	}
+}
+
+// AddChangeStatusChangedHandler adds a callback function that will be invoked
+// whenever a Change changes status.
+// NOTE: Callbacks registered this way may be invoked in the context
+// of the taskrunner, so the callbacks should be as simple as possible, and return
+// as quickly as possible, and should avoid the use of i/o code or blocking, as this
+// will stop the entire task system.
+func (s *State) AddChangeStatusChangedHandler(f func(chg *Change, old, new Status)) (id int) {
+	// We are reading here as we want to ensure access to the state is serialized,
+	// and not writing as we are not changing the part of state that goes on the disk.
+	s.reading()
+	id = s.lastHandlerId
+	s.lastHandlerId++
+	s.changeHandlers[id] = f
+	return id
+}
+
+func (s *State) RemoveChangeStatusChangedHandler(id int) {
+	s.reading()
+	delete(s.changeHandlers, id)
+}
+
+func (s *State) notifyChangeStatusChangedHandlers(chg *Change, old, new Status) {
+	s.reading()
+	for _, f := range s.changeHandlers {
+		f(chg, old, new)
+	}
+}
+
+// SaveTimings implements timings.GetSaver
+func (s *State) SaveTimings(timings interface{}) {
+	s.Set("timings", timings)
+}
+
 // ReadState returns the state deserialized from r.
 func ReadState(backend Backend, r io.Reader) (*State, error) {
 	s := new(State)
@@ -454,8 +586,11 @@ func ReadState(backend Backend, r io.Reader) (*State, error) {
 		return nil, fmt.Errorf("cannot read state: %s", err)
 	}
 	s.backend = backend
+	s.noticeCond = sync.NewCond(s)
 	s.modified = false
 	s.cache = make(map[interface{}]interface{})
-	s.noticeCond = sync.NewCond(s)
+	s.pendingChangeByAttr = make(map[string]func(*Change) bool)
+	s.changeHandlers = make(map[int]func(chg *Change, old Status, new Status))
+	s.taskHandlers = make(map[int]func(t *Task, old Status, new Status))
 	return s, err
 }

--- a/internals/overlord/state/state_test.go
+++ b/internals/overlord/state/state_test.go
@@ -1,21 +1,16 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2016 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package state_test
 
@@ -23,12 +18,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/testutil"
 )
 
 func TestState(t *testing.T) { TestingT(t) }
@@ -55,6 +52,17 @@ func (ss *stateSuite) TestLockUnlock(c *C) {
 	st.Unlock()
 }
 
+func (ss *stateSuite) TestUnlocker(c *C) {
+	st := state.New(nil)
+	unlocker := st.Unlocker()
+	st.Lock()
+	defer st.Unlock()
+	relock := unlocker()
+	st.Lock()
+	st.Unlock()
+	relock()
+}
+
 func (ss *stateSuite) TestGetAndSet(c *C) {
 	st := state.New(nil)
 	st.Lock()
@@ -76,6 +84,37 @@ func (ss *stateSuite) TestGetAndSet(c *C) {
 	c.Check(&mSt2B, DeepEquals, mSt2)
 }
 
+func (ss *stateSuite) TestHas(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	c.Check(st.Has("a"), Equals, false)
+
+	st.Set("a", 1)
+	c.Check(st.Has("a"), Equals, true)
+
+	st.Set("a", nil)
+	c.Check(st.Has("a"), Equals, false)
+}
+
+func (ss *stateSuite) TestStrayTaskWithNoChange(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.NewChange("change", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+	_ = st.NewTask("bar", "...")
+
+	// only the task with associate change is returned
+	c.Assert(st.Tasks(), HasLen, 1)
+	c.Assert(st.Tasks()[0].ID(), Equals, t1.ID())
+	// but count includes all tasks
+	c.Assert(st.TaskCount(), Equals, 2)
+}
+
 func (ss *stateSuite) TestSetPanic(c *C) {
 	st := state.New(nil)
 	st.Lock()
@@ -94,7 +133,7 @@ func (ss *stateSuite) TestGetNoState(c *C) {
 
 	var mSt1B mgrState1
 	err := st.Get("mgr9", &mSt1B)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 }
 
 func (ss *stateSuite) TestSetToNilDeletes(c *C) {
@@ -112,7 +151,7 @@ func (ss *stateSuite) TestSetToNilDeletes(c *C) {
 
 	var v1 map[string]int
 	err = st.Get("a", &v1)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(v1, HasLen, 0)
 }
 
@@ -126,7 +165,7 @@ func (ss *stateSuite) TestNullMeansNoState(c *C) {
 
 	var v1 map[string]int
 	err = st.Get("a", &v1)
-	c.Check(err, Equals, state.ErrNoState)
+	c.Check(err, testutil.ErrorIs, state.ErrNoState)
 	c.Check(v1, HasLen, 0)
 }
 
@@ -514,6 +553,30 @@ func (ss *stateSuite) TestEmptyStateDataAndCheckpointReadAndSet(c *C) {
 
 	// no crash
 	st2.Set("a", 1)
+
+	// ensure all maps of state are correctly initialized by ReadState
+	val := reflect.ValueOf(st2)
+	typ := val.Elem().Type()
+	var maps []string
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.Type.Kind() == reflect.Map {
+			maps = append(maps, f.Name)
+			fv := val.Elem().Field(i)
+			c.Check(fv.IsNil(), Equals, false, Commentf("Map field %s of state was not initialized by ReadState", f.Name))
+		}
+	}
+	c.Check(maps, DeepEquals, []string{
+		"data",
+		"changes",
+		"tasks",
+		"warnings",
+		"notices",
+		"cache",
+		"pendingChangeByAttr",
+		"taskHandlers",
+		"changeHandlers",
+	})
 }
 
 func (ss *stateSuite) TestEmptyTaskAndChangeDataAndCheckpointReadAndSet(c *C) {
@@ -702,7 +765,7 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.Tasks() },
 		func() { st.Task("foo") },
 		func() { st.MarshalJSON() },
-		func() { st.Prune(time.Hour, time.Hour, 100) },
+		func() { st.Prune(time.Now(), time.Hour, time.Hour, 100) },
 		func() { st.TaskCount() },
 		func() { st.AllWarnings() },
 		func() { st.PendingWarnings() },
@@ -768,7 +831,8 @@ func (ss *stateSuite) TestPrune(c *C) {
 	st.AddWarning("hello", now, never, time.Nanosecond, state.DefaultRepeatAfter)
 	st.Warnf("hello again")
 
-	st.Prune(pruneWait, abortWait, 100)
+	past := time.Now().AddDate(-1, 0, 0)
+	st.Prune(past, pruneWait, abortWait, 100)
 
 	c.Assert(st.Change(chg1.ID()), Equals, chg1)
 	c.Assert(st.Change(chg2.ID()), IsNil)
@@ -793,6 +857,55 @@ func (ss *stateSuite) TestPrune(c *C) {
 	c.Check(st.AllWarnings(), HasLen, 1)
 }
 
+func (ss *stateSuite) TestRegisterPendingChangeByAttr(c *C) {
+	st := state.New(&fakeStateBackend{})
+	st.Lock()
+	defer st.Unlock()
+
+	now := time.Now()
+	pruneWait := 1 * time.Hour
+	abortWait := 3 * time.Hour
+
+	unset := time.Time{}
+
+	t1 := st.NewTask("foo", "...")
+	t2 := st.NewTask("foo", "...")
+	t3 := st.NewTask("foo", "...")
+	t4 := st.NewTask("foo", "...")
+
+	chg1 := st.NewChange("abort", "...")
+	chg1.AddTask(t1)
+	chg1.AddTask(t2)
+	state.FakeChangeTimes(chg1, now.Add(-abortWait), unset)
+
+	chg2 := st.NewChange("pending", "...")
+	chg2.AddTask(t3)
+	chg2.AddTask(t4)
+	state.FakeChangeTimes(chg2, now.Add(-abortWait), unset)
+	chg2.Set("pending-flag", true)
+	t3.SetStatus(state.HoldStatus)
+
+	st.RegisterPendingChangeByAttr("pending-flag", func(chg *state.Change) bool {
+		c.Check(chg.ID(), Equals, chg2.ID())
+		return true
+	})
+
+	past := time.Now().AddDate(-1, 0, 0)
+	st.Prune(past, pruneWait, abortWait, 100)
+
+	c.Assert(st.Change(chg1.ID()), Equals, chg1)
+	c.Assert(st.Change(chg2.ID()), Equals, chg2)
+	c.Assert(st.Task(t1.ID()), Equals, t1)
+	c.Assert(st.Task(t2.ID()), Equals, t2)
+	c.Assert(st.Task(t3.ID()), Equals, t3)
+	c.Assert(st.Task(t4.ID()), Equals, t4)
+
+	c.Assert(t1.Status(), Equals, state.HoldStatus)
+	c.Assert(t2.Status(), Equals, state.HoldStatus)
+	c.Assert(t3.Status(), Equals, state.HoldStatus)
+	c.Assert(t4.Status(), Equals, state.DoStatus)
+}
+
 func (ss *stateSuite) TestPruneEmptyChange(c *C) {
 	// Empty changes are a bit special because they start out on Hold
 	// which is a Ready status, but the change itself is not considered Ready
@@ -809,7 +922,8 @@ func (ss *stateSuite) TestPruneEmptyChange(c *C) {
 	chg := st.NewChange("abort", "...")
 	state.FakeChangeTimes(chg, now.Add(-pruneWait), time.Time{})
 
-	st.Prune(pruneWait, abortWait, 100)
+	past := time.Now().AddDate(-1, 0, 0)
+	st.Prune(past, pruneWait, abortWait, 100)
 	c.Assert(st.Change(chg.ID()), IsNil)
 }
 
@@ -844,13 +958,14 @@ func (ss *stateSuite) TestPruneMaxChangesHappy(c *C) {
 
 	// test that nothing is done when we are within pruneWait and
 	// maxReadyChanges
+	past := time.Now().AddDate(-1, 0, 0)
 	maxReadyChanges := 100
-	st.Prune(pruneWait, abortWait, maxReadyChanges)
+	st.Prune(past, pruneWait, abortWait, maxReadyChanges)
 	c.Assert(st.Changes(), HasLen, 15)
 
 	// but with maxReadyChanges we remove the ready ones
 	maxReadyChanges = 5
-	st.Prune(pruneWait, abortWait, maxReadyChanges)
+	st.Prune(past, pruneWait, abortWait, maxReadyChanges)
 	c.Assert(st.Changes(), HasLen, 10)
 	remaining := map[string]bool{}
 	for _, chg := range st.Changes() {
@@ -886,8 +1001,9 @@ func (ss *stateSuite) TestPruneMaxChangesSomeNotReady(c *C) {
 	c.Assert(st.Changes(), HasLen, 10)
 
 	// nothing can be pruned
+	past := time.Now().AddDate(-1, 0, 0)
 	maxChanges := 5
-	st.Prune(1*time.Hour, 3*time.Hour, maxChanges)
+	st.Prune(past, 1*time.Hour, 3*time.Hour, maxChanges)
 	c.Assert(st.Changes(), HasLen, 10)
 }
 
@@ -905,7 +1021,7 @@ func (ss *stateSuite) TestPruneMaxChangesHonored(c *C) {
 	c.Assert(st.Changes(), HasLen, 10)
 
 	// one extra change that just now entered ready state
-	chg := st.NewChange(fmt.Sprintf("chg99"), "so-ready")
+	chg := st.NewChange("chg99", "so-ready")
 	t := st.NewTask("foo", "so-ready")
 	when := 1 * time.Second
 	state.FakeChangeTimes(chg, time.Now().Add(-when), time.Now().Add(-when))
@@ -916,11 +1032,45 @@ func (ss *stateSuite) TestPruneMaxChangesHonored(c *C) {
 	//
 	// this test we do not purge the freshly ready change
 	maxChanges := 10
-	st.Prune(1*time.Hour, 3*time.Hour, maxChanges)
+	past := time.Now().AddDate(-1, 0, 0)
+	st.Prune(past, 1*time.Hour, 3*time.Hour, maxChanges)
 	c.Assert(st.Changes(), HasLen, 11)
 }
 
-func (ss *stateSuite) TestReadStateInitsCache(c *C) {
+func (ss *stateSuite) TestPruneHonorsStartOperationTime(c *C) {
+	st := state.New(&fakeStateBackend{})
+	st.Lock()
+	defer st.Unlock()
+
+	now := time.Now()
+
+	startTime := 2 * time.Hour
+	spawnTime := 10 * time.Hour
+	pruneWait := 1 * time.Hour
+	abortWait := 3 * time.Hour
+
+	chg := st.NewChange("change", "...")
+	t := st.NewTask("foo", "")
+	chg.AddTask(t)
+	// change spawned 10h ago
+	state.FakeChangeTimes(chg, now.Add(-spawnTime), time.Time{})
+
+	// start operation time is 2h ago, change is not aborted because
+	// it's less than abortWait limit.
+	opTime := now.Add(-startTime)
+	st.Prune(opTime, pruneWait, abortWait, 100)
+	c.Assert(st.Changes(), HasLen, 1)
+	c.Check(chg.Status(), Equals, state.DoStatus)
+
+	// start operation time is 9h ago, change is aborted.
+	startTime = 9 * time.Hour
+	opTime = time.Now().Add(-startTime)
+	st.Prune(opTime, pruneWait, abortWait, 100)
+	c.Assert(st.Changes(), HasLen, 1)
+	c.Check(chg.Status(), Equals, state.HoldStatus)
+}
+
+func (ss *stateSuite) TestReadStateInitsTransientMapFields(c *C) {
 	st, err := state.ReadState(nil, bytes.NewBufferString("{}"))
 	c.Assert(err, IsNil)
 	st.Lock()
@@ -928,4 +1078,195 @@ func (ss *stateSuite) TestReadStateInitsCache(c *C) {
 
 	st.Cache("key", "value")
 	c.Assert(st.Cached("key"), Equals, "value")
+	st.RegisterPendingChangeByAttr("attr", func(*state.Change) bool { return false })
+}
+
+func (ss *stateSuite) TestTimingsSupport(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var tims []int
+
+	err := st.GetMaybeTimings(&tims)
+	c.Assert(err, IsNil)
+	c.Check(tims, IsNil)
+
+	st.SaveTimings([]int{1, 2, 3})
+
+	err = st.GetMaybeTimings(&tims)
+	c.Assert(err, IsNil)
+	c.Check(tims, DeepEquals, []int{1, 2, 3})
+}
+
+func (ss *stateSuite) TestNoStateErrorIs(c *C) {
+	err := &state.NoStateError{Key: "foo"}
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{})
+	c.Assert(err, testutil.ErrorIs, &state.NoStateError{Key: "bar"})
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+}
+
+func (ss *stateSuite) TestNoStateErrorString(c *C) {
+	err := &state.NoStateError{}
+	c.Assert(err.Error(), Equals, `no state entry for key`)
+	err.Key = "foo"
+	c.Assert(err.Error(), Equals, `no state entry for key "foo"`)
+}
+
+type taskAndStatus struct {
+	t        *state.Task
+	old, new state.Status
+}
+
+func (ss *stateSuite) TestTaskChangedHandler(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var taskObservedChanges []taskAndStatus
+	oId := st.AddTaskStatusChangedHandler(func(t *state.Task, old, new state.Status) {
+		taskObservedChanges = append(taskObservedChanges, taskAndStatus{
+			t:   t,
+			old: old,
+			new: new,
+		})
+	})
+
+	t1 := st.NewTask("foo", "...")
+
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task status to identical status, we don't want
+	// task events when task don't actually change status.
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task to done.
+	t1.SetStatus(state.DoneStatus)
+
+	// Unregister us, and make sure we do not receive more events.
+	st.RemoveTaskStatusChangedHandler(oId)
+
+	// must not appear in list.
+	t1.SetStatus(state.DoingStatus)
+
+	c.Check(taskObservedChanges, DeepEquals, []taskAndStatus{
+		{
+			t:   t1,
+			old: state.DefaultStatus,
+			new: state.DoingStatus,
+		},
+		{
+			t:   t1,
+			old: state.DoingStatus,
+			new: state.DoneStatus,
+		},
+	})
+}
+
+type changeAndStatus struct {
+	chg      *state.Change
+	old, new state.Status
+}
+
+func (ss *stateSuite) TestChangeChangedHandler(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var observedChanges []changeAndStatus
+	oId := st.AddChangeStatusChangedHandler(func(chg *state.Change, old, new state.Status) {
+		observedChanges = append(observedChanges, changeAndStatus{
+			chg: chg,
+			old: old,
+			new: new,
+		})
+	})
+
+	chg := st.NewChange("test-chg", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task status to identical status, we don't want
+	// change events when changes don't actually change status.
+	t1.SetStatus(state.DoingStatus)
+
+	// Set task to waiting
+	t1.SetToWait(state.DoneStatus)
+
+	// Unregister us, and make sure we do not receive more events.
+	st.RemoveChangeStatusChangedHandler(oId)
+
+	// must not appear in list.
+	t1.SetStatus(state.DoneStatus)
+
+	c.Check(observedChanges, DeepEquals, []changeAndStatus{
+		{
+			chg: chg,
+			old: state.DefaultStatus,
+			new: state.DoingStatus,
+		},
+		{
+			chg: chg,
+			old: state.DoingStatus,
+			new: state.WaitStatus,
+		},
+	})
+}
+
+func (ss *stateSuite) TestChangeSetStatusChangedHandler(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	var observedChanges []changeAndStatus
+	oId := st.AddChangeStatusChangedHandler(func(chg *state.Change, old, new state.Status) {
+		observedChanges = append(observedChanges, changeAndStatus{
+			chg: chg,
+			old: old,
+			new: new,
+		})
+	})
+
+	chg := st.NewChange("test-chg", "...")
+	t1 := st.NewTask("foo", "...")
+	chg.AddTask(t1)
+
+	t1.SetStatus(state.DoingStatus)
+
+	// We have a single task in Doing, now we manipulate the status
+	// of the change to ensure we are receiving correct events
+	chg.SetStatus(state.WaitStatus)
+
+	// Change to a new status
+	chg.SetStatus(state.ErrorStatus)
+
+	// Now return the status back to Default, which should result
+	// in the change reporting Doing
+	chg.SetStatus(state.DefaultStatus)
+	st.RemoveChangeStatusChangedHandler(oId)
+
+	c.Check(observedChanges, DeepEquals, []changeAndStatus{
+		{
+			chg: chg,
+			old: state.DefaultStatus,
+			new: state.DoingStatus,
+		},
+		{
+			chg: chg,
+			old: state.DoingStatus,
+			new: state.WaitStatus,
+		},
+		{
+			chg: chg,
+			old: state.WaitStatus,
+			new: state.ErrorStatus,
+		},
+		{
+			chg: chg,
+			old: state.ErrorStatus,
+			new: state.DoingStatus,
+		},
+	})
 }

--- a/internals/overlord/state/warning.go
+++ b/internals/overlord/state/warning.go
@@ -1,21 +1,16 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2018 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package state
 

--- a/internals/overlord/state/warning_test.go
+++ b/internals/overlord/state/warning_test.go
@@ -1,21 +1,16 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2018 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package state_test
 
@@ -99,7 +94,7 @@ func (stateSuite) TestUnmarshalErrors(c *check.C) {
 	}
 
 	for _, t := range []T1{
-		// sanity check
+		// validity check
 		{`{"message": "x", "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1h"}`, nil},
 		// remove one field at a time:
 		{`{                "first-added": "2006-01-02T15:04:05Z", "expire-after": "1h", "repeat-after": "1h"}`, state.ErrNoWarningMessage},


### PR DESCRIPTION
There are several major changes to the state package:

* Add WaitStatus support that allows a task to wait until further action to continue its execution. The WaitStatus is treated mostly as DoneStatus, except it is not ready status.
* Add Change.AbortUnreadyLanes.
* Add Change.CheckTaskDependencies to check if tasks have circular dependencies.
* Add task and change callbacks invoked on a status change.
* Update clients of the State.Get to use a new NoStateError to check if a desired key is present.
* Take StartOfOperationTime as a Prune parameter.