### PR TITLE
fix(enter): disable logs for interactive exec runs

### DIFF
--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -145,9 +145,20 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	// applications. Ignore --verbose for those cases, to avoid
 	// log output being sent to the interactive terminal.
 	if execCmd, ok := commander.(*cmdExec); ok {
+		// The following logic is duplicated from cmdExec.Execute()
+		// in internals/cli/cmd_exec.go.
 		stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
 		stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
-		terminal := execCmd.useTerminal(stdoutIsTerminal)
+		var terminal bool
+		if execCmd.Terminal {
+			terminal = true
+		} else if execCmd.NoTerminal {
+			terminal = false
+		} else {
+			terminal = stdoutIsTerminal
+		}
+		// Terminal is made RAW in exec if both terminal and
+		// stdIsTerminal are true.
 		if terminal && stdinIsTerminal {
 			cmd.Verbose = false
 			runCmd.Verbose = false

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -147,7 +147,8 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	if execCmd, ok := commander.(*cmdExec); ok {
 		stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
 		stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
-		if stdinIsTerminal && execCmd.useTerminal(stdoutIsTerminal) {
+		terminal := execCmd.useTerminal(stdoutIsTerminal)
+		if terminal && stdinIsTerminal {
 			cmd.Verbose = false
 			runCmd.Verbose = false
 		}

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -139,6 +139,15 @@ func (cmd *cmdEnter) Execute(args []string) error {
 		panic("internal error: expected subcommand (parser.Active == nil)")
 	}
 
+	// The exec command makes terminal raw to run interactive
+	// applications. Ignore --verbose for those cases.
+	if execCmd, ok := commander.(*cmdExec); ok {
+		if execCmd.willMakeTerminalRaw() {
+			cmd.Verbose = false
+			runCmd.Verbose = false
+		}
+	}
+
 	enterFlags, supported := commandEnterFlags(commander)
 
 	if !supported {

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -223,6 +223,22 @@ func (cmd *cmdExec) Execute(args []string) error {
 	}
 }
 
+// willMakeTerminalRaw returns true if the exec command will make the
+// terminal raw during execution.
+func (cmd *cmdExec) willMakeTerminalRaw() bool {
+	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
+	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
+	var terminal bool
+	if cmd.Terminal {
+		terminal = true
+	} else if cmd.NoTerminal {
+		terminal = false
+	} else {
+		terminal = stdoutIsTerminal
+	}
+	return terminal && stdinIsTerminal
+}
+
 func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan struct{}, sighup chan<- struct{}) {
 	ch := make(chan os.Signal, 10)
 	signal.Notify(ch,

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -117,7 +117,14 @@ func (cmd *cmdExec) Execute(args []string) error {
 
 	// Specify Terminal=true if -t is given, or if stdout is a TTY.
 	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
-	terminal := cmd.useTerminal(stdoutIsTerminal)
+	var terminal bool
+	if cmd.Terminal {
+		terminal = true
+	} else if cmd.NoTerminal {
+		terminal = false
+	} else {
+		terminal = stdoutIsTerminal
+	}
 
 	// Specify Interactive=true if -i is given, or if stdin and stdout are TTYs.
 	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
@@ -213,17 +220,6 @@ func (cmd *cmdExec) Execute(args []string) error {
 		fmt.Fprintf(os.Stderr, "SIGHUP received, exiting\r\n")
 		// Exit with exit code 0 in this case (same behaviour as ssh).
 		return nil
-	}
-}
-
-// useTerminal returns true if -t is given, or if stdoutIsTerminal is true.
-func (cmd *cmdExec) useTerminal(stdoutIsTerminal bool) bool {
-	if cmd.Terminal {
-		return true
-	} else if cmd.NoTerminal {
-		return false
-	} else {
-		return stdoutIsTerminal
 	}
 }
 

--- a/internals/cli/cmd_exec.go
+++ b/internals/cli/cmd_exec.go
@@ -117,14 +117,7 @@ func (cmd *cmdExec) Execute(args []string) error {
 
 	// Specify Terminal=true if -t is given, or if stdout is a TTY.
 	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
-	var terminal bool
-	if cmd.Terminal {
-		terminal = true
-	} else if cmd.NoTerminal {
-		terminal = false
-	} else {
-		terminal = stdoutIsTerminal
-	}
+	terminal := cmd.useTerminal(stdoutIsTerminal)
 
 	// Specify Interactive=true if -i is given, or if stdin and stdout are TTYs.
 	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
@@ -223,20 +216,15 @@ func (cmd *cmdExec) Execute(args []string) error {
 	}
 }
 
-// willMakeTerminalRaw returns true if the exec command will make the
-// terminal raw during execution.
-func (cmd *cmdExec) willMakeTerminalRaw() bool {
-	stdinIsTerminal := ptyutil.IsTerminal(unix.Stdin)
-	stdoutIsTerminal := ptyutil.IsTerminal(unix.Stdout)
-	var terminal bool
+// useTerminal returns true if -t is given, or if stdoutIsTerminal is true.
+func (cmd *cmdExec) useTerminal(stdoutIsTerminal bool) bool {
 	if cmd.Terminal {
-		terminal = true
+		return true
 	} else if cmd.NoTerminal {
-		terminal = false
+		return false
 	} else {
-		terminal = stdoutIsTerminal
+		return stdoutIsTerminal
 	}
-	return terminal && stdinIsTerminal
 }
 
 func execControlHandler(process *client.ExecProcess, terminal bool, stop <-chan struct{}, sighup chan<- struct{}) {


### PR DESCRIPTION
Fixes #339 

The PR disables logs for `pebble enter exec` only if the `exec` command is connected to a TTY and it makes the TTY RAW, even if the `--verbose` flag is passed. 

Interactive applications, like Vim, can be run as an exec command:

    pebble enter --verbose exec -it vim

Since `enter` runs the pebble daemon and executes the `exec` command afterwards, the same TTY that will be made raw by exec to run interactive applications like Vim is also used for logging and service outputs. Thus, the logs coming from pebble find the TTY RAW and weird indentation is introduced. See issue #339.

The issue, however, is not limited to only indentation. For example, if a text editor was being run with `exec -it`, like Vim, the incoming logs would go to the text editor and may change the content of the editor’s buffer.

This PR disables logs completely for `pebble enter --verbose exec -it` (if a terminal is connected) even if the `--verbose` flag is passed. Since logs are currently disabled for `pebble enter exec` if `--verbose` is not passed and `-i`, `-t` are assumed if stdin and stdout are TTYs, the PR only ignores the `--verbose` flag in cases where exec is connected to a TTY and it will make the TTY raw.

See also the spec, [RK034](https://docs.google.com/document/d/1JrFkUh3KeuIGOMk0wRDx40f4WQV3ARY3BEZ4oscOvl0/edit).