### PR TITLE
feat(personality): Allow state filename customization

### DIFF
--- a/cmd/personality.go
+++ b/cmd/personality.go
@@ -22,3 +22,6 @@ var DisplayName string = "Pebble"
 
 // DefaultDir is the Pebble directory used if $PEBBLE is not set.
 var DefaultDir string = "/var/lib/pebble/default"
+
+// StateFile is the file name of the state file in pebble dir.
+var StateFile string = ".pebble.state"

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/systemd"
 	"github.com/canonical/pebble/internals/testutil"
+	"github.com/canonical/pebble/cmd"
 )
 
 // Hook up check.v1 into the "go test" runner
@@ -69,7 +70,7 @@ func (s *daemonSuite) SetUpTest(c *C) {
 	}
 
 	s.pebbleDir = c.MkDir()
-	s.statePath = filepath.Join(s.pebbleDir, ".pebble.state")
+	s.statePath = filepath.Join(s.pebbleDir, cmd.StateFile)
 	systemdSdNotify = func(notif string) error {
 		s.notified = append(s.notified, notif)
 		return nil

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gorilla/mux"
 	. "gopkg.in/check.v1"
 
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/osutil"
 	"github.com/canonical/pebble/internals/overlord"
@@ -44,7 +45,6 @@ import (
 	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/systemd"
 	"github.com/canonical/pebble/internals/testutil"
-	"github.com/canonical/pebble/cmd"
 )
 
 // Hook up check.v1 into the "go test" runner

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -38,6 +38,7 @@ import (
 	"github.com/canonical/pebble/internals/overlord/servstate"
 	"github.com/canonical/pebble/internals/overlord/state"
 	"github.com/canonical/pebble/internals/timing"
+	"github.com/canonical/pebble/cmd"
 )
 
 var (
@@ -120,7 +121,7 @@ func New(opts *Options) (*Overlord, error) {
 	if !osutil.IsDir(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q does not exist", o.pebbleDir)
 	}
-	statePath := filepath.Join(o.pebbleDir, ".pebble.state")
+	statePath := filepath.Join(o.pebbleDir, cmd.StateFile)
 
 	backend := &overlordStateBackend{
 		path:         statePath,

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -28,6 +28,7 @@ import (
 	"github.com/canonical/x-go/randutil"
 	"gopkg.in/tomb.v2"
 
+	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/osutil"
 	"github.com/canonical/pebble/internals/overlord/checkstate"
 	"github.com/canonical/pebble/internals/overlord/cmdstate"
@@ -38,7 +39,6 @@ import (
 	"github.com/canonical/pebble/internals/overlord/servstate"
 	"github.com/canonical/pebble/internals/overlord/state"
 	"github.com/canonical/pebble/internals/timing"
-	"github.com/canonical/pebble/cmd"
 )
 
 var (

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -67,7 +67,7 @@ func fakePruneTicker() (w *ticker, restore func()) {
 
 func (ovs *overlordSuite) SetUpTest(c *C) {
 	ovs.dir = c.MkDir()
-	ovs.statePath = filepath.Join(ovs.dir, ".pebble.state")
+	ovs.statePath = filepath.Join(ovs.dir, cmd.StateFile)
 }
 
 func (ovs *overlordSuite) TearDownTest(c *C) {


### PR DESCRIPTION
Make it possible to customize the state file name, which is part of the personality (application name, pebble dir, ...).