### PR TITLE
feat(cli): new Info category for help, version

### DIFF
--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -185,7 +185,11 @@ type HelpCategory struct {
 var HelpCategories = []HelpCategory{{
 	Label:       "Run",
 	Description: "run the service manager",
-	Commands:    []string{"run", "help", "version"},
+	Commands:    []string{"run"},
+}, {
+	Label:       "Info",
+	Description: "help and version information",
+	Commands:    []string{"help", "version"},
 }, {
 	Label:       "Plan",
 	Description: "view and change configuration",


### PR DESCRIPTION
The commands `help` and `version` are not related to running the service manager (you can run `help` also for client help, and `version` prints both the client and the server version). This splits those two commands into a new "Info" category, leaving only the `run` command in the "Run" category.