### PR TITLE
fix(cli): PEBBLE_COPY_ONCE on missing dir.

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -316,6 +316,13 @@ func maybeCopyPebbleDir(destDir, srcDir string) error {
 	if srcDir == "" {
 		return nil
 	}
+	_, err := os.Stat(srcDir)
+	if errors.Is(err, os.ErrNotExist) {
+		// Skip missing source directory.
+		return nil
+	} else if err != nil {
+		return err
+	}
 	entries, err := os.ReadDir(destDir)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err

--- a/internals/cli/cmd_run_test.go
+++ b/internals/cli/cmd_run_test.go
@@ -103,3 +103,25 @@ func (s *PebbleSuite) TestMaybeCopyPebbleDirNoCopy(c *C) {
 		"a.yaml": true,
 	})
 }
+
+func (s *PebbleSuite) TestMaybeCopyPebbleDirSourceNotExist(c *C) {
+	tmpDir := c.MkDir()
+	dst := path.Join(tmpDir, "dst")
+	err := os.Mkdir(dst, 0o700)
+	c.Assert(err, IsNil)
+	src := path.Join(tmpDir, "not-exist")
+	err = cli.MaybeCopyPebbleDir(dst, src)
+	c.Assert(err, IsNil)
+}
+
+func (s *PebbleSuite) TestMaybeCopyPebbleDirSourceNotADirectory(c *C) {
+	tmpDir := c.MkDir()
+	dst := path.Join(tmpDir, "dst")
+	err := os.Mkdir(dst, 0o700)
+	c.Assert(err, IsNil)
+	src := path.Join(tmpDir, "file")
+	err = os.WriteFile(src, nil, 0o666)
+	c.Assert(err, IsNil)
+	err = cli.MaybeCopyPebbleDir(dst, src)
+	c.Assert(err, ErrorMatches, ".*not a directory.*")
+}


### PR DESCRIPTION
If the `PEBBLE_COPY_ONCE` source directory does not exist, it will fail to copy inside the borrowed std go copyFS function. This adds an `os.Stat` to check if it first exists, ignoring it otherwise (the expected behavior).