### PR TITLE
fix(client): use host from BaseURL for websockets

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,9 @@ type Requester interface {
 
 	// Transport returns the HTTP transport in use by the underlying HTTP client.
 	Transport() *http.Transport
+
+	// Host returns the host/host:port of the Pebble daemon (localhost for UNIX domain sockets).
+	Host() string
 }
 
 type RequestType int
@@ -191,7 +194,7 @@ func (client *Client) Requester() Requester {
 }
 
 func (client *Client) getTaskWebsocket(taskID, websocketID string) (clientWebsocket, error) {
-	url := fmt.Sprintf("ws://localhost/v1/tasks/%s/websocket/%s", taskID, websocketID)
+	url := fmt.Sprintf("ws://%s/v1/tasks/%s/websocket/%s", client.requester.Host(), taskID, websocketID)
 	return client.getWebsocket(url)
 }
 
@@ -600,4 +603,8 @@ func newDefaultRequester(client *Client, opts *Config) (*defaultRequester, error
 
 func (rq *defaultRequester) Transport() *http.Transport {
 	return rq.transport
+}
+
+func (rq *defaultRequester) Host() string {
+	return rq.baseURL.Host
 }

--- a/client/client.go
+++ b/client/client.go
@@ -39,9 +39,6 @@ type Requester interface {
 
 	// Transport returns the HTTP transport in use by the underlying HTTP client.
 	Transport() *http.Transport
-
-	// Host returns the host/host:port of the Pebble daemon (localhost for UNIX domain sockets).
-	Host() string
 }
 
 type RequestType int
@@ -155,6 +152,8 @@ type Client struct {
 	warningTimestamp time.Time
 
 	getWebsocket getWebsocketFunc
+
+	host string
 }
 
 type getWebsocketFunc func(url string) (clientWebsocket, error)
@@ -185,6 +184,7 @@ func New(config *Config) (*Client, error) {
 	client.getWebsocket = func(url string) (clientWebsocket, error) {
 		return getWebsocket(requester.Transport(), url)
 	}
+	client.host = requester.baseURL.Host
 
 	return client, nil
 }
@@ -194,7 +194,7 @@ func (client *Client) Requester() Requester {
 }
 
 func (client *Client) getTaskWebsocket(taskID, websocketID string) (clientWebsocket, error) {
-	url := fmt.Sprintf("ws://%s/v1/tasks/%s/websocket/%s", client.requester.Host(), taskID, websocketID)
+	url := fmt.Sprintf("ws://%s/v1/tasks/%s/websocket/%s", client.host, taskID, websocketID)
 	return client.getWebsocket(url)
 }
 
@@ -603,8 +603,4 @@ func newDefaultRequester(client *Client, opts *Config) (*defaultRequester, error
 
 func (rq *defaultRequester) Transport() *http.Transport {
 	return rq.transport
-}
-
-func (rq *defaultRequester) Host() string {
-	return rq.baseURL.Host
 }


### PR DESCRIPTION
Properly pass the Host (`localhost` for UNIX domain sockets, the host and port values for TCP sockets) to the websockets library.