### PR TITLE
doc(state): say why we're not implementing warnings as notices yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,10 @@ These notice types are currently available:
 
 * `custom`: a custom client notice reported via `pebble notify`. The key and any data is provided by the user. The key must be in the format `mydomain.io/mykey` to ensure well-namespaced notice keys.
 
-<!-- TODO: * `warning`: Pebble warnings are implemented in terms of notices. The key for this type of notice is the human-readable warning message. -->
+<!-- TODO: * `warning`: Pebble warnings are implemented in terms of notices. The key for this type of notice is the human-readable warning message.
+
+See comment at the top of internals/overlord/state/warning.go for more info.
+-->
 
 To record `custom` notices, use `pebble notify` -- the notice user ID will be set to the client's user ID:
 

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -194,6 +194,9 @@ const (
 
 	// Warnings are a subset of notices where the key is a human-readable
 	// warning message.
+	//
+	// NOTE: This isn't used yet. See comment at the top of
+	// internals/overlord/state/notices.go for more info.
 	WarningNotice NoticeType = "warning"
 )
 

--- a/internals/overlord/state/warning.go
+++ b/internals/overlord/state/warning.go
@@ -14,6 +14,25 @@
 
 package state
 
+/*
+NOTE: Pebble Notices (added in 2023) was designed as a kind of superset of
+warnings, and we were planning to implement warnings in terms of notices.
+This is still the plan, however, we've put it on hold for now as it's not
+trivial, and warnings aren't actually recorded in Pebble at all right now, so
+it would just be busy work. Here are the reasons it's not trivial:
+
+- Warnings have a single lastShown timestamp (on the server) for when they
+  were last shown to the (single) client, whereas notices aren't marked as
+  "shown" on the server.
+- Each server response includes pending warnings (pending means not shown or
+  having a lastShown earlier than repeatAfter ago).
++ All this assumes a single client; Notices don't assume a single client.
++ One approach is to drop the warnings storage, drop the "pending warnings in
+  every request" functionality, and push ahead with warnings as notices.
++ Or we could fix this by passing the last-seen timestamp from the client to
+  the server on each request.
+*/
+
 import (
 	"encoding/json"
 	"errors"


### PR DESCRIPTION
See comment in `warning.go` for details.