### PR TITLE
fix(client): make retry loop stop immediately when context is cancelled

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -302,6 +302,7 @@ func (rq *defaultRequester) retry(ctx context.Context, method, urlpath string, q
 		case <-retry.C:
 			continue
 		case <-timeout:
+		case <-ctx.Done():
 		}
 		break
 	}


### PR DESCRIPTION
I noticed that `pebble notices --timeout=60s` was taking about 5s to exit after you pressed Ctrl-C, when we were listening to SIGINT correctly and cancelling the context. Turns out `defaultRequester.retry` was only looking at the timeout channel, not the `ctx.Done()` one.

Writing this afresh we'd probably just use a context for the timeout as well as for cancellation, but do this minimal fix for now.