### PR TITLE
fix: start process subreaper at top level to avoid shutdown hangs

### DIFF
--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/plan"
+	"github.com/canonical/pebble/internals/reaper"
 )
 
 var _ = Suite(&execSuite{})
@@ -46,6 +47,11 @@ func (s *execSuite) SetUpSuite(c *C) {
 }
 
 func (s *execSuite) SetUpTest(c *C) {
+	err := reaper.Start()
+	if err != nil {
+		c.Fatalf("cannot start reaper: %v", err)
+	}
+
 	socketPath := c.MkDir() + ".pebble.socket"
 	daemon, err := New(&Options{
 		Dir:        c.MkDir(),
@@ -64,6 +70,11 @@ func (s *execSuite) SetUpTest(c *C) {
 func (s *execSuite) TearDownTest(c *C) {
 	err := s.daemon.Stop(nil)
 	c.Check(err, IsNil)
+
+	err = reaper.Stop()
+	if err != nil {
+		c.Fatalf("cannot stop reaper: %v", err)
+	}
 }
 
 // Some of these tests use the Go client for simplicity.

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internals/overlord/restart"
+	"github.com/canonical/pebble/internals/reaper"
 )
 
 var _ = check.Suite(&apiSuite{})
@@ -38,6 +39,11 @@ type apiSuite struct {
 }
 
 func (s *apiSuite) SetUpTest(c *check.C) {
+	err := reaper.Start()
+	if err != nil {
+		c.Fatalf("cannot start reaper: %v", err)
+	}
+
 	s.restoreMuxVars = FakeMuxVars(s.muxVars)
 	s.pebbleDir = c.MkDir()
 }
@@ -46,6 +52,11 @@ func (s *apiSuite) TearDownTest(c *check.C) {
 	s.d = nil
 	s.pebbleDir = ""
 	s.restoreMuxVars()
+
+	err := reaper.Stop()
+	if err != nil {
+		c.Fatalf("cannot stop reaper: %v", err)
+	}
 }
 
 func (s *apiSuite) muxVars(*http.Request) map[string]string {

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -43,6 +43,7 @@ import (
 	"github.com/canonical/pebble/internals/overlord/servstate"
 	"github.com/canonical/pebble/internals/overlord/standby"
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/systemd"
 )
 
@@ -680,7 +681,7 @@ func systemdModeReboot(rebootDelay time.Duration) error {
 	}
 	mins := int64(rebootDelay / time.Minute)
 	cmd := exec.Command("shutdown", "-r", fmt.Sprintf("+%d", mins), rebootMsg)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := reaper.CommandCombinedOutput(cmd); err != nil {
 		return osutil.OutputErr(out, err)
 	}
 	return nil

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/canonical/pebble/internals/overlord/restart"
 	"github.com/canonical/pebble/internals/overlord/standby"
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/systemd"
 	"github.com/canonical/pebble/internals/testutil"
 )
@@ -60,6 +61,11 @@ type daemonSuite struct {
 var _ = Suite(&daemonSuite{})
 
 func (s *daemonSuite) SetUpTest(c *C) {
+	err := reaper.Start()
+	if err != nil {
+		c.Fatalf("cannot start reaper: %v", err)
+	}
+
 	s.pebbleDir = c.MkDir()
 	s.statePath = filepath.Join(s.pebbleDir, ".pebble.state")
 	systemdSdNotify = func(notif string) error {
@@ -73,6 +79,11 @@ func (s *daemonSuite) TearDownTest(c *C) {
 	s.notified = nil
 	s.authorized = false
 	s.err = nil
+
+	err := reaper.Stop()
+	if err != nil {
+		c.Fatalf("cannot stop reaper: %v", err)
+	}
 }
 
 func (s *daemonSuite) newDaemon(c *C) *Daemon {

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -9,11 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/overlord/restart"
 	"github.com/canonical/pebble/internals/overlord/state"
 	"github.com/canonical/pebble/internals/plan"
-	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/servicelog"
 )
 
@@ -71,11 +69,6 @@ func NewManager(s *state.State, runner *state.TaskRunner, pebbleDir string, serv
 		logMgr:        logMgr,
 	}
 
-	err := reaper.Start()
-	if err != nil {
-		return nil, err
-	}
-
 	runner.AddHandler("start", manager.doStart, nil)
 	runner.AddHandler("stop", manager.doStop, nil)
 
@@ -84,11 +77,6 @@ func NewManager(s *state.State, runner *state.TaskRunner, pebbleDir string, serv
 
 // Stop implements overlord.StateStopper and stops background functions.
 func (m *ServiceManager) Stop() {
-	err := reaper.Stop()
-	if err != nil {
-		logger.Noticef("Cannot stop child process reaper: %v", err)
-	}
-
 	// Close all the service ringbuffers
 	m.servicesLock.Lock()
 	defer m.servicesLock.Unlock()

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/canonical/pebble/internals/overlord/servstate"
 	"github.com/canonical/pebble/internals/overlord/state"
 	"github.com/canonical/pebble/internals/plan"
+	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/servicelog"
 	"github.com/canonical/pebble/internals/testutil"
 )
@@ -180,6 +181,11 @@ func (s *S) SetUpSuite(c *C) {
 }
 
 func (s *S) SetUpTest(c *C) {
+	err := reaper.Start()
+	if err != nil {
+		c.Fatalf("cannot start reaper: %v", err)
+	}
+
 	s.BaseTest.SetUpTest(c)
 
 	s.dir = c.MkDir()
@@ -210,6 +216,11 @@ func (s *S) TearDownTest(c *C) {
 	s.manager.Stop()
 	// General test cleanup
 	s.BaseTest.TearDownTest(c)
+
+	err := reaper.Stop()
+	if err != nil {
+		c.Fatalf("cannot stop reaper: %v", err)
+	}
 }
 
 func (s *S) TestDefaultServiceNames(c *C) {

--- a/internals/systemd/systemd.go
+++ b/internals/systemd/systemd.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/canonical/pebble/internals/osutil"
 	"github.com/canonical/pebble/internals/osutil/squashfs"
+	"github.com/canonical/pebble/internals/reaper"
 )
 
 var (
@@ -88,7 +89,8 @@ func (m *extMutex) Taken(errMsg string) {
 
 // systemctlCmd calls systemctl with the given args, returning its standard output (and wrapped error)
 var systemctlCmd = func(args ...string) ([]byte, error) {
-	bs, err := exec.Command("systemctl", args...).CombinedOutput()
+	cmd := exec.Command("systemctl", args...)
+	bs, err := reaper.CommandCombinedOutput(cmd)
 	if err != nil {
 		exitCode, _ := osutil.ExitCode(err)
 		return nil, &Error{cmd: args, exitCode: exitCode, msg: bs}
@@ -726,7 +728,8 @@ func (s *systemd) RemoveMountUnitFile(mountedDir string) error {
 		return err
 	}
 	if isMounted {
-		if output, err := exec.Command("umount", "-d", "-l", mountedDir).CombinedOutput(); err != nil {
+		cmd := exec.Command("umount", "-d", "-l", mountedDir)
+		if output, err := reaper.CommandCombinedOutput(cmd); err != nil {
 			return osutil.OutputErr(output, err)
 		}
 


### PR DESCRIPTION
For example, if an exec command is running when you Ctrl-C the Pebble daemon, it hangs.

It's hanging because the ServiceManager is stopping the reaper early in the process, before TaskRunner has had a chance to abort the exec tasks (aborting an exec task sends SIGKILL to its pid via the tomb and command context).

Then when TaskRunner.Stop is called, it calls tomb.Kill and then tomb.Wait on each task (exec) tomb, and because the reaper's not running, the tomb.Wait hangs.

So the fix is to move the reaper.Start and reaper.Stop to the top level (inside the "run" command, which is also used for "enter"), instead of putting them in servstate.NewManager and ServiceManager.Stop.

After doing this, some of the tests also had to be modified to start and stop the reaper.

Fixes https://github.com/canonical/pebble/issues/163 and fixes #284 