### PR TITLE
refactor: remove maybeShellcheck from FakeCommand

### DIFF
--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -771,7 +771,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 }
 
 func (s *daemonSuite) TestRebootHelper(c *C) {
-	cmd := testutil.FakeCommand(c, "shutdown", "", true)
+	cmd := testutil.FakeCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
 	tests := []struct {
@@ -815,7 +815,7 @@ func (s *daemonSuite) TestRestartShutdownWithSigtermInBetween(c *C) {
 	}()
 	rebootNoticeWait = 150 * time.Millisecond
 
-	cmd := testutil.FakeCommand(c, "shutdown", "", false)
+	cmd := testutil.FakeCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -847,7 +847,7 @@ func (s *daemonSuite) TestRestartShutdown(c *C) {
 	rebootWaitTimeout = 100 * time.Millisecond
 	rebootNoticeWait = 150 * time.Millisecond
 
-	cmd := testutil.FakeCommand(c, "shutdown", "", false)
+	cmd := testutil.FakeCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -886,7 +886,7 @@ func (s *daemonSuite) TestRestartExpectedRebootIsMissing(c *C) {
 	rebootRetryWaitTimeout = 100 * time.Millisecond
 	rebootNoticeWait = 150 * time.Millisecond
 
-	cmd := testutil.FakeCommand(c, "shutdown", "", true)
+	cmd := testutil.FakeCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -925,7 +925,7 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *C) {
 	err := os.WriteFile(s.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	cmd := testutil.FakeCommand(c, "shutdown", "", true)
+	cmd := testutil.FakeCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)
@@ -949,7 +949,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *C) {
 	err = os.WriteFile(s.statePath, fakeState, 0600)
 	c.Assert(err, IsNil)
 
-	cmd := testutil.FakeCommand(c, "shutdown", "", true)
+	cmd := testutil.FakeCommand(c, "shutdown", "")
 	defer cmd.Restore()
 
 	d := s.newDaemon(c)

--- a/internals/systemd/systemd_test.go
+++ b/internals/systemd/systemd_test.go
@@ -572,12 +572,12 @@ func (s *SystemdTestSuite) TestFuseInContainer(c *C) {
 	systemdCmd := testutil.FakeCommand(c, "systemd-detect-virt", `
 echo lxc
 exit 0
-	`, false)
+	`)
 	defer systemdCmd.Restore()
 
 	fuseCmd := testutil.FakeCommand(c, "squashfuse", `
 exit 0
-	`, false)
+	`)
 	defer fuseCmd.Restore()
 
 	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
@@ -610,12 +610,12 @@ func (s *SystemdTestSuite) TestFuseOutsideContainer(c *C) {
 	systemdCmd := testutil.FakeCommand(c, "systemd-detect-virt", `
 echo none
 exit 0
-	`, false)
+	`)
 	defer systemdCmd.Restore()
 
 	fuseCmd := testutil.FakeCommand(c, "squashfuse", `
 exit 0
-	`, false)
+	`)
 	defer fuseCmd.Restore()
 
 	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")

--- a/internals/testutil/exec.go
+++ b/internals/testutil/exec.go
@@ -17,67 +17,13 @@ package testutil
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"gopkg.in/check.v1"
-
-	"github.com/canonical/pebble/internals/reaper"
 )
-
-var shellcheckPath string
-
-func init() {
-	if p, err := exec.LookPath("shellcheck"); err == nil {
-		shellcheckPath = p
-	}
-}
-
-var (
-	shellchecked   = make(map[string]bool, 16)
-	shellcheckedMu sync.Mutex
-)
-
-func shellcheckSeenAlready(script string) bool {
-	shellcheckedMu.Lock()
-	defer shellcheckedMu.Unlock()
-	if shellchecked[script] {
-		return true
-	}
-	shellchecked[script] = true
-	return false
-}
-
-func maybeShellcheck(c *check.C, script string, wholeScript io.Reader, withReaper bool) {
-	// FakeCommand is used sometimes in SetUptTest, so it adds up
-	// even for the empty script, don't recheck the essentially same
-	// thing again and again!
-	if shellcheckSeenAlready(script) {
-		return
-	}
-	c.Logf("using shellcheck: %q", shellcheckPath)
-	if shellcheckPath == "" {
-		// no shellcheck, nothing to do
-		return
-	}
-	cmd := exec.Command(shellcheckPath, "-s", "bash", "-")
-	cmd.Stdin = wholeScript
-
-	var out []byte
-	var err error
-	if withReaper {
-		out, err = reaper.CommandCombinedOutput(cmd)
-	} else {
-		out, err = cmd.CombinedOutput()
-	}
-
-	c.Check(err, check.IsNil, check.Commentf("shellcheck failed:\n%s", string(out)))
-}
 
 // FakeCmd allows faking commands for testing.
 type FakeCmd struct {
@@ -113,7 +59,7 @@ printf '\f\n\r' >> %[1]q
 // non-empty then it is used as is and the caller is responsible for how the
 // script behaves (exit code and any extra behavior). If script is empty then
 // the command exits successfully without any other side-effect.
-func FakeCommand(c *check.C, basename, script string, withReaper bool) *FakeCmd {
+func FakeCommand(c *check.C, basename, script string) *FakeCmd {
 	var wholeScript bytes.Buffer
 	var binDir, exeFile, logFile string
 	if filepath.IsAbs(basename) {
@@ -131,8 +77,6 @@ func FakeCommand(c *check.C, basename, script string, withReaper bool) *FakeCmd 
 	if err != nil {
 		panic(err)
 	}
-
-	maybeShellcheck(c, script, &wholeScript, withReaper)
 
 	return &FakeCmd{binDir: binDir, exeFile: exeFile, logFile: logFile}
 }

--- a/internals/testutil/export_test.go
+++ b/internals/testutil/export_test.go
@@ -21,11 +21,3 @@ import (
 func UnexpectedIntChecker(relation string) *intChecker {
 	return &intChecker{CheckerInfo: &check.CheckerInfo{Name: "unexpected", Params: []string{"a", "b"}}, rel: relation}
 }
-
-func FakeShellcheckPath(p string) (restore func()) {
-	old := shellcheckPath
-	shellcheckPath = p
-	return func() {
-		shellcheckPath = old
-	}
-}


### PR DESCRIPTION
Partly due to the fact that Pebble acts as a child subreaper, running additional commands outside the reaper is problematic. The "withReaper" argument to FakeCommand is a case in point.

However, instead of refactoring tests and FakeCommand to be reaper-aware, let's just remove the "maybe shellcheck" thing altogether.

I think it's problematic to have tests *maybe* do something if a specific command ("shellcheck" in this case) is installed on the system: some developers will catch issues with shellcheck, others won't. Plus, this has never caught anything for me in my Pebble journeys.

It also adds about 1s to the test running time, though that's not the main reason I want to take it out.

For reference, [here](https://github.com/snapcore/snapd/commit/a1f3919502da59a9cf331e3a7d10d5269dcf64bd) is the original commit where it was added to snapd.