### PR TITLE
fix(client): WebSockets dialer with client BaseURL set

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -122,6 +122,12 @@ func unixDialer(socketPath string) func(string, string) (net.Conn, error) {
 	}
 }
 
+func tcpDialer(address string) func(string, string) (net.Conn, error) {
+	return func(_, _ string) (net.Conn, error) {
+		return net.Dial("tcp", address)
+	}
+}
+
 type doer interface {
 	Do(*http.Request) (*http.Response, error)
 }
@@ -587,7 +593,7 @@ func newDefaultRequester(client *Client, opts *Config) (*defaultRequester, error
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse base URL: %w", err)
 		}
-		transport := &http.Transport{DisableKeepAlives: opts.DisableKeepAlive}
+		transport := &http.Transport{Dial: tcpDialer(baseURL.Host), DisableKeepAlives: opts.DisableKeepAlive}
 		requester = &defaultRequester{baseURL: *baseURL, transport: transport}
 	}
 


### PR DESCRIPTION
Add a custom TCP dialer to allow WebSockets to work with remote TCP connections for clients that have BaseURL set.