### PR TITLE
fix(daemon): improve health state lock test, remove LockCount

### DIFF
--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -79,8 +79,6 @@ type State struct {
 	mu  sync.Mutex
 	muC int32
 
-	lockCount int32 // used only for testing
-
 	lastTaskId   int
 	lastChangeId int
 	lastLaneId   int
@@ -137,14 +135,6 @@ func (s *State) Modified() bool {
 func (s *State) Lock() {
 	s.mu.Lock()
 	atomic.AddInt32(&s.muC, 1)
-	atomic.AddInt32(&s.lockCount, 1)
-}
-
-// LockCount returns the number of times the state lock was held.
-//
-// NOTE: This needs to be exported, but should only be used in testing.
-func (s *State) LockCount() int {
-	return int(atomic.LoadInt32(&s.lockCount))
 }
 
 func (s *State) reading() {


### PR DESCRIPTION
As Harry pointed out at https://github.com/canonical/pebble/pull/369#discussion_r1505423350, there's a much simpler way to test this without needing a new State method like LockCount. Just acquire the state lock, then call the endpoint. If it times out, we know it was trying to acquire the lock.

In addition, fix an issue where the health endpoint would still hold the state lock if it returned an error. Fix those and add a test for that too.

As far as I'm concerned, this additional fix isn't critical to ship out right away, as it's extremely unlikely the health check endpoint returns an error. It can just go out in the next version of Pebble.