### PR TITLE
fix(help): DefaultDir to personality, allow overriding header and footer

### DIFF
--- a/cmd/personality.go
+++ b/cmd/personality.go
@@ -14,10 +14,6 @@
 
 package cmd
 
-import (
-	"strings"
-)
-
 // ProgramName represents the name of the application binary.
 var ProgramName string = "pebble"
 
@@ -26,12 +22,3 @@ var DisplayName string = "Pebble"
 
 // DefaultDir is the Pebble directory used if $PEBBLE is not set.
 var DefaultDir string = "/var/lib/pebble/default"
-
-func ApplyPersonality(s string) string {
-	r := strings.NewReplacer(
-		"{{.ProgramName}}", ProgramName,
-		"{{.DisplayName}}", DisplayName,
-		"{{.DefaultDir}}", DefaultDir,
-	)
-	return r.Replace(s)
-}

--- a/cmd/personality.go
+++ b/cmd/personality.go
@@ -14,6 +14,10 @@
 
 package cmd
 
+import (
+	"strings"
+)
+
 // ProgramName represents the name of the application binary.
 var ProgramName string = "pebble"
 
@@ -22,3 +26,12 @@ var DisplayName string = "Pebble"
 
 // DefaultDir is the Pebble directory used if $PEBBLE is not set.
 var DefaultDir string = "/var/lib/pebble/default"
+
+func ApplyPersonality(s string) string {
+	r := strings.NewReplacer(
+		"{{.ProgramName}}", ProgramName,
+		"{{.DisplayName}}", DisplayName,
+		"{{.DefaultDir}}", DefaultDir,
+	)
+	return r.Replace(s)
+}

--- a/cmd/personality.go
+++ b/cmd/personality.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2014-2024 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -14,13 +14,11 @@
 
 package cmd
 
-//go:generate ./mkversion.sh
+// ProgramName represents the name of the application binary.
+var ProgramName string = "pebble"
 
-// Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.10.0-dev"
+// DisplayName represents the user-facing name of the application.
+var DisplayName string = "Pebble"
 
-func MockVersion(version string) (restore func()) {
-	old := Version
-	Version = version
-	return func() { Version = old }
-}
+// DefaultDir is the Pebble directory used if $PEBBLE is not set.
+var DefaultDir string = "/var/lib/pebble/default"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,3 +30,6 @@ var ProgramName string = "pebble"
 
 // DisplayName represents the user-facing name of the application.
 var DisplayName string = "Pebble"
+
+// DefaultDir is the Pebble directory used if $PEBBLE is not set.
+var DefaultDir string = "/var/lib/pebble/default"

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -48,11 +48,6 @@ var (
 	noticef = logger.Noticef
 )
 
-// defaultPebbleDir is the Pebble directory used if $PEBBLE is not set. It is
-// created by the daemon ("pebble run") if it doesn't exist, and also used by
-// the pebble client.
-const defaultPebbleDir = "/var/lib/pebble/default"
-
 // ErrExtraArgs is returned  if extra arguments to a command are found
 var ErrExtraArgs = fmt.Errorf("too many arguments for command")
 
@@ -243,7 +238,11 @@ func Parser(cli *client.Client) *flags.Parser {
 }
 
 func applyPersonality(s string) string {
-	r := strings.NewReplacer("{{.ProgramName}}", cmd.ProgramName, "{{.DisplayName}}", cmd.DisplayName)
+	r := strings.NewReplacer(
+		"{{.ProgramName}}", cmd.ProgramName,
+		"{{.DisplayName}}", cmd.DisplayName,
+		"{{.DefaultDir}}", cmd.DefaultDir,
+	)
 	return r.Replace(s)
 }
 
@@ -379,7 +378,7 @@ func errorToMessage(e error) (normalMessage string, err error) {
 func getEnvPaths() (pebbleDir string, socketPath string) {
 	pebbleDir = os.Getenv("PEBBLE")
 	if pebbleDir == "" {
-		pebbleDir = defaultPebbleDir
+		pebbleDir = cmd.DefaultDir
 	}
 	socketPath = os.Getenv("PEBBLE_SOCKET")
 	if socketPath == "" {

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -163,7 +163,7 @@ func Parser(cli *client.Client) *flags.Parser {
 	parser := flags.NewParser(&defaultOpts, flagOpts)
 	parser.Command.Name = cmd.ProgramName
 	parser.ShortDescription = "System and service manager"
-	parser.LongDescription = applyPersonality(longPebbleDescription)
+	parser.LongDescription = applyPersonality(HelpHeader)
 
 	// Add --help like what go-flags would do for us, but hidden
 	addHelp(parser)

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/canonical/pebble/client"
-	cmdpkg "github.com/canonical/pebble/cmd"
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/logger"
 )
 
@@ -161,9 +161,9 @@ func Parser(cli *client.Client) *flags.Parser {
 
 	flagOpts := flags.Options(flags.PassDoubleDash)
 	parser := flags.NewParser(&defaultOpts, flagOpts)
-	parser.Command.Name = cmdpkg.ProgramName
+	parser.Command.Name = cmd.ProgramName
 	parser.ShortDescription = "System and service manager"
-	parser.LongDescription = cmdpkg.ApplyPersonality(HelpHeader)
+	parser.LongDescription = applyPersonality(HelpHeader)
 
 	// Add --help like what go-flags would do for us, but hidden
 	addHelp(parser)
@@ -189,7 +189,7 @@ func Parser(cli *client.Client) *flags.Parser {
 		} else {
 			target = parser.Command
 		}
-		cmd, err := target.AddCommand(c.Name, cmdpkg.ApplyPersonality(c.Summary), cmdpkg.ApplyPersonality(strings.TrimSpace(c.Description)), obj)
+		cmd, err := target.AddCommand(c.Name, applyPersonality(c.Summary), applyPersonality(strings.TrimSpace(c.Description)), obj)
 		if err != nil {
 			logger.Panicf("internal error: cannot add command %q: %v", c.Name, err)
 		}
@@ -200,9 +200,9 @@ func Parser(cli *client.Client) *flags.Parser {
 		positionalHelp := map[string]string{}
 		for specifier, help := range c.ArgsHelp {
 			if flagRegexp.MatchString(specifier) {
-				flagHelp[specifier] = cmdpkg.ApplyPersonality(help)
+				flagHelp[specifier] = applyPersonality(help)
 			} else if positionalRegexp.MatchString(specifier) {
-				positionalHelp[specifier] = cmdpkg.ApplyPersonality(help)
+				positionalHelp[specifier] = applyPersonality(help)
 			} else {
 				logger.Panicf("internal error: invalid help specifier from %q: %q", c.Name, specifier)
 			}
@@ -216,10 +216,10 @@ func Parser(cli *client.Client) *flags.Parser {
 		for _, opt := range opts {
 			if description, ok := flagHelp["--"+opt.LongName]; ok {
 				lintDesc(c.Name, opt.LongName, description, opt.Description)
-				opt.Description = cmdpkg.ApplyPersonality(description)
+				opt.Description = applyPersonality(description)
 			} else if description, ok := flagHelp["-"+string(opt.ShortName)]; ok {
 				lintDesc(c.Name, string(opt.ShortName), description, opt.Description)
-				opt.Description = cmdpkg.ApplyPersonality(description)
+				opt.Description = applyPersonality(description)
 			} else if !opt.Hidden {
 				logger.Panicf("internal error: %q missing description for %q", c.Name, opt)
 			}
@@ -235,6 +235,15 @@ func Parser(cli *client.Client) *flags.Parser {
 		}
 	}
 	return parser
+}
+
+func applyPersonality(s string) string {
+	r := strings.NewReplacer(
+		"{{.ProgramName}}", cmd.ProgramName,
+		"{{.DisplayName}}", cmd.DisplayName,
+		"{{.DefaultDir}}", cmd.DefaultDir,
+	)
+	return r.Replace(s)
 }
 
 var (
@@ -276,7 +285,7 @@ func Run(options *RunOptions) error {
 
 	log := options.Logger
 	if log == nil {
-		log = logger.New(os.Stderr, fmt.Sprintf("[%s] ", cmdpkg.ProgramName))
+		log = logger.New(os.Stderr, fmt.Sprintf("[%s] ", cmd.ProgramName))
 	}
 	logger.SetLogger(log)
 
@@ -303,11 +312,11 @@ func Run(options *RunOptions) error {
 				return nil
 			case flags.ErrUnknownCommand:
 				sub := os.Args[1]
-				sug := cmdpkg.ProgramName + " help"
+				sug := cmd.ProgramName + " help"
 				if len(xtra) > 0 {
 					sub = xtra[0]
 					if x := parser.Command.Active; x != nil && x.Name != "help" {
-						sug = cmdpkg.ProgramName + " help " + x.Name
+						sug = cmd.ProgramName + " help " + x.Name
 					}
 				}
 				return fmt.Errorf("unknown command %q, see '%s'", sub, sug)
@@ -351,7 +360,7 @@ func errorToMessage(e error) (normalMessage string, err error) {
 		}
 	case client.ErrorKindSystemRestart:
 		isError = false
-		msg = fmt.Sprintf("%s is about to reboot the system", cmdpkg.DisplayName)
+		msg = fmt.Sprintf("%s is about to reboot the system", cmd.DisplayName)
 	case client.ErrorKindNoDefaultServices:
 		msg = "no default services"
 	default:
@@ -369,7 +378,7 @@ func errorToMessage(e error) (normalMessage string, err error) {
 func getEnvPaths() (pebbleDir string, socketPath string) {
 	pebbleDir = os.Getenv("PEBBLE")
 	if pebbleDir == "" {
-		pebbleDir = cmdpkg.DefaultDir
+		pebbleDir = cmd.DefaultDir
 	}
 	socketPath = os.Getenv("PEBBLE_SOCKET")
 	if socketPath == "" {

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -231,23 +231,23 @@ the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
 )
 
 func printHelpHeader() {
-	fmt.Fprintln(Stdout, applyPersonality(HelpHeader))
+	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(HelpHeader))
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(pebbleUsage))
+	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleUsage))
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpCategoriesIntro))
+	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleHelpCategoriesIntro))
 }
 
 func printHelpAllFooter() {
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(HelpFooter))
+	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(HelpFooter))
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpAllFooter))
+	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleHelpAllFooter))
 }
 
 func printHelpFooter() {
 	printHelpAllFooter()
-	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpFooter))
+	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleHelpFooter))
 }
 
 // this is called when the Execute returns a flags.Error with ErrCommandRequired

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -240,7 +240,9 @@ func printHelpHeader() {
 
 func printHelpAllFooter() {
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(HelpFooter+"\n\n"+pebbleHelpAllFooter))
+	fmt.Fprintln(Stdout, applyPersonality(HelpFooter))
+	fmt.Fprintln(Stdout)
+	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpAllFooter))
 }
 
 func printHelpFooter() {

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -221,7 +221,7 @@ the system that is running them.
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
 
 	// can be overridden in derivative projects
-	PebbleHelpAllFooterText  = strings.TrimSpace(`
+	PebbleHelpAllFooterText = strings.TrimSpace(`
 Set the PEBBLE environment variable to override the configuration directory
 (which defaults to {{.DefaultDir}}). Set PEBBLE_SOCKET to override
 the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -221,7 +221,7 @@ the system that is running them.
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
 
 	// can be overridden in derivative projects
-	PebbleHelpAllFooterText = strings.TrimSpace(`
+	FooterHelp = strings.TrimSpace(`
 Set the PEBBLE environment variable to override the configuration directory
 (which defaults to {{.DefaultDir}}). Set PEBBLE_SOCKET to override
 the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
@@ -241,7 +241,7 @@ func printHelpHeader() {
 
 func printHelpAllFooter() {
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(PebbleHelpAllFooterText+"\n\n"+pebbleHelpAllFooter))
+	fmt.Fprintln(Stdout, applyPersonality(FooterHelp+"\n\n"+pebbleHelpAllFooter))
 }
 
 func printHelpFooter() {

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -219,12 +219,16 @@ the system that is running them.
 `)
 	pebbleUsage               = "Usage: {{.ProgramName}} <command> [<options>...]"
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
-	pebbleHelpAllFooter       = "Set the PEBBLE environment variable to override the configuration directory \n" +
-		"(which defaults to " + defaultPebbleDir + "). Set PEBBLE_SOCKET to override \n" +
-		"the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).\n" +
-		"\n" +
-		"For more information about a command, run '{{.ProgramName}} help <command>'."
-	pebbleHelpFooter = "For a short summary of all commands, run '{{.ProgramName}} help --all'."
+
+	// can be overridden in derivative projects
+	PebbleHelpAllFooterText  = strings.TrimSpace(`
+Set the PEBBLE environment variable to override the configuration directory
+(which defaults to {{.DefaultDir}}). Set PEBBLE_SOCKET to override
+the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
+`)
+
+	pebbleHelpAllFooter = "For more information about a command, run '{{.ProgramName}} help <command>'."
+	pebbleHelpFooter    = "For a short summary of all commands, run '{{.ProgramName}} help --all'."
 )
 
 func printHelpHeader() {
@@ -237,7 +241,7 @@ func printHelpHeader() {
 
 func printHelpAllFooter() {
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpAllFooter))
+	fmt.Fprintln(Stdout, applyPersonality(PebbleHelpAllFooterText+"\n\n"+pebbleHelpAllFooter))
 }
 
 func printHelpFooter() {

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -231,23 +231,23 @@ the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
 )
 
 func printHelpHeader() {
-	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(HelpHeader))
+	fmt.Fprintln(Stdout, applyPersonality(HelpHeader))
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleUsage))
+	fmt.Fprintln(Stdout, applyPersonality(pebbleUsage))
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleHelpCategoriesIntro))
+	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpCategoriesIntro))
 }
 
 func printHelpAllFooter() {
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(HelpFooter))
+	fmt.Fprintln(Stdout, applyPersonality(HelpFooter))
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleHelpAllFooter))
+	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpAllFooter))
 }
 
 func printHelpFooter() {
 	printHelpAllFooter()
-	fmt.Fprintln(Stdout, cmdpkg.ApplyPersonality(pebbleHelpFooter))
+	fmt.Fprintln(Stdout, applyPersonality(pebbleHelpFooter))
 }
 
 // this is called when the Execute returns a flags.Error with ErrCommandRequired

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -213,15 +213,14 @@ var HelpCategories = []HelpCategory{{
 }}
 
 var (
-	longPebbleDescription = strings.TrimSpace(`
+	HelpHeader = strings.TrimSpace(`
 {{.DisplayName}} lets you control services and perform management actions on
 the system that is running them.
 `)
 	pebbleUsage               = "Usage: {{.ProgramName}} <command> [<options>...]"
 	pebbleHelpCategoriesIntro = "Commands can be classified as follows:"
 
-	// can be overridden in derivative projects
-	FooterHelp = strings.TrimSpace(`
+	HelpFooter = strings.TrimSpace(`
 Set the PEBBLE environment variable to override the configuration directory
 (which defaults to {{.DefaultDir}}). Set PEBBLE_SOCKET to override
 the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
@@ -232,7 +231,7 @@ the unix socket used for the API (defaults to $PEBBLE/.pebble.socket).
 )
 
 func printHelpHeader() {
-	fmt.Fprintln(Stdout, applyPersonality(longPebbleDescription))
+	fmt.Fprintln(Stdout, applyPersonality(HelpHeader))
 	fmt.Fprintln(Stdout)
 	fmt.Fprintln(Stdout, applyPersonality(pebbleUsage))
 	fmt.Fprintln(Stdout)
@@ -241,7 +240,7 @@ func printHelpHeader() {
 
 func printHelpAllFooter() {
 	fmt.Fprintln(Stdout)
-	fmt.Fprintln(Stdout, applyPersonality(FooterHelp+"\n\n"+pebbleHelpAllFooter))
+	fmt.Fprintln(Stdout, applyPersonality(HelpFooter+"\n\n"+pebbleHelpAllFooter))
 }
 
 func printHelpFooter() {


### PR DESCRIPTION
Just like `ProgramName` and `DisplayName` can already be customized via public vars in the `cmd` package, `DefaultDir` also looks like a perfect candidate to customize this way (and assembling the help text can then be done using `{{.DefaultDir}}`).

In addition, `cli.HelpHeader` and `cli.HelpFooter` are made public, so that they can be extended and overridden.