### PR TITLE
fix: add chmod to mkdir to ignore umask settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,9 @@ jobs:
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^filesSuite\.TestMakeDirsUserGroupReal$
         go test -c ./internals/overlord/servstate/
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./servstate.test -check.v -check.f ^S.TestUserGroup$
+        go test -c ./internals/osutil
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./osutil.test -check.v -check.f ^mkdacSuite\.TestMkdirChownWithMkdirFlagsAndChown$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./osutil.test -check.v -check.f ^mkdacSuite\.TestMkdirAllChownWithMkdirFlagsAndChown$
 
   format:
     runs-on: ubuntu-latest

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -168,7 +168,7 @@ func writeWarningTimestamp(t time.Time) error {
 
 	// FIXME Keep track of this data on a per-user+per-pebble socket basis.
 	filename := warnFilename(user.HomeDir)
-	if err := osutil.MkdirAllChown(filepath.Dir(filename), 0700, uid, gid); err != nil {
+	if err := osutil.MkdirAllChown(filepath.Dir(filename), 0700, 0, uid, gid); err != nil {
 		return err
 	}
 

--- a/internals/daemon/api_files.go
+++ b/internals/daemon/api_files.go
@@ -481,7 +481,7 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 
 	// Create parent directory if needed.
 	if item.MakeDirs {
-		err := mkdirAllUserGroup(pathpkg.Dir(item.Path), 0o755, osutil.AtomicWriteChmod, uid, gid)
+		err := mkdirAllUserGroup(pathpkg.Dir(item.Path), 0o755, osutil.MkdirChmod, uid, gid)
 		if err != nil {
 			return fmt.Errorf("cannot create directory: %w", err)
 		}
@@ -499,7 +499,7 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 	return atomicWriteChown(item.Path, source, perm, osutil.AtomicWriteChmod, sysUid, sysGid)
 }
 
-func mkdirAllUserGroup(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid, gid *int) error {
+func mkdirAllUserGroup(path string, perm os.FileMode, flags osutil.MkdirFlags, uid, gid *int) error {
 	if uid != nil && gid != nil {
 		return mkdirAllChown(path, perm, flags, sys.UserID(*uid), sys.GroupID(*gid))
 	} else {
@@ -507,7 +507,7 @@ func mkdirAllUserGroup(path string, perm os.FileMode, flags osutil.AtomicWriteFl
 	}
 }
 
-func mkdirUserGroup(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid, gid *int) error {
+func mkdirUserGroup(path string, perm os.FileMode, flags osutil.MkdirFlags, uid, gid *int) error {
 	if uid != nil && gid != nil {
 		return mkdirChown(path, perm, flags, sys.UserID(*uid), sys.GroupID(*gid))
 	} else {
@@ -563,9 +563,9 @@ func makeDir(dir makeDirsItem) error {
 		return fmt.Errorf("cannot look up user and group: %w", err)
 	}
 	if dir.MakeParents {
-		err = mkdirAllUserGroup(dir.Path, perm, osutil.AtomicWriteChmod, uid, gid)
+		err = mkdirAllUserGroup(dir.Path, perm, osutil.MkdirChmod, uid, gid)
 	} else {
-		err = mkdirUserGroup(dir.Path, perm, osutil.AtomicWriteChmod, uid, gid)
+		err = mkdirUserGroup(dir.Path, perm, osutil.MkdirChmod, uid, gid)
 	}
 	if err != nil {
 		return err

--- a/internals/daemon/api_files.go
+++ b/internals/daemon/api_files.go
@@ -481,7 +481,7 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 
 	// Create parent directory if needed.
 	if item.MakeDirs {
-		err := mkdirAllUserGroup(pathpkg.Dir(item.Path), 0o755, uid, gid)
+		err := mkdirAllUserGroup(pathpkg.Dir(item.Path), 0o755, osutil.AtomicWriteChmod, uid, gid)
 		if err != nil {
 			return fmt.Errorf("cannot create directory: %w", err)
 		}
@@ -499,19 +499,19 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 	return atomicWriteChown(item.Path, source, perm, osutil.AtomicWriteChmod, sysUid, sysGid)
 }
 
-func mkdirAllUserGroup(path string, perm os.FileMode, uid, gid *int) error {
+func mkdirAllUserGroup(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid, gid *int) error {
 	if uid != nil && gid != nil {
-		return mkdirAllChown(path, perm, sys.UserID(*uid), sys.GroupID(*gid))
+		return mkdirAllChown(path, perm, flags, sys.UserID(*uid), sys.GroupID(*gid))
 	} else {
-		return mkdirAllChown(path, perm, osutil.NoChown, osutil.NoChown)
+		return mkdirAllChown(path, perm, flags, osutil.NoChown, osutil.NoChown)
 	}
 }
 
-func mkdirUserGroup(path string, perm os.FileMode, uid, gid *int) error {
+func mkdirUserGroup(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid, gid *int) error {
 	if uid != nil && gid != nil {
-		return mkdirChown(path, perm, sys.UserID(*uid), sys.GroupID(*gid))
+		return mkdirChown(path, perm, flags, sys.UserID(*uid), sys.GroupID(*gid))
 	} else {
-		return mkdirChown(path, perm, osutil.NoChown, osutil.NoChown)
+		return mkdirChown(path, perm, flags, osutil.NoChown, osutil.NoChown)
 	}
 }
 
@@ -563,9 +563,9 @@ func makeDir(dir makeDirsItem) error {
 		return fmt.Errorf("cannot look up user and group: %w", err)
 	}
 	if dir.MakeParents {
-		err = mkdirAllUserGroup(dir.Path, perm, uid, gid)
+		err = mkdirAllUserGroup(dir.Path, perm, osutil.AtomicWriteChmod, uid, gid)
 	} else {
-		err = mkdirUserGroup(dir.Path, perm, uid, gid)
+		err = mkdirUserGroup(dir.Path, perm, osutil.AtomicWriteChmod, uid, gid)
 	}
 	if err != nil {
 		return err

--- a/internals/daemon/api_files_test.go
+++ b/internals/daemon/api_files_test.go
@@ -448,12 +448,12 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	type args struct {
 		path  string
 		perm  os.FileMode
-		flags osutil.AtomicWriteFlags
+		flags osutil.MkdirFlags
 		uid   sys.UserID
 		gid   sys.GroupID
 	}
 	var mkdirChownCalls []args
-	mkdirChown = func(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) error {
+	mkdirChown = func(path string, perm os.FileMode, flags osutil.MkdirFlags, uid sys.UserID, gid sys.GroupID) error {
 		mkdirChownCalls = append(mkdirChownCalls, args{path, perm, flags, uid, gid})
 		return os.Mkdir(path, perm)
 	}
@@ -472,7 +472,7 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	}
 
 	var mkdirAllChownCalls []args
-	mkdirAllChown = func(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) error {
+	mkdirAllChown = func(path string, perm os.FileMode, flags osutil.MkdirFlags, uid sys.UserID, gid sys.GroupID) error {
 		mkdirAllChownCalls = append(mkdirAllChownCalls, args{path, perm, flags, uid, gid})
 		return os.MkdirAll(path, perm)
 	}
@@ -486,13 +486,13 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	tmpDir := s.testMakeDirsUserGroup(c, 12, 34, "USER", "GROUP")
 
 	c.Assert(mkdirChownCalls, HasLen, 3)
-	c.Check(mkdirChownCalls[0], Equals, args{tmpDir + "/normal", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown})
-	c.Check(mkdirChownCalls[1], Equals, args{tmpDir + "/uid-gid", 0o755, osutil.AtomicWriteChmod, 12, 34})
-	c.Check(mkdirChownCalls[2], Equals, args{tmpDir + "/user-group", 0o755, osutil.AtomicWriteChmod, 56, 78})
+	c.Check(mkdirChownCalls[0], Equals, args{tmpDir + "/normal", 0o755, osutil.MkdirChmod, osutil.NoChown, osutil.NoChown})
+	c.Check(mkdirChownCalls[1], Equals, args{tmpDir + "/uid-gid", 0o755, osutil.MkdirChmod, 12, 34})
+	c.Check(mkdirChownCalls[2], Equals, args{tmpDir + "/user-group", 0o755, osutil.MkdirChmod, 56, 78})
 
 	c.Assert(mkdirAllChownCalls, HasLen, 2)
-	c.Check(mkdirAllChownCalls[0], Equals, args{tmpDir + "/nested1/normal", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown})
-	c.Check(mkdirAllChownCalls[1], Equals, args{tmpDir + "/nested2/user-group", 0o755, osutil.AtomicWriteChmod, 56, 78})
+	c.Check(mkdirAllChownCalls[0], Equals, args{tmpDir + "/nested1/normal", 0o755, osutil.MkdirChmod, osutil.NoChown, osutil.NoChown})
+	c.Check(mkdirAllChownCalls[1], Equals, args{tmpDir + "/nested2/user-group", 0o755, osutil.MkdirChmod, 56, 78})
 }
 
 func (s *filesSuite) testMakeDirsUserGroup(c *C, uid, gid int, user, group string) string {
@@ -966,7 +966,7 @@ func (s *filesSuite) TestWriteUserGroupMocked(c *C) {
 	}
 
 	var mkdirAllChownCalls []args
-	mkdirAllChown = func(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) error {
+	mkdirAllChown = func(path string, perm os.FileMode, flags osutil.MkdirFlags, uid sys.UserID, gid sys.GroupID) error {
 		mkdirAllChownCalls = append(mkdirAllChownCalls, args{path, perm, uid, gid})
 		return os.MkdirAll(path, perm)
 	}

--- a/internals/daemon/api_files_test.go
+++ b/internals/daemon/api_files_test.go
@@ -446,14 +446,15 @@ func (s *filesSuite) TestMakeDirsMultiple(c *C) {
 
 func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	type args struct {
-		path string
-		perm os.FileMode
-		uid  sys.UserID
-		gid  sys.GroupID
+		path  string
+		perm  os.FileMode
+		flags osutil.AtomicWriteFlags
+		uid   sys.UserID
+		gid   sys.GroupID
 	}
 	var mkdirChownCalls []args
-	mkdirChown = func(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
-		mkdirChownCalls = append(mkdirChownCalls, args{path, perm, uid, gid})
+	mkdirChown = func(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) error {
+		mkdirChownCalls = append(mkdirChownCalls, args{path, perm, flags, uid, gid})
 		return os.Mkdir(path, perm)
 	}
 
@@ -471,8 +472,8 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	}
 
 	var mkdirAllChownCalls []args
-	mkdirAllChown = func(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
-		mkdirAllChownCalls = append(mkdirAllChownCalls, args{path, perm, uid, gid})
+	mkdirAllChown = func(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) error {
+		mkdirAllChownCalls = append(mkdirAllChownCalls, args{path, perm, flags, uid, gid})
 		return os.MkdirAll(path, perm)
 	}
 
@@ -485,13 +486,13 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	tmpDir := s.testMakeDirsUserGroup(c, 12, 34, "USER", "GROUP")
 
 	c.Assert(mkdirChownCalls, HasLen, 3)
-	c.Check(mkdirChownCalls[0], Equals, args{tmpDir + "/normal", 0o755, osutil.NoChown, osutil.NoChown})
-	c.Check(mkdirChownCalls[1], Equals, args{tmpDir + "/uid-gid", 0o755, 12, 34})
-	c.Check(mkdirChownCalls[2], Equals, args{tmpDir + "/user-group", 0o755, 56, 78})
+	c.Check(mkdirChownCalls[0], Equals, args{tmpDir + "/normal", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown})
+	c.Check(mkdirChownCalls[1], Equals, args{tmpDir + "/uid-gid", 0o755, osutil.AtomicWriteChmod, 12, 34})
+	c.Check(mkdirChownCalls[2], Equals, args{tmpDir + "/user-group", 0o755, osutil.AtomicWriteChmod, 56, 78})
 
 	c.Assert(mkdirAllChownCalls, HasLen, 2)
-	c.Check(mkdirAllChownCalls[0], Equals, args{tmpDir + "/nested1/normal", 0o755, osutil.NoChown, osutil.NoChown})
-	c.Check(mkdirAllChownCalls[1], Equals, args{tmpDir + "/nested2/user-group", 0o755, 56, 78})
+	c.Check(mkdirAllChownCalls[0], Equals, args{tmpDir + "/nested1/normal", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown})
+	c.Check(mkdirAllChownCalls[1], Equals, args{tmpDir + "/nested2/user-group", 0o755, osutil.AtomicWriteChmod, 56, 78})
 }
 
 func (s *filesSuite) testMakeDirsUserGroup(c *C, uid, gid int, user, group string) string {
@@ -965,7 +966,7 @@ func (s *filesSuite) TestWriteUserGroupMocked(c *C) {
 	}
 
 	var mkdirAllChownCalls []args
-	mkdirAllChown = func(path string, perm os.FileMode, uid sys.UserID, gid sys.GroupID) error {
+	mkdirAllChown = func(path string, perm os.FileMode, flags osutil.AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) error {
 		mkdirAllChownCalls = append(mkdirAllChownCalls, args{path, perm, uid, gid})
 		return os.MkdirAll(path, perm)
 	}

--- a/internals/osutil/mkdirallchown_test.go
+++ b/internals/osutil/mkdirallchown_test.go
@@ -95,21 +95,23 @@ func (mkdacSuite) TestMkdirChownWithMkdirFlags(c *check.C) {
 	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
 }
 
-func (mkdacSuite) TestMkdirChownWithMkdirFlagsAndChown(c *check.C) {
-	tmpDir := c.MkDir()
+// The following test is commented out because it would fail in GitHub Actions, but it would be nice
+// to run them locally to test the other if/else branch of the function MkdirChown.
+// func (mkdacSuite) TestMkdirChownWithMkdirFlagsAndChown(c *check.C) {
+// 	tmpDir := c.MkDir()
 
-	err := osutil.MkdirChown(tmpDir+"/foo", 0o777, osutil.MkdirChmod, 1000, 1000)
-	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+// 	err := osutil.MkdirChown(tmpDir+"/foo", 0o777, osutil.MkdirChmod, 1000, 1000)
+// 	c.Assert(err, check.IsNil)
+// 	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
 
-	info, err := os.Stat(tmpDir + "/foo")
-	c.Assert(err, check.IsNil)
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		c.Assert(int(stat.Uid), check.Equals, 1000)
-		c.Assert(int(stat.Gid), check.Equals, 1000)
-	}
-	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
-}
+// 	info, err := os.Stat(tmpDir + "/foo")
+// 	c.Assert(err, check.IsNil)
+// 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+// 		c.Assert(int(stat.Uid), check.Equals, 1000)
+// 		c.Assert(int(stat.Gid), check.Equals, 1000)
+// 	}
+// 	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
+// }
 
 func (mkdacSuite) TestMkdirAllChownWithoutMkdirFlags(c *check.C) {
 	oldmask := syscall.Umask(0022)
@@ -148,27 +150,29 @@ func (mkdacSuite) TestMkdirAllChownWithMkdirFlags(c *check.C) {
 	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
 }
 
-func (mkdacSuite) TestMkdirAllChownWithMkdirFlagsAndChown(c *check.C) {
-	tmpDir := c.MkDir()
+// The following test is commented out because it would fail in GitHub Actions, but it would be nice
+// to run them locally to test the other if/else branch of the function MkdirAllChown.
+// func (mkdacSuite) TestMkdirAllChownWithMkdirFlagsAndChown(c *check.C) {
+// 	tmpDir := c.MkDir()
 
-	err := osutil.MkdirAllChown(tmpDir+"/foo/bar", 0o777, osutil.MkdirChmod, 1000, 1000)
-	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+// 	err := osutil.MkdirAllChown(tmpDir+"/foo/bar", 0o777, osutil.MkdirChmod, 1000, 1000)
+// 	c.Assert(err, check.IsNil)
+// 	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+// 	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
 
-	info, err := os.Stat(tmpDir + "/foo")
-	c.Assert(err, check.IsNil)
-	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		c.Assert(int(stat.Uid), check.Equals, 1000)
-		c.Assert(int(stat.Gid), check.Equals, 1000)
-	}
+// 	info, err := os.Stat(tmpDir + "/foo")
+// 	c.Assert(err, check.IsNil)
+// 	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
+// 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+// 		c.Assert(int(stat.Uid), check.Equals, 1000)
+// 		c.Assert(int(stat.Gid), check.Equals, 1000)
+// 	}
 
-	info, err = os.Stat(tmpDir + "/foo/bar")
-	c.Assert(err, check.IsNil)
-	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		c.Assert(int(stat.Uid), check.Equals, 1000)
-		c.Assert(int(stat.Gid), check.Equals, 1000)
-	}
-}
+// 	info, err = os.Stat(tmpDir + "/foo/bar")
+// 	c.Assert(err, check.IsNil)
+// 	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
+// 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+// 		c.Assert(int(stat.Uid), check.Equals, 1000)
+// 		c.Assert(int(stat.Gid), check.Equals, 1000)
+// 	}
+// }

--- a/internals/osutil/mkdirallchown_test.go
+++ b/internals/osutil/mkdirallchown_test.go
@@ -36,7 +36,7 @@ func (mkdacSuite) TestSlashySlashy(c *check.C) {
 		d := c.MkDir()
 		// just in case
 		c.Assert(strings.HasSuffix(d, "/"), check.Equals, false)
-		err := osutil.MkdirAllChown(d+dir, 0755, osutil.NoChown, osutil.NoChown)
+		err := osutil.MkdirAllChown(d+dir, 0755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown)
 		c.Assert(err, check.IsNil, check.Commentf("%q", dir))
 	}
 }
@@ -46,22 +46,22 @@ func (mkdacSuite) TestSlashySlashy(c *check.C) {
 func (mkdacSuite) TestMkdirAllChown(c *check.C) {
 	tmpDir := c.MkDir()
 
-	err := osutil.MkdirAllChown(tmpDir+"/foo/bar", 0o755, osutil.NoChown, osutil.NoChown)
+	err := osutil.MkdirAllChown(tmpDir+"/foo/bar", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, check.IsNil)
 	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
 	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
 
-	err = osutil.MkdirChown(tmpDir+"/foo/bar", 0o755, osutil.NoChown, osutil.NoChown)
+	err = osutil.MkdirChown(tmpDir+"/foo/bar", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
 }
 
 func (mkdacSuite) TestMkdirChown(c *check.C) {
 	tmpDir := c.MkDir()
 
-	err := osutil.MkdirChown(tmpDir+"/foo", 0o755, osutil.NoChown, osutil.NoChown)
+	err := osutil.MkdirChown(tmpDir+"/foo", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, check.IsNil)
 	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
 
-	err = osutil.MkdirChown(tmpDir+"/foo", 0o755, osutil.NoChown, osutil.NoChown)
+	err = osutil.MkdirChown(tmpDir+"/foo", 0o755, osutil.AtomicWriteChmod, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
 }


### PR DESCRIPTION
Add a flag so that pebble mkdir won't be affected by umask settings.

Closes https://github.com/canonical/pebble/issues/372.