### PR TITLE
daemon: make ucrednetGet() return *ucrednet

### DIFF
--- a/internals/daemon/api_notices.go
+++ b/internals/daemon/api_notices.go
@@ -137,11 +137,11 @@ func v1GetNotices(c *Command, r *http.Request, _ *UserState) Response {
 
 // Get the UID of the request. If the UID is not known, return an error.
 func uidFromRequest(r *http.Request) (uint32, error) {
-	_, uid, _, err := ucrednetGet(r.RemoteAddr)
+	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err != nil {
 		return 0, fmt.Errorf("could not parse request UID")
 	}
-	return uid, nil
+	return ucred.Uid, nil
 }
 
 // Construct the user IDs filter which will be passed to state.Notices.

--- a/internals/daemon/ucrednet.go
+++ b/internals/daemon/ucrednet.go
@@ -35,40 +35,42 @@ const (
 
 var raddrRegexp = regexp.MustCompile(`^pid=(\d+);uid=(\d+);socket=([^;]*);$`)
 
-func ucrednetGet(remoteAddr string) (pid int32, uid uint32, socket string, err error) {
+func ucrednetGet(remoteAddr string) (*ucrednet, error) {
 	// NOTE treat remoteAddr at one point included a user-controlled
 	// string. In case that happens again by accident, treat it as tainted,
 	// and be very suspicious of it.
-	pid = ucrednetNoProcess
-	uid = ucrednetNobody
+	u := &ucrednet{
+		Pid: ucrednetNoProcess,
+		Uid: ucrednetNobody,
+	}
 	subs := raddrRegexp.FindStringSubmatch(remoteAddr)
 	if subs != nil {
 		if v, err := strconv.ParseInt(subs[1], 10, 32); err == nil {
-			pid = int32(v)
+			u.Pid = int32(v)
 		}
 		if v, err := strconv.ParseUint(subs[2], 10, 32); err == nil {
-			uid = uint32(v)
+			u.Uid = uint32(v)
 		}
-		socket = subs[3]
+		u.Socket = subs[3]
 	}
-	if pid == ucrednetNoProcess || uid == ucrednetNobody {
-		err = errNoID
+	if u.Pid == ucrednetNoProcess || u.Uid == ucrednetNobody {
+		return nil, errNoID
 	}
 
-	return pid, uid, socket, err
+	return u, nil
 }
 
 type ucrednet struct {
-	pid    int32
-	uid    uint32
-	socket string
+	Pid    int32
+	Uid    uint32
+	Socket string
 }
 
 func (un *ucrednet) String() string {
 	if un == nil {
 		return "pid=;uid=;socket=;"
 	}
-	return fmt.Sprintf("pid=%d;uid=%d;socket=%s;", un.pid, un.uid, un.socket)
+	return fmt.Sprintf("pid=%d;uid=%d;socket=%s;", un.Pid, un.Uid, un.Socket)
 }
 
 type ucrednetAddr struct {
@@ -127,9 +129,9 @@ func (wl *ucrednetListener) Accept() (net.Conn, error) {
 			return nil, ucredErr
 		}
 		unet = &ucrednet{
-			pid:    ucred.Pid,
-			uid:    ucred.Uid,
-			socket: ucon.LocalAddr().String(),
+			Pid:    ucred.Pid,
+			Uid:    ucred.Uid,
+			Socket: ucon.LocalAddr().String(),
 		}
 	}
 


### PR DESCRIPTION
This ports https://github.com/snapcore/snapd/pull/10126 from snapd, so that `ucrednetGet()` has the same return type.

This change is in preparation for porting the `accessChecker` API from snapd (https://github.com/snapcore/snapd/pull/10127): #358