### PR TITLE
feat: make layers with label prefix "pebble-" reserved

### DIFF
--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -208,7 +208,7 @@ func (m *PlanManager) SetServiceArgs(serviceArgs map[string][]string) error {
 	defer m.planLock.Unlock()
 
 	newLayer := &plan.Layer{
-		// Labels with "pebble-*" prefix are (will be) reserved, see:
+		// Labels with "pebble-*" prefix are reserved, see:
 		// https://github.com/canonical/pebble/issues/220
 		Label:    "pebble-service-args",
 		Services: make(map[string]*plan.Service),
@@ -231,7 +231,11 @@ func (m *PlanManager) SetServiceArgs(serviceArgs map[string][]string) error {
 
 	err := newLayer.Validate()
 	if err != nil {
-		return err
+		if _, ok := err.(*plan.ReservedLabelError); ok {
+			// Labels with "pebble-*" prefix are reserved.
+		} else {
+			return err
+		}
 	}
 
 	return m.appendLayer(newLayer)

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -229,14 +229,8 @@ func (m *PlanManager) SetServiceArgs(serviceArgs map[string][]string) error {
 		}
 	}
 
-	err := newLayer.Validate()
-	if err != nil {
-		if _, ok := err.(*plan.ReservedLabelError); ok {
-			// Labels with "pebble-*" prefix are reserved.
-		} else {
-			return err
-		}
-	}
+	// We have added validation for layer labels (pebble-* prefix is reserved),
+	// so after creating the Layer directly, we don't validate it any more.
 
 	return m.appendLayer(newLayer)
 }

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -210,6 +210,8 @@ func (m *PlanManager) SetServiceArgs(serviceArgs map[string][]string) error {
 	newLayer := &plan.Layer{
 		// Labels with "pebble-*" prefix are reserved, see:
 		// https://github.com/canonical/pebble/issues/220
+		// Validation for layer labels has been added, so after so after creating the
+		// Layer directly (not parsing from raw data), it won't need to be validated.
 		Label:    "pebble-service-args",
 		Services: make(map[string]*plan.Service),
 	}
@@ -228,9 +230,6 @@ func (m *PlanManager) SetServiceArgs(serviceArgs map[string][]string) error {
 			Command:  plan.CommandString(base, args),
 		}
 	}
-
-	// We have added validation for layer labels (pebble-* prefix is reserved),
-	// so after creating the Layer directly, we don't validate it any more.
 
 	return m.appendLayer(newLayer)
 }

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -208,10 +208,9 @@ func (m *PlanManager) SetServiceArgs(serviceArgs map[string][]string) error {
 	defer m.planLock.Unlock()
 
 	newLayer := &plan.Layer{
-		// Labels with "pebble-*" prefix are reserved, see:
-		// https://github.com/canonical/pebble/issues/220
-		// Validation for layer labels has been added, so after so after creating the
-		// Layer directly (not parsing from raw data), it won't need to be validated.
+		// Labels with "pebble-*" prefix are reserved for use by Pebble.
+		// Layer.Validate() ensures this, so skip calling that because we're creating the
+		// Layer directly, not parsing from user input.
 		Label:    "pebble-service-args",
 		Services: make(map[string]*plan.Service),
 	}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -687,6 +687,12 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 // See also Plan.Validate, which does additional checks based on the combined
 // layers.
 func (layer *Layer) Validate() error {
+	if strings.HasPrefix(layer.Label, "pebble-") {
+		return &FormatError{
+			Message: `cannot use reserved label prefix "pebble-"`,
+		}
+	}
+
 	for name, service := range layer.Services {
 		if name == "" {
 			return &FormatError{
@@ -816,12 +822,6 @@ func (layer *Layer) Validate() error {
 				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
 					name, target.Type, LokiTarget, SyslogTarget),
 			}
-		}
-	}
-
-	if strings.HasPrefix(layer.Label, "pebble-") {
-		return &FormatError{
-			Message: fmt.Sprintf("cannot use reserved layer label %q", layer.Label),
 		}
 	}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -549,16 +549,6 @@ func (e *FormatError) Error() string {
 	return e.Message
 }
 
-// ReservedLabelError is the error returned when a layer label has the reserved
-// prefix "pebble-", such as "pebble-foo-bar".
-type ReservedLabelError struct {
-	Message string
-}
-
-func (e *ReservedLabelError) Error() string {
-	return e.Message
-}
-
 // CombineLayers combines the given layers into a single layer, with the later
 // layers overriding earlier ones.
 // Neither the individual layers nor the combined layer are validated here - the
@@ -830,7 +820,7 @@ func (layer *Layer) Validate() error {
 	}
 
 	if strings.HasPrefix(layer.Label, "pebble-") {
-		return &ReservedLabelError{
+		return &FormatError{
 			Message: fmt.Sprintf("cannot use reserved layer label %q", layer.Label),
 		}
 	}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -549,6 +549,16 @@ func (e *FormatError) Error() string {
 	return e.Message
 }
 
+// ReservedLabelError is the error returned when a layer label has the reserved
+// prefix "pebble-", such as "pebble-foo-bar".
+type ReservedLabelError struct {
+	Message string
+}
+
+func (e *ReservedLabelError) Error() string {
+	return e.Message
+}
+
 // CombineLayers combines the given layers into a single layer, with the later
 // layers overriding earlier ones.
 // Neither the individual layers nor the combined layer are validated here - the
@@ -816,6 +826,12 @@ func (layer *Layer) Validate() error {
 				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
 					name, target.Type, LokiTarget, SyslogTarget),
 			}
+		}
+	}
+
+	if strings.HasPrefix(layer.Label, "pebble-") {
+		return &ReservedLabelError{
+			Message: fmt.Sprintf("cannot use reserved layer label %q", layer.Label),
 		}
 	}
 

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1936,7 +1936,7 @@ func (s *S) TestMergeServiceContextOverrides(c *C) {
 
 func (s *S) TestValidateLayerReservedLabel(c *C) {
 	newLayer := &plan.Layer{
-		// Labels with "pebble-*" are reserved,
+		// Labels with "pebble-*" prefix are reserved,
 		Label:    "pebble-service-args",
 		Services: make(map[string]*plan.Service),
 	}
@@ -1945,7 +1945,7 @@ func (s *S) TestValidateLayerReservedLabel(c *C) {
 }
 
 func (s *S) TestParseLayerReservedLabel(c *C) {
-	// Validate fails if layer label has prefix "pebble-"
+	// Validate fails if layer label has the reserved prefix "pebble-"
 	_, err := plan.ParseLayer(0, "pebble-service-args", []byte("{}"))
 	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-service-args"`)
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1933,3 +1933,19 @@ func (s *S) TestMergeServiceContextOverrides(c *C) {
 		WorkingDir:  "/working/dir",
 	})
 }
+
+func (s *S) TestValidateLayerReservedLabel(c *C) {
+	newLayer := &plan.Layer{
+		// Labels with "pebble-*" are reserved,
+		Label:    "pebble-service-args",
+		Services: make(map[string]*plan.Service),
+	}
+	err := newLayer.Validate()
+	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-service-args"`)
+}
+
+func (s *S) TestParseLayerReservedLabel(c *C) {
+	// Validate fails if layer label has prefix "pebble-"
+	_, err := plan.ParseLayer(0, "pebble-service-args", []byte("{}"))
+	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-service-args"`)
+}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1934,8 +1934,8 @@ func (s *S) TestMergeServiceContextOverrides(c *C) {
 	})
 }
 
-func (s *S) TestParseLayerReservedLabel(c *C) {
+func (s *S) TestPebbleLabelPrefixReserved(c *C) {
 	// Validate fails if layer label has the reserved prefix "pebble-"
-	_, err := plan.ParseLayer(0, "pebble-service-args", []byte("{}"))
-	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-service-args"`)
+	_, err := plan.ParseLayer(0, "pebble-foo", []byte("{}"))
+	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-foo"`)
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1937,5 +1937,5 @@ func (s *S) TestMergeServiceContextOverrides(c *C) {
 func (s *S) TestPebbleLabelPrefixReserved(c *C) {
 	// Validate fails if layer label has the reserved prefix "pebble-"
 	_, err := plan.ParseLayer(0, "pebble-foo", []byte("{}"))
-	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-foo"`)
+	c.Check(err, ErrorMatches, `cannot use reserved label prefix "pebble-"`)
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1934,16 +1934,6 @@ func (s *S) TestMergeServiceContextOverrides(c *C) {
 	})
 }
 
-func (s *S) TestValidateLayerReservedLabel(c *C) {
-	newLayer := &plan.Layer{
-		// Labels with "pebble-*" prefix are reserved,
-		Label:    "pebble-service-args",
-		Services: make(map[string]*plan.Service),
-	}
-	err := newLayer.Validate()
-	c.Check(err, ErrorMatches, `cannot use reserved layer label "pebble-service-args"`)
-}
-
 func (s *S) TestParseLayerReservedLabel(c *C) {
 	// Validate fails if layer label has the reserved prefix "pebble-"
 	_, err := plan.ParseLayer(0, "pebble-service-args", []byte("{}"))


### PR DESCRIPTION
Making layers with label "pebble-*" reserved for pebble use only.

Closes https://github.com/canonical/pebble/issues/220.

Test:

```$ tree $PEBBLE
/home/ubuntu/PEBBLE_HOME
└── layers
    └── 001-pebble-test.yaml

1 directory, 1 file
$ go run ./cmd/pebble run
cannot run daemon: cannot load plan: cannot use reserved layer label "pebble-test"
exit status 1
```