### PR TITLE
fix: validate whole plan, rather than topmost two layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ cmd/VERSION
 .idea
 .vscode
 /pebble
+__debug_bin*
 
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ cmd/VERSION
 .idea
 .vscode
 /pebble
-__debug_bin*
 
 dist/

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -174,6 +174,10 @@ func (m *ServiceManager) updatePlanLayers(layers []*plan.Layer) error {
 		Checks:     combined.Checks,
 		LogTargets: combined.LogTargets,
 	}
+	err = p.Validate()
+	if err != nil {
+		return err
+	}
 	m.updatePlan(p)
 	return nil
 }

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -556,6 +556,11 @@ func (m *ServiceManager) SetServiceArgs(serviceArgs map[string][]string) error {
 		}
 	}
 
+	err = newLayer.Validate()
+	if err != nil {
+		return err
+	}
+
 	return m.appendLayer(newLayer)
 }
 

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -752,6 +752,18 @@ services:
         command: /bin/b
 `[1:])
 	s.planLayersHasLen(c, s.manager, 3)
+
+	// Make sure that layer validation is happening.
+	layer = parseLayer(c, 0, "label4", `
+checks:
+    bad-check:
+        override: replace
+        level: invalid
+        tcp:
+            port: 8080
+`)
+	err = s.manager.CombineLayer(layer)
+	c.Check(err, ErrorMatches, `(?s).*plan check.*must be "alive" or "ready".*`)
 }
 
 func (s *S) TestSetServiceArgs(c *C) {
@@ -1031,6 +1043,7 @@ checks:
     chk1:
          override: replace
          period: 100ms
+         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail
@@ -1126,6 +1139,7 @@ checks:
     chk1:
          override: replace
          period: 100ms
+         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail
@@ -1213,6 +1227,7 @@ checks:
     chk1:
          override: replace
          period: 100ms
+         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail
@@ -1297,6 +1312,7 @@ checks:
     chk1:
          override: replace
          period: 100ms
+         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -754,15 +754,14 @@ services:
 	s.planLayersHasLen(c, s.manager, 3)
 
 	// Make sure that layer validation is happening.
-	layer = parseLayer(c, 0, "label4", `
+	layer, err = plan.ParseLayer(0, "label4", []byte(`
 checks:
     bad-check:
         override: replace
         level: invalid
         tcp:
             port: 8080
-`)
-	err = s.manager.CombineLayer(layer)
+`))
 	c.Check(err, ErrorMatches, `(?s).*plan check.*must be "alive" or "ready".*`)
 }
 
@@ -1043,7 +1042,6 @@ checks:
     chk1:
          override: replace
          period: 100ms
-         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail
@@ -1139,7 +1137,6 @@ checks:
     chk1:
          override: replace
          period: 100ms
-         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail
@@ -1227,7 +1224,6 @@ checks:
     chk1:
          override: replace
          period: 100ms
-         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail
@@ -1312,7 +1308,6 @@ checks:
     chk1:
          override: replace
          period: 100ms
-         timeout: 90ms
          threshold: 1
          exec:
              command: will-fail

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -681,8 +681,8 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 // an error if there are validation errors.
 // See also Plan.Validate, which does additional checks based on the combined
 // layers.
-func (l *Layer) Validate() error {
-	for name, service := range l.Services {
+func (layer *Layer) Validate() error {
+	for name, service := range layer.Services {
 		_, _, err := service.ParseCommand()
 		if err != nil {
 			return &FormatError{
@@ -713,7 +713,7 @@ func (l *Layer) Validate() error {
 		}
 	}
 
-	for name, check := range l.Checks {
+	for name, check := range layer.Checks {
 		if check.Level != UnsetLevel && check.Level != AliveLevel && check.Level != ReadyLevel {
 			return &FormatError{
 				Message: fmt.Sprintf(`plan check %q level must be "alive" or "ready"`, name),
@@ -746,7 +746,7 @@ func (l *Layer) Validate() error {
 		}
 	}
 
-	for name, target := range l.LogTargets {
+	for name, target := range layer.LogTargets {
 		switch target.Type {
 		case LokiTarget, SyslogTarget:
 			// valid, continue

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -663,8 +663,13 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		}
 		if !check.Timeout.IsSet {
 			check.Timeout.Value = defaultCheckTimeout
-		} else if check.Timeout.Value > check.Period.Value {
+		}
+		if check.Timeout.Value > check.Period.Value {
 			// The effective timeout will be the period, so make that clear.
+			// `.IsSet` remains false so that the capped value does not appear
+			// in the combined plan output - and it's not *user* set - the
+			// effective default timeout is the minimum of (check.Period.Value,
+			// default timeout).
 			check.Timeout.Value = check.Period.Value
 		}
 		if check.Threshold == 0 {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -950,15 +950,6 @@ func order(services map[string]*Service, names []string, stop bool) ([]string, e
 	return order, nil
 }
 
-func (l *Layer) checkCycles() error {
-	var names []string
-	for name := range l.Services {
-		names = append(names, name)
-	}
-	_, err := order(l.Services, names, false)
-	return err
-}
-
 func (p *Plan) checkCycles() error {
 	var names []string
 	for name := range p.Services {
@@ -1051,10 +1042,6 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		target.Name = name
 	}
 
-	err = layer.checkCycles()
-	if err != nil {
-		return nil, err
-	}
 	return &layer, err
 }
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -677,7 +677,8 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 	return combined, nil
 }
 
-// Validate checks that the layer is valid.
+// Validate checks that the layer is valid. It returns nil if all the checks pass, or
+// an error if there are validation errors.
 // See also Plan.Validate, which does additional checks based on the combined
 // layers.
 func (l *Layer) Validate() error {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -764,7 +764,7 @@ func (layer *Layer) Validate() error {
 }
 
 // Validate checks that the combined layers form a valid plan.
-// See also Plan.Validate, which checks that the individual layers are valid.
+// See also Layer.Validate, which checks that the individual layers are valid.
 func (p *Plan) Validate() error {
 	for name, service := range p.Services {
 		if service.Command == "" {

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -737,7 +737,7 @@ var planTests = []planTest{{
 		checks:
 			chk-http:
 				override: merge
-				period: 4s
+				period: 1s
 		
 			chk-tcp:
 				override: merge
@@ -778,8 +778,8 @@ var planTests = []planTest{{
 			"chk-http": {
 				Name:      "chk-http",
 				Override:  plan.MergeOverride,
-				Period:    plan.OptionalDuration{Value: 4 * time.Second, IsSet: true},
-				Timeout:   plan.OptionalDuration{Value: defaultCheckTimeout},
+				Period:    plan.OptionalDuration{Value: time.Second, IsSet: true},
+				Timeout:   plan.OptionalDuration{Value: time.Second},
 				Threshold: defaultCheckThreshold,
 				HTTP: &plan.HTTPCheck{
 					URL:     "https://example.com/bar",

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -737,7 +737,7 @@ var planTests = []planTest{{
 		checks:
 			chk-http:
 				override: merge
-				period: 4s
+				period: 1s
 		
 			chk-tcp:
 				override: merge
@@ -778,7 +778,7 @@ var planTests = []planTest{{
 			"chk-http": {
 				Name:      "chk-http",
 				Override:  plan.MergeOverride,
-				Period:    plan.OptionalDuration{Value: 4 * time.Second, IsSet: true},
+				Period:    plan.OptionalDuration{Value: time.Second, IsSet: true},
 				Timeout:   plan.OptionalDuration{Value: defaultCheckTimeout},
 				Threshold: defaultCheckThreshold,
 				HTTP: &plan.HTTPCheck{
@@ -809,6 +809,35 @@ var planTests = []planTest{{
 					Environment: map[string]string{
 						"FOO": "bar",
 					},
+				},
+			},
+		},
+		LogTargets: map[string]*plan.LogTarget{},
+	},
+}, {
+	summary: "Timeout is capped at period",
+	input: []string{`
+		checks:
+			chk1:
+				override: replace
+				period: 100ms
+				timeout: 2s
+				tcp:
+					host: foobar
+					port: 80
+`},
+	result: &plan.Layer{
+		Services: map[string]*plan.Service{},
+		Checks: map[string]*plan.Check{
+			"chk1": {
+				Name:      "chk1",
+				Override:  plan.ReplaceOverride,
+				Period:    plan.OptionalDuration{Value: 100 * time.Millisecond, IsSet: true},
+				Timeout:   plan.OptionalDuration{Value: 100 * time.Millisecond, IsSet: true},
+				Threshold: defaultCheckThreshold,
+				TCP: &plan.TCPCheck{
+					Port: 80,
+					Host: "foobar",
 				},
 			},
 		},

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -737,7 +737,7 @@ var planTests = []planTest{{
 		checks:
 			chk-http:
 				override: merge
-				period: 1s
+				period: 4s
 		
 			chk-tcp:
 				override: merge
@@ -778,7 +778,7 @@ var planTests = []planTest{{
 			"chk-http": {
 				Name:      "chk-http",
 				Override:  plan.MergeOverride,
-				Period:    plan.OptionalDuration{Value: time.Second, IsSet: true},
+				Period:    plan.OptionalDuration{Value: 4 * time.Second, IsSet: true},
 				Timeout:   plan.OptionalDuration{Value: defaultCheckTimeout},
 				Threshold: defaultCheckThreshold,
 				HTTP: &plan.HTTPCheck{
@@ -834,6 +834,34 @@ var planTests = []planTest{{
 				Override:  plan.ReplaceOverride,
 				Period:    plan.OptionalDuration{Value: 100 * time.Millisecond, IsSet: true},
 				Timeout:   plan.OptionalDuration{Value: 100 * time.Millisecond, IsSet: true},
+				Threshold: defaultCheckThreshold,
+				TCP: &plan.TCPCheck{
+					Port: 80,
+					Host: "foobar",
+				},
+			},
+		},
+		LogTargets: map[string]*plan.LogTarget{},
+	},
+}, {
+	summary: "Unset timeout is capped at period",
+	input: []string{`
+		checks:
+			chk1:
+				override: replace
+				period: 100ms
+				tcp:
+					host: foobar
+					port: 80
+`},
+	result: &plan.Layer{
+		Services: map[string]*plan.Service{},
+		Checks: map[string]*plan.Check{
+			"chk1": {
+				Name:      "chk1",
+				Override:  plan.ReplaceOverride,
+				Period:    plan.OptionalDuration{Value: 100 * time.Millisecond, IsSet: true},
+				Timeout:   plan.OptionalDuration{Value: 100 * time.Millisecond, IsSet: false},
 				Threshold: defaultCheckThreshold,
 				TCP: &plan.TCPCheck{
 					Port: 80,


### PR DESCRIPTION
This PR moves layer/plan validation into dedicated functions, with `Layer.Validate` covering validation that is specific to a layer (such as an invalid value) and `Plan.Validate` covering validation that covers the plan as a whole (such as cycles or missing values).

Plan validation includes layer validation, and is done in the service manager's `updatePlanLayers` and in `plan.CombineLayers`.

We also use the check period as the upper bound for the timeout in checks, which was happening before, but less explicitly.

No additional validation is done - all of the validation code is moved rather than changed.

Fixes #349