### PR TITLE
fix(enter): block --verbose for exec subcommand

### DIFF
--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -164,7 +164,7 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	}
 
 	if enterFlags&enterProhibitVerbose != 0 && cmd.Verbose {
-		return fmt.Errorf("enter: cannot provide -v, --verbose before %q subcommand", parser.Active.Name)
+		return fmt.Errorf("enter: cannot provide -v/--verbose before %q subcommand", parser.Active.Name)
 	}
 
 	if enterFlags&enterNoServiceManager != 0 {

--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -143,6 +143,16 @@ func (s *PebbleSuite) TestEnterServicesNoRun(c *C) {
 	c.Check(exitCode, Equals, 1)
 }
 
+func (s *PebbleSuite) TestEnterExecNoVerbose(c *C) {
+	restore := fakeArgs("pebble", "enter", "--verbose", "exec", "date")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(s.Stderr(), Equals, "error: enter: cannot provide -v, --verbose before \"exec\" subcommand\n")
+	c.Check(s.Stdout(), Equals, "")
+	c.Check(exitCode, Equals, 1)
+}
+
 func (s *PebbleSuite) TestEnterExecListDir(c *C) {
 	files := []string{"foo", "bar", "baz"}
 	for _, file := range files {

--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -148,7 +148,7 @@ func (s *PebbleSuite) TestEnterExecNoVerbose(c *C) {
 	defer restore()
 
 	exitCode := cli.PebbleMain()
-	c.Check(s.Stderr(), Equals, "error: enter: cannot provide -v, --verbose before \"exec\" subcommand\n")
+	c.Check(s.Stderr(), Equals, "error: enter: cannot provide -v/--verbose before \"exec\" subcommand\n")
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(exitCode, Equals, 1)
 }


### PR DESCRIPTION
**NOTE: do not merge until https://github.com/canonical/rockcraft/pull/495 is finalized.**

This PR blocks the usage of ``--verbose`` option in "enter" command whenever the "exec" subcommand follows. Thus, the following will result in errors:

    pebble enter --verbose [enter-OPTS*] exec [exec-OPTS] <cmd..>

Everything else, however, are kept unchanged. So the following is okay:

    pebble enter [enter-OPTS*] exec [exec-OPTS] <cmd..>

Note that `enter-OPTS*` refer to all "enter" options except `-v`, `--verbose`.

Resolves https://github.com/canonical/pebble/issues/339.