### PR TITLE
feat(cli): add RunWithConfig, remove global variable

### DIFF
--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -253,9 +253,6 @@ var (
 	osExit      = os.Exit
 )
 
-// ClientConfig is the configuration of the Client used by all commands.
-var clientConfig client.Config
-
 // exitStatus can be used in panic(&exitStatus{code}) to cause Pebble's main
 // function to exit with a given exit code, for the rare cases when you want
 // to return an exit code other than 0 or 1, or when an error return is not
@@ -269,6 +266,13 @@ func (e *exitStatus) Error() string {
 }
 
 func Run() error {
+	// the configuration of the Client used by all commands.
+	var clientConfig client.Config
+	_, clientConfig.Socket = getEnvPaths()
+	return RunWithConfig(&clientConfig)
+}
+
+func RunWithConfig(config *client.Config) error {
 	defer func() {
 		if v := recover(); v != nil {
 			if e, ok := v.(*exitStatus); ok {
@@ -280,9 +284,7 @@ func Run() error {
 
 	logger.SetLogger(logger.New(os.Stderr, fmt.Sprintf("[%s] ", cmd.ProgramName)))
 
-	_, clientConfig.Socket = getEnvPaths()
-
-	cli, err := client.New(&clientConfig)
+	cli, err := client.New(config)
 	if err != nil {
 		return fmt.Errorf("cannot create client: %v", err)
 	}

--- a/internals/cli/export_test.go
+++ b/internals/cli/export_test.go
@@ -20,9 +20,11 @@ import (
 	"github.com/canonical/pebble/client"
 )
 
-var RunMain = Run
+func RunMain() error {
+	return RunWithConfig(ClientConfig)
+}
 
-var ClientConfig = &clientConfig
+var ClientConfig = &client.Config{}
 
 func Client() *client.Client {
 	cli, err := client.New(ClientConfig)


### PR DESCRIPTION
The goal of this PR is to allow full customization of the `client.Config` (including its `Socket`, `BaseURL` and `UserAgent` members) for callers of `cli.Run()`. This is achieved by exposing a new public function `cli.RunWithConfig(*client.Config)`.

The `clientConfig` global variable isn't accessed by any non-test code, so it can be turned into a local variable in the `Run()` function, and an additional `RunWithConfig()` function exposed that fully customize `ClientConfig`.

---

Additional information about test-related changes:

The global variable WAS used in tests (as `ClientConfig`, in `internals/cli/cli_test.go`: `cli.ClientConfig.BaseURL = server.URL`), but since all tests use `cli.RunMain()` (which is defined in `cli/export_test.go`) instead of `cli.Run()`, we can just define the global variable for the tests only, and make `RunMain` use that config object by calling `RunWithConfig`.