### PR TITLE
feat(plan): disable KnownFields for YAML unmarshal

### DIFF
--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1020,7 +1020,6 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		LogTargets: map[string]*LogTarget{},
 	}
 	dec := yaml.NewDecoder(bytes.NewBuffer(data))
-	dec.KnownFields(true)
 	err := dec.Decode(&layer)
 	if err != nil {
 		return nil, &FormatError{

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -396,16 +396,6 @@ var planTests = []planTest{{
 		LogTargets: map[string]*plan.LogTarget{},
 	}},
 }, {
-	summary: "Unknown keys are not accepted",
-	error:   "(?s).*field future not found.*",
-	input: []string{`
-		services:
-			srv1:
-				future: true
-				override: replace
-				command: cmd
-	`},
-}, {
 	summary: `Cannot use service name "pebble"`,
 	error:   `cannot use reserved service name "pebble"`,
 	input: []string{`


### PR DESCRIPTION
Disable YAML KnownFields during plan unmarshal, so that we align with the general Pebble JSON unmarshal strategy (DisallowUnknownFields is false)

Pebble currently sets KnownFields=true when loading the configuration layers, or when parsing a layer supplied over the daemon server API.

The result of this is strict attribute checking. An unmarshal error will be reported if any attribute present in the YAML does not exist in the backing code structure.

This option trades forward/backwards compatibility for user input error detection. This may have been the best choice up until this point in time.

However, Pebble is getting used in derivative projects where the ability for the derivative binary to cope with an earlier or later plan revision YAML data will make it more robust against upgrades and downgrades.

Since this relaxes the unmarshal rules, this will be backwards compatible in all existing non-error use-cases. Any existing tests expecting an error from Pebble will have to be updated/removed.

This would also align with how JSON decoding is done in Pebble (since we never set DisallowUnknownFields).