### PR TITLE
Updated base structure for Pebble docs

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -19,7 +19,7 @@ import datetime
 ############################################################
 
 # Product name
-project = 'Documentation starter pack'
+project = 'Pebble'
 author = 'Canonical Group Ltd'
 
 # The title you want to display for the documentation in the sidebar.
@@ -89,14 +89,14 @@ html_context = {
 
     # Change to the GitHub URL for your project
     # This is used, for example, to link to the source files and allow creating GitHub issues directly from the documentation.
-    'github_url': 'https://github.com/canonical/sphinx-docs-starter-pack',
+    'github_url': 'https://github.com/canonical/pebble',
 
     # Change to the branch for this version of the documentation
     'github_version': 'main',
 
     # Change to the folder that contains the documentation
     # (usually "/" or "/docs/")
-    'github_folder': '/',
+    'github_folder': '/docs/',
 
     # Change to an empty value if your GitHub repo doesn't have issues enabled.
     # This will disable the feedback button and the issue link in the footer.
@@ -104,7 +104,7 @@ html_context = {
 
     # Controls the existence of Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
-    'sequential_nav': "none", 
+    'sequential_nav': "both", 
     
     # Controls if to display the contributors of a file or not
     "display_contributors": True,
@@ -115,7 +115,7 @@ html_context = {
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ""
+slug = "pebble"
 
 ############################################################
 ### Redirects
@@ -165,7 +165,8 @@ custom_extensions = [
     'canonical.related-links',
     'canonical.custom-rst-roles',
     'canonical.terminal-output',
-    'notfound.extension'
+    'notfound.extension',
+    'canonical.filtered-toc'
     ]
 
 # Add custom required Python modules that must be added to the

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,5 @@
+# Explanation
+
+This section addresses conceptual topics about Pebble:
+
+<toctree goes here>

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,5 @@
+# How-to guides
+
+These how-to guides cover key operations and processes in Pebble:
+
+<toctree goes here>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,59 @@
-# Starter pack
+---
+relatedlinks: "[Diátaxis](https://diataxis.fr/)"
+---
 
-This starter pack contains the files you need to quickly set up your Sphinx documentation.
+```{filtered-toctree}
+:hidden:
+:titlesonly:
 
-Before you start, see the information about `Read the Docs at Canonical`_ and the instructions for `How to publish documentation on Read the Docs`_.
+tutorials/index
+how-to/index
+explanation/index
+reference/index
+```
 
-Then, to start setting up your docs, check the :doc:`ReadMe <readme>` for instructions.
-The `Example product documentation`_ shows how to set up a Diátaxis structure in Sphinx.
+# Pebble
 
-For quick help on reST or MyST syntax, see the :file:`doc-cheat-sheet.rst.txt` or :file:`doc-cheat-sheet-myst.md.txt` files in the repository.
-(Open the files in your text editor; the rendered output is not very useful.)
+An overview of Pebble...
 
+## In this documentation
+
+````{grid} 1 1 2 2
+
+```{grid-item-card} [Tutorials](tutorials/index)
+
+**Start here**: a hands-on introduction to Pebble for new users
+```
+
+```{grid-item-card} [How-to guides](how-to/index)
+
+**Step-by-step guides** covering key operations and common tasks
+```
+
+````
+
+````{grid} 1 1 2 2
+:reverse:
+
+```{grid-item-card} [Reference](reference/index)
+
+**Technical information** - specifications, APIs, architecture
+```
+
+```{grid-item-card} [Explanation](explanation/index)
+
+**Discussion and clarification** of key topics
+```
+
+````
+
+## Project and community
+
+Pebble is free software and released under
+[AGPL-3.0-only](https://www.gnu.org/licenses/agpl-3.0.en.html)...
+
+The Pebble project is sponsored by [Canonical Ltd](https://www.canonical.com).
+
+- [Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct)
+
+...

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,5 @@
+# Reference
+
+This section provides detailed reference material for Pebble:
+
+<toctree goes here>

--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -23,3 +23,11 @@ commands_pre =
     pip-sync {toxinidir}/requirements.txt
 commands =
     sphinx-build -W --keep-going . _build/html
+
+[testenv:serve]
+description = Live reload and serve the Sphinx docs
+deps = pip-tools
+commands_pre =
+    pip-sync {toxinidir}/requirements.txt
+commands =
+    sphinx-autobuild . _build/html

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,5 @@
+# Tutorials
+
+The following tutorials guide you to install, operate, and customise Pebble:
+
+<toctree goes here>


### PR DESCRIPTION
Several base updates for Pebble docs:

1. Modified the necessary configuration values to reflect Pebble project.
2. Updated `conf.py` to include the PR fixes from the Sphinx docs starter pack: https://github.com/canonical/sphinx-docs-starter-pack/pull/229/files.
3. Added a live reload + serve option in `tox.ini`, similar to `make run`.
4. Added the base folder structure to reflect Diataxis framework.