### PR TITLE
feat(client): add change-update notice type

### DIFF
--- a/client/notices.go
+++ b/client/notices.go
@@ -122,6 +122,10 @@ type Notice struct {
 type NoticeType string
 
 const (
+	// Recorded whenever a change is updated: when it is first spawned or its
+	// status was updated. The key for change-update notices is the change ID.
+	ChangeUpdateNotice NoticeType = "change-update"
+
 	// A custom notice reported via the Pebble client API or "pebble notify".
 	// The key and data fields are provided by the user. The key must be in
 	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.

--- a/client/notices_test.go
+++ b/client/notices_test.go
@@ -28,7 +28,7 @@ import (
 
 func (cs *clientSuite) TestNotice(c *C) {
 	cs.rsp = `{"type": "sync", "result": {
-		"id":   "123",
+		"id": "123",
 		"user-id": 1000,
 		"type": "custom",
 		"key": "a.b/c",
@@ -55,6 +55,32 @@ func (cs *clientSuite) TestNotice(c *C) {
 		LastData:      map[string]string{"k": "v"},
 		RepeatAfter:   time.Hour,
 		ExpireAfter:   7 * 24 * time.Hour,
+	})
+}
+
+func (cs *clientSuite) TestChangeUpdateNotice(c *C) {
+	cs.rsp = `{"type": "sync", "result": {
+		"id": "456",
+		"user-id": 1001,
+		"type": "change-update",
+		"key": "42",
+		"first-occurred": "2024-09-05T15:43:00.123Z",
+		"last-occurred": "2024-09-05T17:43:00.567Z",
+		"last-repeated": "2024-09-05T16:43:00Z",
+		"occurrences": 3
+	}}`
+	notice, err := cs.cli.Notice("123")
+	c.Assert(err, IsNil)
+	uid := uint32(1001)
+	c.Assert(notice, DeepEquals, &client.Notice{
+		ID:            "456",
+		UserID:        &uid,
+		Type:          client.ChangeUpdateNotice,
+		Key:           "42",
+		FirstOccurred: time.Date(2024, 9, 5, 15, 43, 0, 123_000_000, time.UTC),
+		LastOccurred:  time.Date(2024, 9, 5, 17, 43, 0, 567_000_000, time.UTC),
+		LastRepeated:  time.Date(2024, 9, 5, 16, 43, 0, 0, time.UTC),
+		Occurrences:   3,
 	})
 }
 

--- a/client/notices_test.go
+++ b/client/notices_test.go
@@ -58,32 +58,6 @@ func (cs *clientSuite) TestNotice(c *C) {
 	})
 }
 
-func (cs *clientSuite) TestChangeUpdateNotice(c *C) {
-	cs.rsp = `{"type": "sync", "result": {
-		"id": "456",
-		"user-id": 1001,
-		"type": "change-update",
-		"key": "42",
-		"first-occurred": "2024-09-05T15:43:00.123Z",
-		"last-occurred": "2024-09-05T17:43:00.567Z",
-		"last-repeated": "2024-09-05T16:43:00Z",
-		"occurrences": 3
-	}}`
-	notice, err := cs.cli.Notice("123")
-	c.Assert(err, IsNil)
-	uid := uint32(1001)
-	c.Assert(notice, DeepEquals, &client.Notice{
-		ID:            "456",
-		UserID:        &uid,
-		Type:          client.ChangeUpdateNotice,
-		Key:           "42",
-		FirstOccurred: time.Date(2024, 9, 5, 15, 43, 0, 123_000_000, time.UTC),
-		LastOccurred:  time.Date(2024, 9, 5, 17, 43, 0, 567_000_000, time.UTC),
-		LastRepeated:  time.Date(2024, 9, 5, 16, 43, 0, 0, time.UTC),
-		Occurrences:   3,
-	})
-}
-
 func (cs *clientSuite) TestNoticeInvalidID(c *C) {
 	_, err := cs.cli.Notice("<boo>")
 	c.Assert(err, ErrorMatches, "invalid notice ID.*")


### PR DESCRIPTION
Just the addition of the constant.

This was missed earlier when adding the change-update notice.