### PR TITLE
feat(daemon): support additional admin UIDs via PEBBLE_ADMINS

### DIFF
--- a/internals/cli/cli_test.go
+++ b/internals/cli/cli_test.go
@@ -189,15 +189,16 @@ func (s *PebbleSuite) TestGetAdditionalAdminUIDs(c *C) {
 
 	os.Setenv("PEBBLE_ADMINS", "123, 345")
 	_, err = cli.GetAdditionalAdminUIDs()
-	c.Assert(err, ErrorMatches, `cannot parse value " 345" in \$PEBBLE_ADMINS: strconv.ParseUint: parsing " 345": invalid syntax`)
+	c.Assert(err, IsNil)
+	c.Assert(uids, DeepEquals, []sys.UserID{123, 345})
 
 	os.Setenv("PEBBLE_ADMINS", "4294967296")
 	_, err = cli.GetAdditionalAdminUIDs()
-	c.Assert(err, ErrorMatches, `cannot parse value "4294967296" in \$PEBBLE_ADMINS: strconv.ParseUint: parsing "4294967296": value out of range`)
+	c.Assert(err, ErrorMatches, `cannot parse PEBBLE_ADMINS: "4294967296" is not a valid user ID`)
 
 	os.Setenv("PEBBLE_ADMINS", "-1")
 	_, err = cli.GetAdditionalAdminUIDs()
-	c.Assert(err, ErrorMatches, `cannot parse value "-1" in \$PEBBLE_ADMINS: strconv.ParseUint: parsing "-1": invalid syntax`)
+	c.Assert(err, ErrorMatches, `cannot parse PEBBLE_ADMINS: "-1" is not a valid user ID`)
 }
 
 func (s *PebbleSuite) readCLIState(c *C) map[string]any {

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -20,11 +20,11 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/canonical/go-flags"
+	"github.com/canonical/x-go/strutil"
 
 	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/cmd"
@@ -288,16 +288,12 @@ func convertArgs(args [][]string) (map[string][]string, error) {
 // getAdditionalAdminUIDs parses additional admin user ids passed in via the PEBBLE_ADMINS
 // environment variable.
 func getAdditionalAdminUIDs() ([]sys.UserID, error) {
-	envValue := os.Getenv("PEBBLE_ADMINS")
-	if envValue == "" {
-		return nil, nil
-	}
-	uidStrings := strings.Split(envValue, ",")
+	uidStrings := strutil.CommaSeparatedList(os.Getenv("PEBBLE_ADMINS"))
 	uids := make([]sys.UserID, 0, len(uidStrings))
 	for _, uidStr := range uidStrings {
 		uid64, err := strconv.ParseUint(uidStr, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse value %q in $PEBBLE_ADMINS: %w", uidStr, err)
+			return nil, fmt.Errorf("cannot parse PEBBLE_ADMINS: %q is not a valid user ID", uidStr)
 		}
 		uids = append(uids, sys.UserID(uid64))
 	}

--- a/internals/cli/export_test.go
+++ b/internals/cli/export_test.go
@@ -42,7 +42,8 @@ var (
 	WriteWarningTimestamp = writeWarningTimestamp
 	MaybePresentWarnings  = maybePresentWarnings
 
-	GetEnvPaths = getEnvPaths
+	GetEnvPaths            = getEnvPaths
+	GetAdditionalAdminUIDs = getAdditionalAdminUIDs
 )
 
 func FakeIsStdoutTTY(t bool) (restore func()) {

--- a/internals/daemon/api_notices_test.go
+++ b/internals/daemon/api_notices_test.go
@@ -293,9 +293,7 @@ func (s *apiSuite) TestNoticesUserIDAdminDefault(c *C) {
 }
 
 func (s *apiSuite) TestNoticesUserIDAdminFilter(c *C) {
-	s.daemon(c, func(o *Options) {
-		o.AdditionalAdminUIDs = []sys.UserID{0xbadd00d}
-	})
+	s.daemon(c)
 	restore := fakeSysGetuid(0)
 	defer restore()
 

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -52,11 +52,15 @@ func (s *apiSuite) muxVars(*http.Request) map[string]string {
 	return s.vars
 }
 
-func (s *apiSuite) daemon(c *check.C) *Daemon {
+func (s *apiSuite) daemon(c *check.C, opts ...daemonOpt) *Daemon {
 	if s.d != nil {
 		panic("called daemon() twice")
 	}
-	d, err := New(&Options{Dir: s.pebbleDir})
+	o := &Options{Dir: s.pebbleDir}
+	for _, opt := range opts {
+		opt(o)
+	}
+	d, err := New(o)
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
 

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -22,6 +22,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/canonical/pebble/internals/osutil/sys"
 	"github.com/canonical/pebble/internals/overlord/restart"
 )
 
@@ -52,15 +53,14 @@ func (s *apiSuite) muxVars(*http.Request) map[string]string {
 	return s.vars
 }
 
-func (s *apiSuite) daemon(c *check.C, opts ...daemonOpt) *Daemon {
+func (s *apiSuite) daemon(c *check.C) *Daemon {
 	if s.d != nil {
 		panic("called daemon() twice")
 	}
-	o := &Options{Dir: s.pebbleDir}
-	for _, opt := range opts {
-		opt(o)
-	}
-	d, err := New(o)
+	d, err := New(&Options{
+		Dir:                 s.pebbleDir,
+		AdditionalAdminUIDs: []sys.UserID{0xbadd00d},
+	})
 	c.Assert(err, check.IsNil)
 	d.addRoutes()
 

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -872,7 +872,10 @@ func New(opts *Options) (*Daemon, error) {
 	}
 
 	// Superuser and process owner can do anything.
-	d.admins = []sys.UserID{0, sysGetuid()}
+	d.admins = []sys.UserID{0}
+	if uid := sysGetuid(); uid != 0 {
+		d.admins = append(d.admins, uid)
+	}
 	d.admins = append(d.admins, opts.AdditionalAdminUIDs...)
 
 	ovldOptions := overlord.Options{


### PR DESCRIPTION
This PR proposes a means for the Pebble daemon to authenticate additional local unix users as admins through a new environment variable, `$PEBBLE_ADMINS`. This environment variable is a comma `,` delimited unordered list of UIDs that represent admins in addition to the defaults (e.g. root and the user running the daemon).

The use case for this is in Juju, where we have a charm container (the pebble client) and the workload container (the pebble daemon), both running as different non-root users. The charm container needs to be able to connect to and control the pebble process in the neighbouring container.

It is expected that the following should not work:
```
$ sudo pebble run &
$ pebble exec echo hello
error: access denied (try with sudo)
```

But with this PR, this is expected that the following should work:
```
$ sudo PEBBLE_ADMINS=1000 pebble run &
$ pebble exec echo hello
hello
```

[JU091](https://docs.google.com/document/d/1FKWkUvV4OPSh8BFzjmg0Jt0rVRHBTtZxzubcL5ls6H0/edit)