### PR TITLE
fix(servstate): reduce scope of holding ServiceManager.planLock

### DIFF
--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -228,14 +228,11 @@ func (c *Command) Daemon() *Daemon {
 }
 
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	st := c.d.state
-	st.Lock()
-	user, err := userFromRequest(st, r)
+	user, err := userFromRequest(nil, r) // don't pass state as this does nothing right now
 	if err != nil {
 		statusForbidden("forbidden").ServeHTTP(w, r)
 		return
 	}
-	st.Unlock()
 
 	// check if we are in degradedMode
 	if c.d.degradedErr != nil && r.Method != "GET" {
@@ -273,6 +270,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if rsp, ok := rsp.(*resp); ok {
+		st := c.d.state
 		st.Lock()
 		_, rst := restart.Pending(st)
 		st.Unlock()

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -114,12 +114,11 @@ func (m *ServiceManager) doStart(task *state.Task, tomb *tomb.Tomb) error {
 		return err
 	}
 
-	releasePlan, err := m.acquirePlan()
+	mgrPlan, err := m.Plan()
 	if err != nil {
-		return fmt.Errorf("cannot acquire plan lock: %w", err)
+		return fmt.Errorf("cannot fetch plan: %w", err)
 	}
-	config, ok := m.plan.Services[request.Name]
-	releasePlan()
+	config, ok := mgrPlan.Services[request.Name]
 	if !ok {
 		return fmt.Errorf("cannot find service %q in plan", request.Name)
 	}


### PR DESCRIPTION
In most cases we're just reading from m.plan fields (Services,
DefaultServiceNames, and so on), so we can use m.Plan(), which holds
the plan lock only for the duration of fetch m.plan -- this is safe,
because we never mutate what's inside m.plan, we only replace it (in
updatePlan).

This also means that in functions like Services() we're only holding
either the plan lock or the services lock at once, not both -- avoiding
the 3-way deadlock described in #314.

For the cases we are updating the plan (AppendLayer, CombineLayer,
SetServiceArgs), we still need acquirePlan.

In ServiceManager.ServiceLogs, we don't need to acquire the plan lock
at all (m.plan isn't used).

Fixes #314.