### PR TITLE
fix(daemon): Export error responders from daemon.response

### DIFF
--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -36,7 +36,7 @@ func v1GetChecks(c *Command, r *http.Request, _ *UserState) Response {
 	switch level {
 	case plan.UnsetLevel, plan.AliveLevel, plan.ReadyLevel:
 	default:
-		return statusBadRequest(`level must be "alive" or "ready"`)
+		return BadRequest(`level must be "alive" or "ready"`)
 	}
 
 	names := strutil.MultiCommaSeparatedList(query["names"])
@@ -44,7 +44,7 @@ func v1GetChecks(c *Command, r *http.Request, _ *UserState) Response {
 	checkMgr := c.d.overlord.CheckManager()
 	checks, err := checkMgr.Checks()
 	if err != nil {
-		return statusInternalError("%v", err)
+		return InternalError("%v", err)
 	}
 
 	infos := []checkInfo{} // if no checks, return [] instead of null

--- a/internals/daemon/api_health.go
+++ b/internals/daemon/api_health.go
@@ -34,7 +34,7 @@ func v1Health(c *Command, r *http.Request, _ *UserState) Response {
 	switch level {
 	case plan.UnsetLevel, plan.AliveLevel, plan.ReadyLevel:
 	default:
-		return statusBadRequest(`level must be "alive" or "ready"`)
+		return BadRequest(`level must be "alive" or "ready"`)
 	}
 
 	names := strutil.MultiCommaSeparatedList(query["names"])
@@ -42,7 +42,7 @@ func v1Health(c *Command, r *http.Request, _ *UserState) Response {
 	checks, err := getChecks(c.d.overlord)
 	if err != nil {
 		logger.Noticef("Cannot fetch checks: %v", err.Error())
-		return statusInternalError("internal server error")
+		return InternalError("internal server error")
 	}
 
 	healthy := true

--- a/internals/daemon/api_logs.go
+++ b/internals/daemon/api_logs.go
@@ -61,7 +61,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	followStr := query.Get("follow")
 	if followStr != "" && followStr != "true" && followStr != "false" {
-		response := statusBadRequest(`follow parameter must be "true" or "false"`)
+		response := BadRequest(`follow parameter must be "true" or "false"`)
 		response.ServeHTTP(w, req)
 		return
 	}
@@ -72,7 +72,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if nStr != "" {
 		n, err := strconv.Atoi(nStr)
 		if err != nil || n < -1 {
-			response := statusBadRequest("n must be -1, 0, or a positive integer")
+			response := BadRequest("n must be -1, 0, or a positive integer")
 			response.ServeHTTP(w, req)
 			return
 		}
@@ -87,7 +87,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if len(services) == 0 {
 		infos, err := r.svcMgr.Services(nil)
 		if err != nil {
-			response := statusInternalError("cannot fetch services: %v", err)
+			response := InternalError("cannot fetch services: %v", err)
 			response.ServeHTTP(w, req)
 			return
 		}
@@ -99,7 +99,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	itsByName, err := r.svcMgr.ServiceLogs(services, numLogs)
 	if err != nil {
-		response := statusInternalError("cannot fetch log iterators: %v", err)
+		response := InternalError("cannot fetch log iterators: %v", err)
 		response.ServeHTTP(w, req)
 		return
 	}

--- a/internals/daemon/api_notices.go
+++ b/internals/daemon/api_notices.go
@@ -47,7 +47,7 @@ func v1GetNotices(c *Command, r *http.Request, _ *UserState) Response {
 
 	requestUID, err := uidFromRequest(r)
 	if err != nil {
-		return statusForbidden("cannot determine UID of request, so cannot retrieve notices")
+		return Forbidden("cannot determine UID of request, so cannot retrieve notices")
 	}
 	daemonUID := uint32(sysGetuid())
 
@@ -56,23 +56,23 @@ func v1GetNotices(c *Command, r *http.Request, _ *UserState) Response {
 
 	if len(query["user-id"]) > 0 {
 		if !isAdmin(requestUID, daemonUID) {
-			return statusForbidden(`only admins may use the "user-id" filter`)
+			return Forbidden(`only admins may use the "user-id" filter`)
 		}
 		userID, err = sanitizeUserIDFilter(query["user-id"])
 		if err != nil {
-			return statusBadRequest(`invalid "user-id" filter: %v`, err)
+			return BadRequest(`invalid "user-id" filter: %v`, err)
 		}
 	}
 
 	if len(query["select"]) > 0 {
 		if !isAdmin(requestUID, daemonUID) {
-			return statusForbidden(`only admins may use the "select" filter`)
+			return Forbidden(`only admins may use the "select" filter`)
 		}
 		if len(query["user-id"]) > 0 {
-			return statusBadRequest(`cannot use both "select" and "user-id" parameters`)
+			return BadRequest(`cannot use both "select" and "user-id" parameters`)
 		}
 		if query.Get("select") != "all" {
-			return statusBadRequest(`invalid "select" filter: must be "all"`)
+			return BadRequest(`invalid "select" filter: must be "all"`)
 		}
 		// Clear the userID filter so all notices will be returned.
 		userID = nil
@@ -89,7 +89,7 @@ func v1GetNotices(c *Command, r *http.Request, _ *UserState) Response {
 
 	after, err := parseOptionalTime(query.Get("after"))
 	if err != nil {
-		return statusBadRequest(`invalid "after" timestamp: %v`, err)
+		return BadRequest(`invalid "after" timestamp: %v`, err)
 	}
 
 	filter := &state.NoticeFilter{
@@ -101,7 +101,7 @@ func v1GetNotices(c *Command, r *http.Request, _ *UserState) Response {
 
 	timeout, err := parseOptionalDuration(query.Get("timeout"))
 	if err != nil {
-		return statusBadRequest("invalid timeout: %v", err)
+		return BadRequest("invalid timeout: %v", err)
 	}
 
 	st := c.d.overlord.State()
@@ -117,12 +117,12 @@ func v1GetNotices(c *Command, r *http.Request, _ *UserState) Response {
 
 		notices, err = st.WaitNotices(ctx, filter)
 		if errors.Is(err, context.Canceled) {
-			return statusBadRequest("request canceled")
+			return BadRequest("request canceled")
 		}
 		// DeadlineExceeded will occur if timeout elapses; in that case return
 		// an empty list of notices, not an error.
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-			return statusInternalError("cannot wait for notices: %s", err)
+			return InternalError("cannot wait for notices: %s", err)
 		}
 	} else {
 		// No timeout given, fetch currently-available notices
@@ -188,7 +188,7 @@ func isAdmin(requestUID, daemonUID uint32) bool {
 func v1PostNotices(c *Command, r *http.Request, _ *UserState) Response {
 	requestUID, err := uidFromRequest(r)
 	if err != nil {
-		return statusForbidden("cannot determine UID of request, so cannot create notice")
+		return Forbidden("cannot determine UID of request, so cannot create notice")
 	}
 
 	var payload struct {
@@ -200,35 +200,35 @@ func v1PostNotices(c *Command, r *http.Request, _ *UserState) Response {
 	}
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&payload); err != nil {
-		return statusBadRequest("cannot decode request body: %v", err)
+		return BadRequest("cannot decode request body: %v", err)
 	}
 
 	if payload.Action != "add" {
-		return statusBadRequest("invalid action %q", payload.Action)
+		return BadRequest("invalid action %q", payload.Action)
 	}
 	if payload.Type != "custom" {
-		return statusBadRequest(`invalid type %q (can only add "custom" notices)`, payload.Type)
+		return BadRequest(`invalid type %q (can only add "custom" notices)`, payload.Type)
 	}
 	if !customKeyRegexp.MatchString(payload.Key) {
-		return statusBadRequest(`invalid key %q (must be in "domain.com/key" format)`, payload.Key)
+		return BadRequest(`invalid key %q (must be in "domain.com/key" format)`, payload.Key)
 	}
 	if len(payload.Key) > maxNoticeKeyLength {
-		return statusBadRequest("key must be %d bytes or less", maxNoticeKeyLength)
+		return BadRequest("key must be %d bytes or less", maxNoticeKeyLength)
 	}
 
 	repeatAfter, err := parseOptionalDuration(payload.RepeatAfter)
 	if err != nil {
-		return statusBadRequest("invalid repeat-after: %v", err)
+		return BadRequest("invalid repeat-after: %v", err)
 	}
 
 	if len(payload.DataJSON) > maxNoticeDataSize {
-		return statusBadRequest("total size of data must be %d bytes or less", maxNoticeDataSize)
+		return BadRequest("total size of data must be %d bytes or less", maxNoticeDataSize)
 	}
 	var data map[string]string
 	if len(payload.DataJSON) > 0 {
 		err = json.Unmarshal(payload.DataJSON, &data)
 		if err != nil {
-			return statusBadRequest("cannot decode notice data: %v", err)
+			return BadRequest("cannot decode notice data: %v", err)
 		}
 	}
 
@@ -241,7 +241,7 @@ func v1PostNotices(c *Command, r *http.Request, _ *UserState) Response {
 		RepeatAfter: repeatAfter,
 	})
 	if err != nil {
-		return statusInternalError("%v", err)
+		return InternalError("%v", err)
 	}
 
 	return SyncResponse(addedNotice{ID: noticeId})
@@ -250,7 +250,7 @@ func v1PostNotices(c *Command, r *http.Request, _ *UserState) Response {
 func v1GetNotice(c *Command, r *http.Request, _ *UserState) Response {
 	requestUID, err := uidFromRequest(r)
 	if err != nil {
-		return statusForbidden("cannot determine UID of request, so cannot retrieve notice")
+		return Forbidden("cannot determine UID of request, so cannot retrieve notice")
 	}
 	daemonUID := uint32(sysGetuid())
 	noticeID := muxVars(r)["id"]
@@ -259,10 +259,10 @@ func v1GetNotice(c *Command, r *http.Request, _ *UserState) Response {
 	defer st.Unlock()
 	notice := st.Notice(noticeID)
 	if notice == nil {
-		return statusNotFound("cannot find notice with ID %q", noticeID)
+		return NotFound("cannot find notice with ID %q", noticeID)
 	}
 	if !noticeViewableByUser(notice, requestUID, daemonUID) {
-		return statusForbidden("not allowed to access notice with id %q", noticeID)
+		return Forbidden("not allowed to access notice with id %q", noticeID)
 	}
 	return SyncResponse(notice)
 }

--- a/internals/daemon/api_plan.go
+++ b/internals/daemon/api_plan.go
@@ -27,17 +27,17 @@ import (
 func v1GetPlan(c *Command, r *http.Request, _ *UserState) Response {
 	format := r.URL.Query().Get("format")
 	if format != "yaml" {
-		return statusBadRequest("invalid format %q", format)
+		return BadRequest("invalid format %q", format)
 	}
 
 	servmgr := overlordServiceManager(c.d.overlord)
 	plan, err := servmgr.Plan()
 	if err != nil {
-		return statusInternalError("%v", err)
+		return InternalError("%v", err)
 	}
 	planYAML, err := yaml.Marshal(plan)
 	if err != nil {
-		return statusInternalError("cannot serialize plan: %v", err)
+		return InternalError("cannot serialize plan: %v", err)
 	}
 	return SyncResponse(string(planYAML))
 }
@@ -52,21 +52,21 @@ func v1PostLayers(c *Command, r *http.Request, _ *UserState) Response {
 	}
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&payload); err != nil {
-		return statusBadRequest("cannot decode request body: %v", err)
+		return BadRequest("cannot decode request body: %v", err)
 	}
 
 	if payload.Action != "add" {
-		return statusBadRequest("invalid action %q", payload.Action)
+		return BadRequest("invalid action %q", payload.Action)
 	}
 	if payload.Label == "" {
-		return statusBadRequest("label must be set")
+		return BadRequest("label must be set")
 	}
 	if payload.Format != "yaml" {
-		return statusBadRequest("invalid format %q", payload.Format)
+		return BadRequest("invalid format %q", payload.Format)
 	}
 	layer, err := plan.ParseLayer(0, payload.Label, []byte(payload.Layer))
 	if err != nil {
-		return statusBadRequest("cannot parse layer YAML: %v", err)
+		return BadRequest("cannot parse layer YAML: %v", err)
 	}
 
 	servmgr := overlordServiceManager(c.d.overlord)
@@ -77,12 +77,12 @@ func v1PostLayers(c *Command, r *http.Request, _ *UserState) Response {
 	}
 	if err != nil {
 		if _, ok := err.(*servstate.LabelExists); ok {
-			return statusBadRequest("%v", err)
+			return BadRequest("%v", err)
 		}
 		if _, ok := err.(*plan.FormatError); ok {
-			return statusBadRequest("%v", err)
+			return BadRequest("%v", err)
 		}
-		return statusInternalError("%v", err)
+		return InternalError("%v", err)
 	}
 	return SyncResponse(true)
 }

--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -41,7 +41,7 @@ func v1GetServices(c *Command, r *http.Request, _ *UserState) Response {
 	servmgr := overlordServiceManager(c.d.overlord)
 	services, err := servmgr.Services(names)
 	if err != nil {
-		return statusInternalError("%v", err)
+		return InternalError("%v", err)
 	}
 
 	infos := make([]serviceInfo, 0, len(services))
@@ -67,7 +67,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&payload); err != nil {
-		return statusBadRequest("cannot decode data from request body: %v", err)
+		return BadRequest("cannot decode data from request body: %v", err)
 	}
 
 	var err error
@@ -75,15 +75,15 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 	switch payload.Action {
 	case "replan":
 		if len(payload.Services) != 0 {
-			return statusBadRequest("%s accepts no service names", payload.Action)
+			return BadRequest("%s accepts no service names", payload.Action)
 		}
 	case "autostart":
 		if len(payload.Services) != 0 {
-			return statusBadRequest("%s accepts no service names", payload.Action)
+			return BadRequest("%s accepts no service names", payload.Action)
 		}
 		services, err := servmgr.DefaultServiceNames()
 		if err != nil {
-			return statusInternalError("%v", err)
+			return InternalError("%v", err)
 		}
 		if len(services) == 0 {
 			return SyncResponse(&resp{
@@ -95,7 +95,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 		payload.Services = services
 	default:
 		if len(payload.Services) == 0 {
-			return statusBadRequest("no services to %s provided", payload.Action)
+			return BadRequest("no services to %s provided", payload.Action)
 		}
 	}
 
@@ -177,10 +177,10 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 		sort.Strings(services)
 		payload.Services = services
 	default:
-		return statusBadRequest("action %q is unsupported", payload.Action)
+		return BadRequest("action %q is unsupported", payload.Action)
 	}
 	if err != nil {
-		return statusBadRequest("cannot %s services: %v", payload.Action, err)
+		return BadRequest("cannot %s services: %v", payload.Action, err)
 	}
 
 	// Use the original requested service name for the summary, not the
@@ -213,11 +213,11 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 }
 
 func v1GetService(c *Command, r *http.Request, _ *UserState) Response {
-	return statusBadRequest("not implemented")
+	return BadRequest("not implemented")
 }
 
 func v1PostService(c *Command, r *http.Request, _ *UserState) Response {
-	return statusBadRequest("not implemented")
+	return BadRequest("not implemented")
 }
 
 // intersectOrdered returns the intersection of left and right where

--- a/internals/daemon/api_signals.go
+++ b/internals/daemon/api_signals.go
@@ -28,16 +28,16 @@ func v1PostSignals(c *Command, req *http.Request, _ *UserState) Response {
 	var payload signalsPayload
 	decoder := json.NewDecoder(req.Body)
 	if err := decoder.Decode(&payload); err != nil {
-		return statusBadRequest("cannot decode request body: %v", err)
+		return BadRequest("cannot decode request body: %v", err)
 	}
 	if len(payload.Services) == 0 {
-		return statusBadRequest("must specify one or more services")
+		return BadRequest("must specify one or more services")
 	}
 
 	serviceMgr := c.d.overlord.ServiceManager()
 	err := serviceMgr.SendSignal(payload.Services, payload.Signal)
 	if err != nil {
-		return statusInternalError("%s", err)
+		return InternalError("%s", err)
 	}
 	return SyncResponse(true)
 }

--- a/internals/daemon/api_tasks.go
+++ b/internals/daemon/api_tasks.go
@@ -38,7 +38,7 @@ func v1GetTaskWebsocket(c *Command, req *http.Request, _ *UserState) Response {
 		// connecting to a websocket they may only see the error
 		// "bad handshake".
 		logger.Noticef("Websocket: cannot find task with id %q", taskID)
-		return statusNotFound("cannot find task with id %q", taskID)
+		return NotFound("cannot find task with id %q", taskID)
 	}
 
 	var connect websocketConnectFunc
@@ -48,7 +48,7 @@ func v1GetTaskWebsocket(c *Command, req *http.Request, _ *UserState) Response {
 		connect = commandMgr.Connect
 	default:
 		logger.Noticef("Websocket %s: %q tasks do not have websockets", task.ID(), task.Kind())
-		return statusBadRequest("%q tasks do not have websockets", task.Kind())
+		return BadRequest("%q tasks do not have websockets", task.Kind())
 	}
 
 	return websocketResponse{
@@ -70,13 +70,13 @@ func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := wr.connect(r, w, wr.task, wr.websocketID)
 	if errors.Is(err, os.ErrNotExist) {
 		logger.Noticef("Websocket %s: cannot find websocket with id %q", wr.task.ID(), wr.websocketID)
-		rsp := statusNotFound("cannot find websocket with id %q", wr.websocketID)
+		rsp := NotFound("cannot find websocket with id %q", wr.websocketID)
 		rsp.ServeHTTP(w, r)
 		return
 	}
 	if err != nil {
 		logger.Noticef("Websocket %s: cannot connect to websocket %q: %v", wr.task.ID(), wr.websocketID, err)
-		rsp := statusInternalError("cannot connect to websocket %q: %v", wr.websocketID, err)
+		rsp := InternalError("cannot connect to websocket %q: %v", wr.websocketID, err)
 		rsp.ServeHTTP(w, r)
 		return
 	}

--- a/internals/daemon/api_warnings.go
+++ b/internals/daemon/api_warnings.go
@@ -30,10 +30,10 @@ func v1AckWarnings(c *Command, r *http.Request, _ *UserState) Response {
 	}
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&op); err != nil {
-		return statusBadRequest("cannot decode request body into warnings operation: %v", err)
+		return BadRequest("cannot decode request body into warnings operation: %v", err)
 	}
 	if op.Action != "okay" {
-		return statusBadRequest("unknown warning action %q", op.Action)
+		return BadRequest("unknown warning action %q", op.Action)
 	}
 	st := c.d.overlord.State()
 	st.Lock()
@@ -53,7 +53,7 @@ func v1GetWarnings(c *Command, r *http.Request, _ *UserState) Response {
 	case "pending", "":
 		all = false
 	default:
-		return statusBadRequest("invalid select parameter: %q", sel)
+		return BadRequest("invalid select parameter: %q", sel)
 	}
 
 	st := c.d.overlord.State()

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -232,14 +232,14 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	st.Lock()
 	user, err := userFromRequest(st, r)
 	if err != nil {
-		statusForbidden("forbidden").ServeHTTP(w, r)
+		Forbidden("forbidden").ServeHTTP(w, r)
 		return
 	}
 	st.Unlock()
 
 	// check if we are in degradedMode
 	if c.d.degradedErr != nil && r.Method != "GET" {
-		statusInternalError(c.d.degradedErr.Error()).ServeHTTP(w, r)
+		InternalError(c.d.degradedErr.Error()).ServeHTTP(w, r)
 		return
 	}
 
@@ -247,15 +247,15 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case accessOK:
 		// nothing
 	case accessUnauthorized:
-		statusUnauthorized("access denied").ServeHTTP(w, r)
+		Unauthorized("access denied").ServeHTTP(w, r)
 		return
 	case accessForbidden:
-		statusForbidden("forbidden").ServeHTTP(w, r)
+		Forbidden("forbidden").ServeHTTP(w, r)
 		return
 	}
 
 	var rspf ResponseFunc
-	var rsp = statusMethodNotAllowed("method %q not allowed", r.Method)
+	var rsp = MethodNotAllowed("method %q not allowed", r.Method)
 
 	switch r.Method {
 	case "GET":
@@ -425,7 +425,7 @@ func (d *Daemon) addRoutes() {
 
 	// also maybe add a /favicon.ico handler...
 
-	d.router.NotFoundHandler = statusNotFound("invalid API endpoint requested")
+	d.router.NotFoundHandler = NotFound("invalid API endpoint requested")
 }
 
 type connTracker struct {

--- a/internals/daemon/response.go
+++ b/internals/daemon/response.go
@@ -135,7 +135,7 @@ type errorResult struct {
 
 func SyncResponse(result interface{}) Response {
 	if err, ok := result.(error); ok {
-		return statusInternalError("internal error: %v", err)
+		return InternalError("internal error: %v", err)
 	}
 
 	if rsp, ok := result.(Response); ok {
@@ -201,11 +201,11 @@ type errorResponder func(string, ...interface{}) Response
 
 // Standard error responses.
 var (
-	statusBadRequest       = makeErrorResponder(http.StatusBadRequest)
-	statusUnauthorized     = makeErrorResponder(http.StatusUnauthorized)
-	statusForbidden        = makeErrorResponder(http.StatusForbidden)
-	statusNotFound         = makeErrorResponder(http.StatusNotFound)
-	statusMethodNotAllowed = makeErrorResponder(http.StatusMethodNotAllowed)
-	statusInternalError    = makeErrorResponder(http.StatusInternalServerError)
-	statusGatewayTimeout   = makeErrorResponder(http.StatusGatewayTimeout)
+	BadRequest       = makeErrorResponder(http.StatusBadRequest)
+	Unauthorized     = makeErrorResponder(http.StatusUnauthorized)
+	Forbidden        = makeErrorResponder(http.StatusForbidden)
+	NotFound         = makeErrorResponder(http.StatusNotFound)
+	MethodNotAllowed = makeErrorResponder(http.StatusMethodNotAllowed)
+	InternalError    = makeErrorResponder(http.StatusInternalServerError)
+	GatewayTimeout   = makeErrorResponder(http.StatusGatewayTimeout)
 )


### PR DESCRIPTION
This brings the error response namings in line with snapd: [`daemon/errors.go` in snapd](https://github.com/snapcore/snapd/blob/489358223f0bd03da01e62a4062174eb7e9e0ffa/daemon/errors.go#L112). Split off from #358. While currently the error responses are used exclusively in the `daemon` package, once `AccessChecker` is available, it should be possible for other packages to create error responders to implement their `AccessChecker` variants.