### PR TITLE
fix(taskrunner): consistent, nicer formatting for task failed log

### DIFF
--- a/internals/overlord/state/taskrunner.go
+++ b/internals/overlord/state/taskrunner.go
@@ -291,7 +291,7 @@ func (r *TaskRunner) run(t *Task) {
 			t.SetStatus(ErrorStatus)
 			t.Errorf("%s", err)
 			// ensure the error is available in the global log too
-			logger.Noticef("[change %s %q task] failed: %v", t.Change().ID(), t.Summary(), err)
+			logger.Noticef("Change %s task (%s) failed: %v", t.Change().ID(), t.Summary(), err)
 			if r.taskErrorCallback != nil {
 				r.taskErrorCallback(err)
 			}

--- a/internals/overlord/state/taskrunner_test.go
+++ b/internals/overlord/state/taskrunner_test.go
@@ -1290,7 +1290,7 @@ func (ts *taskRunnerSuite) TestErrorCallbackCalledOnError(c *C) {
 	c.Check(strings.Join(t1.Log(), ""), Matches, `.*handler error for "foo"`)
 	c.Check(called, Equals, true)
 
-	c.Check(logbuf.String(), Matches, `(?m).*: \[change 1 "task summary" task\] failed: handler error for "foo".*`)
+	c.Check(logbuf.String(), Matches, `(?m).*: Change 1 task \(task summary\) failed: handler error for "foo".*`)
 }
 
 func (ts *taskRunnerSuite) TestErrorCallbackNotCalled(c *C) {


### PR DESCRIPTION
This changes this log:

```
2024-03-21T06:37:37.224Z [pebble] [change 32 "Start service \"svc1\"" task] failed: cannot start service: exited quickly with code 1
```

To this, which is more consistent with the formatting of the other Pebble logs:

```
2024-03-21T06:43:09.559Z [pebble] Change 33 task (Start service "svc1") failed: cannot start service: exited quickly with code 1
```

This log was introduced in this commit:
https://github.com/canonical/pebble/commit/e494ff2eed86799ce5756ae02f9442b890c3472f#diff-e8b7c8da8654dde95838cfa0cc4b497cdd32050ea3a1bf0640e6404303aef0d6R294 which was pulled across from snapd, which originally added it here: https://github.com/snapcore/snapd/commit/8b2a5a8b9b62408e4d549fde3d231f2775dce3b9