### PR TITLE
feat: client side change id validation

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -198,8 +198,8 @@ type WaitChangeOptions struct {
 // succeeds, the returned Change.Err string will be non-empty if the change
 // itself had an error.
 func (client *Client) WaitChange(id string, opts *WaitChangeOptions) (*Change, error) {
-	if err := validateChangeID(id); err != nil {
-		return nil, err
+	if !changeIDRegexp.MatchString(id) {
+		return nil, fmt.Errorf("invalid change ID %q", id)
 	}
 
 	var chgd changeAndData

--- a/client/changes.go
+++ b/client/changes.go
@@ -87,24 +87,16 @@ type changeAndData struct {
 	Data map[string]*json.RawMessage `json:"data"`
 }
 
-func validateChangeID(id string) error {
-	// This is used to ensure we send a well-formed change ID in the URL path.
-	// It's a little more permissive than the currently-valid change IDs (which
-	// are always integers), but it will allow older clients to talk to newer
-	// servers which might start allowing letters too (for example).
-	var changeIDRegexp = regexp.MustCompile(`^[a-z0-9]+$`)
-
-	if changeIDRegexp.MatchString(id) {
-		return nil
-	} else {
-		return fmt.Errorf("invalid change ID %q", id)
-	}
-}
+// This is used to ensure we send a well-formed change ID in the URL path.
+// It's a little more permissive than the currently-valid change IDs (which
+// are always integers), but it will allow older clients to talk to newer
+// servers which might start allowing letters too (for example).
+var changeIDRegexp = regexp.MustCompile(`^[a-z0-9]+$`)
 
 // Change fetches information about a Change given its ID.
 func (client *Client) Change(id string) (*Change, error) {
-	if err := validateChangeID(id); err != nil {
-		return nil, err
+	if !changeIDRegexp.MatchString(id) {
+		return nil, fmt.Errorf("invalid change ID %q", id)
 	}
 
 	var chgd changeAndData
@@ -119,8 +111,8 @@ func (client *Client) Change(id string) (*Change, error) {
 
 // Abort attempts to abort a change that is not yet ready.
 func (client *Client) Abort(id string) (*Change, error) {
-	if err := validateChangeID(id); err != nil {
-		return nil, err
+	if !changeIDRegexp.MatchString(id) {
+		return nil, fmt.Errorf("invalid change ID %q", id)
 	}
 
 	var postData struct {

--- a/client/changes_test.go
+++ b/client/changes_test.go
@@ -271,3 +271,18 @@ func (cs *clientSuite) TestClientAbort(c *check.C) {
 
 	c.Assert(string(body), check.Equals, "{\"action\":\"abort\"}\n")
 }
+
+func (cs *clientSuite) TestChangeInvalidID(c *check.C) {
+	_, err := cs.cli.Change("select * from users;")
+	c.Assert(err, check.ErrorMatches, "invalid change ID.*")
+}
+
+func (cs *clientSuite) TestAbortInvalidID(c *check.C) {
+	_, err := cs.cli.Abort("<foo>")
+	c.Assert(err, check.ErrorMatches, "invalid change ID.*")
+}
+
+func (cs *clientSuite) TestWaitChangeInvalidID(c *check.C) {
+	_, err := cs.cli.WaitChange("$bar", nil)
+	c.Assert(err, check.ErrorMatches, "invalid change ID.*")
+}


### PR DESCRIPTION
Add client-side validation for change ID used in URLs.

Closes https://github.com/canonical/pebble/issues/318.