### PR TITLE
fix(run): don't overwrite err on reaper.Stop()

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -156,7 +156,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	defer func() {
 		err := reaper.Stop()
 		if err != nil {
-			logger.Noticef("cannot stop child process reaper: %w", err)
+			logger.Noticef("cannot stop child process reaper: %v", err)
 		}
 	}()
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -148,15 +148,15 @@ func sanityCheck() error {
 	return nil
 }
 
-func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) (err error) {
-	err = reaper.Start()
+func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
+	err := reaper.Start()
 	if err != nil {
 		return fmt.Errorf("cannot start child process reaper: %w", err)
 	}
 	defer func() {
-		err = reaper.Stop()
+		err := reaper.Stop()
 		if err != nil {
-			err = fmt.Errorf("cannot stop child process reaper: %w", err)
+			logger.Noticef("cannot stop child process reaper: %w", err)
 		}
 	}()
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -156,7 +156,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	defer func() {
 		err := reaper.Stop()
 		if err != nil {
-			logger.Noticef("cannot stop child process reaper: %v", err)
+			logger.Noticef("Cannot stop child process reaper: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
PR #380 recently changed the way the reaper is stopped.

If `runDaemon()` returns an error the `defer` method overwrites the `err` return value in `err = reaper.Stop()`. If `err` was already set to something else, this will in effect overwrite the non-`nil` `err` with either `nil` (if `reaper.Stop()` returns `nil`) or a different error (if `reaper.Stop()` returns a different error).

Currently (without this PR):

- `err == nil` on defer method entry, `reaper.Stop()` returns `nil` - that's okay (no error)
- `err == nil` on defer method entry, `reaper.Stop()` returns non-`nil` - that's okay (reaper error reported)
- `err != nil` on defer method entry, `reaper.Stop()` returns `nil` - `err` overwritten, `runDaemon` errorneously returns success
- `err != nil` on defer method entry, `reaper.Stop()` return non-`nil` - `err` overwritten, `runDaemon` returns an error properly, but the real error is overwritten by the reaper error message

With this PR:

- `err == nil` on defer method entry, `reaper.Stop()` returns `nil` - that's okay (no error)
- `err == nil` on defer method entry, `reaper.Stop()` returns non-`nil` - that's okay (reaper error reported)
- `err != nil` on defer method entry, `reaper.Stop()` returns `nil` - `err` is returned properly
- `err != nil` on defer method entry, `reaper.Stop()` return non-`nil` - `err` is returned, the error from `reaper.Stop()` is hidden / ignored

Because this defer method is the first one in the function, it will get called last, so it's the one that will have `err` set on entry if the function returns a non-`nil` error.