### PR TITLE
fix: allow for the JSON overhead when reading log lines

### DIFF
--- a/client/logs.go
+++ b/client/logs.go
@@ -26,8 +26,8 @@ import (
 	"time"
 )
 
-// This needs to be the size of daemon.api_logs.logReaderSize, plus extra to
-// handle the timestamp, service name, and JSON syntax.
+// This needs to be the size of daemon.logReaderSize, plus extra to handle the
+// timestamp, service name, and JSON syntax.
 const (
 	logReaderSize = 5 * 1024
 )

--- a/client/logs.go
+++ b/client/logs.go
@@ -26,8 +26,10 @@ import (
 	"time"
 )
 
+// This needs to be the size of daemon.api_logs.logReaderSize, plus extra to
+// handle the timestamp, service name, and JSON syntax.
 const (
-	logReaderSize = 4 * 1024
+	logReaderSize = 5 * 1024
 )
 
 type LogsOptions struct {


### PR DESCRIPTION
The server caps lines at 4096 characters, but the client receives these as JSON, so when receiving there's an extra ~70 characters that make up the timestamp, service name, field names, and JSON punctuation. This means that limiting the slice size to 4096 characters there will result in buffer full errors.

Allow an extra 1024 characters for the JSON 'overhead' - this should be far more than needed, but is only used within the `logs` function - I wasn't able to find any maximum length for a service name, so a precise extra count is tricky. This could be lowered (I would guess 128 characters would usually be sufficient) if this might be too much memory in some Pebble use cases.

Also adds tests for the long log line cases.

Fixes #376 