### PR TITLE
chore: use RFC2602 domain (example.com) in custom notice examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ These notice types are currently available:
 
 <!-- TODO: * `change-update`: recorded whenever a change is first spawned or its status is updated. The key for this type of notice is the change ID, and the notice's data includes the change `kind`. -->
 
-* `custom`: a custom client notice reported via `pebble notify`. The key and any data is provided by the user. The key must be in the format `mydomain.io/mykey` to ensure well-namespaced notice keys.
+* `custom`: a custom client notice reported via `pebble notify`. The key and any data is provided by the user. The key must be in the format `example.com/path` to ensure well-namespaced notice keys.
 
 <!-- TODO: * `warning`: Pebble warnings are implemented in terms of notices. The key for this type of notice is the human-readable warning message.
 

--- a/client/notices.go
+++ b/client/notices.go
@@ -31,7 +31,7 @@ type NotifyOptions struct {
 	Type NoticeType
 
 	// Key is the notice's key. For "custom" notices, this must be in
-	// "domain.com/key" format.
+	// "example.com/path" format.
 	Key string
 
 	// Data are optional key=value pairs for this occurrence of the notice.
@@ -128,7 +128,7 @@ const (
 
 	// A custom notice reported via the Pebble client API or "pebble notify".
 	// The key and data fields are provided by the user. The key must be in
-	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.
+	// the format "example.com/path" to ensure well-namespaced notice keys.
 	CustomNotice NoticeType = "custom"
 )
 

--- a/internals/daemon/api_notices.go
+++ b/internals/daemon/api_notices.go
@@ -29,7 +29,7 @@ import (
 	"github.com/canonical/pebble/internals/overlord/state"
 )
 
-// Ensure custom keys are in the form "domain.com/key" (but somewhat more restrictive).
+// Ensure custom keys are in the form "example.com/path" (but somewhat more restrictive).
 var customKeyRegexp = regexp.MustCompile(
 	`^[a-z0-9]+(-[a-z0-9]+)*(\.[a-z0-9]+(-[a-z0-9]+)*)+(/[a-z0-9]+(-[a-z0-9]+)*)+$`)
 
@@ -216,7 +216,7 @@ func v1PostNotices(c *Command, r *http.Request, _ *UserState) Response {
 		return BadRequest(`invalid type %q (can only add "custom" notices)`, payload.Type)
 	}
 	if !customKeyRegexp.MatchString(payload.Key) {
-		return BadRequest(`invalid key %q (must be in "domain.com/key" format)`, payload.Key)
+		return BadRequest(`invalid key %q (must be in "example.com/path" format)`, payload.Key)
 	}
 	if len(payload.Key) > maxNoticeKeyLength {
 		return BadRequest("key must be %d bytes or less", maxNoticeKeyLength)

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -189,7 +189,7 @@ const (
 
 	// A custom notice reported via the Pebble client API or "pebble notify".
 	// The key and data fields are provided by the user. The key must be in
-	// the format "mydomain.io/mykey" to ensure well-namespaced notice keys.
+	// the format "example.com/path" to ensure well-namespaced notice keys.
 	CustomNotice NoticeType = "custom"
 
 	// Warnings are a subset of notices where the key is a human-readable


### PR DESCRIPTION
Also use consistent "/path" to indicate it can be a path (with multiple segments).

This is per Tony's comment at https://github.com/canonical/operator/pull/1170#discussion_r1550998027