### PR TITLE
feat(osutil.Mkdir): add the chmod flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^filesSuite\.TestWriteUserGroupReal$
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./daemon.test -check.v -check.f ^filesSuite\.TestMakeDirsUserGroupReal$
         go test -c ./internals/osutil
-        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./osutil.test -check.v -check.f ^mkdirSuite\.TestMakeParentsAndChown$
+        PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./osutil.test -check.v -check.f ^mkdirSuite\.TestMakeParentsChmodAndChown$
         
         go test -c ./internals/overlord/servstate/
         PEBBLE_TEST_USER=runner PEBBLE_TEST_GROUP=runner sudo -E -H ./servstate.test -check.v -check.f ^S.TestUserGroup$

--- a/internals/daemon/api_files.go
+++ b/internals/daemon/api_files.go
@@ -504,6 +504,7 @@ func mkdirAllUserGroup(path string, perm os.FileMode, uid, gid *int) error {
 		return mkdir(path, perm, &osutil.MkdirOptions{
 			MakeParents: true,
 			ExistOK:     true,
+			Chmod:       true,
 			Chown:       true,
 			UserID:      sys.UserID(*uid),
 			GroupID:     sys.GroupID(*gid),
@@ -512,6 +513,7 @@ func mkdirAllUserGroup(path string, perm os.FileMode, uid, gid *int) error {
 		return mkdir(path, perm, &osutil.MkdirOptions{
 			MakeParents: true,
 			ExistOK:     true,
+			Chmod:       true,
 		})
 	}
 }
@@ -519,12 +521,15 @@ func mkdirAllUserGroup(path string, perm os.FileMode, uid, gid *int) error {
 func mkdirUserGroup(path string, perm os.FileMode, uid, gid *int) error {
 	if uid != nil && gid != nil {
 		return mkdir(path, perm, &osutil.MkdirOptions{
+			Chmod:   true,
 			Chown:   true,
 			UserID:  sys.UserID(*uid),
 			GroupID: sys.GroupID(*gid),
 		})
 	} else {
-		return mkdir(path, perm, nil)
+		return mkdir(path, perm, &osutil.MkdirOptions{
+			Chmod: true,
+		})
 	}
 }
 

--- a/internals/daemon/api_files_test.go
+++ b/internals/daemon/api_files_test.go
@@ -480,11 +480,11 @@ func (s *filesSuite) TestMakeDirsUserGroupMocked(c *C) {
 	tmpDir := s.testMakeDirsUserGroup(c, 12, 34, "USER", "GROUP")
 
 	c.Assert(mkdirCalls, HasLen, 5)
-	c.Check(mkdirCalls[0], Equals, args{tmpDir + "/normal", 0o755, osutil.MkdirOptions{}})
-	c.Check(mkdirCalls[1], Equals, args{tmpDir + "/uid-gid", 0o755, osutil.MkdirOptions{Chown: true, UserID: 12, GroupID: 34}})
-	c.Check(mkdirCalls[2], Equals, args{tmpDir + "/user-group", 0o755, osutil.MkdirOptions{Chown: true, UserID: 56, GroupID: 78}})
-	c.Check(mkdirCalls[3], Equals, args{tmpDir + "/nested1/normal", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true}})
-	c.Check(mkdirCalls[4], Equals, args{tmpDir + "/nested2/user-group", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true, Chown: true, UserID: 56, GroupID: 78}})
+	c.Check(mkdirCalls[0], Equals, args{tmpDir + "/normal", 0o755, osutil.MkdirOptions{Chmod: true}})
+	c.Check(mkdirCalls[1], Equals, args{tmpDir + "/uid-gid", 0o755, osutil.MkdirOptions{Chmod: true, Chown: true, UserID: 12, GroupID: 34}})
+	c.Check(mkdirCalls[2], Equals, args{tmpDir + "/user-group", 0o755, osutil.MkdirOptions{Chmod: true, Chown: true, UserID: 56, GroupID: 78}})
+	c.Check(mkdirCalls[3], Equals, args{tmpDir + "/nested1/normal", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true, Chmod: true}})
+	c.Check(mkdirCalls[4], Equals, args{tmpDir + "/nested2/user-group", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true, Chmod: true, Chown: true, UserID: 56, GroupID: 78}})
 }
 
 func (s *filesSuite) testMakeDirsUserGroup(c *C, uid, gid int, user, group string) string {
@@ -984,8 +984,8 @@ func (s *filesSuite) TestWriteUserGroupMocked(c *C) {
 	c.Check(atomicWriteChownCalls[4], Equals, args{tmpDir + "/nested2/user-group", 0o644, 56, 78})
 
 	c.Assert(mkdirCalls, HasLen, 2)
-	c.Check(mkdirCalls[0], Equals, mkdirArgs{tmpDir + "/nested1", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true}})
-	c.Check(mkdirCalls[1], Equals, mkdirArgs{tmpDir + "/nested2", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true, Chown: true, UserID: 56, GroupID: 78}})
+	c.Check(mkdirCalls[0], Equals, mkdirArgs{tmpDir + "/nested1", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true, Chmod: true}})
+	c.Check(mkdirCalls[1], Equals, mkdirArgs{tmpDir + "/nested2", 0o755, osutil.MkdirOptions{MakeParents: true, ExistOK: true, Chmod: true, Chown: true, UserID: 56, GroupID: 78}})
 }
 
 // See .github/workflows/tests.yml for how to run this test as root.

--- a/internals/osutil/mkdir.go
+++ b/internals/osutil/mkdir.go
@@ -140,7 +140,7 @@ func mkdir(path string, perm os.FileMode, options *MkdirOptions) error {
 	}
 
 	if options.Chmod {
-		if err := os.Chmod(path, perm); err != nil {
+		if err := os.Chmod(cand, perm); err != nil {
 			return err
 		}
 	}

--- a/internals/osutil/mkdir.go
+++ b/internals/osutil/mkdir.go
@@ -41,6 +41,12 @@ type MkdirOptions struct {
 	// it's not a directory).
 	ExistOK bool
 
+	// If false (the default), no explicit chmod is performed. In this case, the permission
+	// of the created directories will be affected by umask settings.
+	//
+	// If true, perform an explicit chmod on any directories created.
+	Chmod bool
+
 	// If false (the default), no explicit chown is performed.
 	// If true, perform an explicit chown on any directories created, using the UserID
 	// and GroupID provided.
@@ -119,7 +125,7 @@ func mkdirAll(path string, perm os.FileMode, options *MkdirOptions) error {
 	return mkdir(path, perm, options)
 }
 
-// Create a single directory and perform chown operations according to options.
+// Create a single directory and perform chown/chmod operations according to options.
 func mkdir(path string, perm os.FileMode, options *MkdirOptions) error {
 	cand := path + ".mkdir-new"
 
@@ -129,6 +135,12 @@ func mkdir(path string, perm os.FileMode, options *MkdirOptions) error {
 
 	if options.Chown {
 		if err := sys.ChownPath(cand, options.UserID, options.GroupID); err != nil {
+			return err
+		}
+	}
+
+	if options.Chmod {
+		if err := os.Chmod(path, perm); err != nil {
 			return err
 		}
 	}

--- a/internals/osutil/mkdir_test.go
+++ b/internals/osutil/mkdir_test.go
@@ -30,7 +30,7 @@ type mkdirSuite struct{}
 
 var _ = check.Suite(&mkdirSuite{})
 
-// Chown requires root, so it's not tested, only test MakeParents, ExistOK,
+// Chown requires root, so it's not tested, only test MakeParents, ExistOK, Chmod,
 // and the combination of them.
 func (mkdirSuite) TestSimpleDir(c *check.C) {
 	tmpDir := c.MkDir()
@@ -112,8 +112,82 @@ func (mkdirSuite) TestMakeParentsAndExistNotOK(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
 }
 
+func (mkdirSuite) TestChmod(c *check.C) {
+	oldmask := syscall.Umask(0022)
+	defer syscall.Umask(oldmask)
+
+	tmpDir := c.MkDir()
+
+	err := osutil.Mkdir(tmpDir+"/foo", 0o777, &osutil.MkdirOptions{
+		Chmod: true,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+
+	info, err := os.Stat(tmpDir + "/foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
+}
+
+func (mkdirSuite) TestNoChmod(c *check.C) {
+	oldmask := syscall.Umask(0022)
+	defer syscall.Umask(oldmask)
+
+	tmpDir := c.MkDir()
+
+	err := osutil.Mkdir(tmpDir+"/foo", 0o777, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+
+	info, err := os.Stat(tmpDir + "/foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o755))
+}
+
+func (mkdirSuite) TestMakeParentsAndChmod(c *check.C) {
+	tmpDir := c.MkDir()
+
+	err := osutil.Mkdir(tmpDir+"/foo/bar", 0o777, &osutil.MkdirOptions{
+		MakeParents: true,
+		Chmod:       true,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+
+	info, err := os.Stat(tmpDir + "/foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
+
+	info, err = os.Stat(tmpDir + "/foo/bar")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
+}
+
+func (mkdirSuite) TestMakeParentsAndNoChmod(c *check.C) {
+	oldmask := syscall.Umask(0022)
+	defer syscall.Umask(oldmask)
+
+	tmpDir := c.MkDir()
+
+	err := osutil.Mkdir(tmpDir+"/foo/bar", 0o777, &osutil.MkdirOptions{
+		MakeParents: true,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+
+	info, err := os.Stat(tmpDir + "/foo")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o755))
+
+	info, err = os.Stat(tmpDir + "/foo/bar")
+	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o755))
+}
+
 // See .github/workflows/tests.yml for how to run this test as root.
-func (mkdirSuite) TestMakeParentsAndChown(c *check.C) {
+func (mkdirSuite) TestMakeParentsChmodAndChown(c *check.C) {
 	if os.Getuid() != 0 {
 		c.Skip("requires running as root")
 	}
@@ -136,6 +210,7 @@ func (mkdirSuite) TestMakeParentsAndChown(c *check.C) {
 
 	err = osutil.Mkdir(tmpDir+"/foo/bar", 0o777, &osutil.MkdirOptions{
 		MakeParents: true,
+		Chmod:       true,
 		Chown:       true,
 		UserID:      sys.UserID(uid),
 		GroupID:     sys.GroupID(gid),
@@ -146,6 +221,7 @@ func (mkdirSuite) TestMakeParentsAndChown(c *check.C) {
 
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	c.Assert(ok, check.Equals, true)
 	c.Assert(int(stat.Uid), check.Equals, uid)
@@ -153,6 +229,7 @@ func (mkdirSuite) TestMakeParentsAndChown(c *check.C) {
 
 	info, err = os.Stat(tmpDir + "/foo/bar")
 	c.Assert(err, check.IsNil)
+	c.Assert(info.Mode().Perm(), check.Equals, os.FileMode(0o777))
 	stat, ok = info.Sys().(*syscall.Stat_t)
 	c.Assert(ok, check.Equals, true)
 	c.Assert(int(stat.Uid), check.Equals, uid)


### PR DESCRIPTION
Add a new `Chmod` flag to `MkdirOptions` so that an explicit `chmod` command is executed on all directories created by `osutil.Mkdir`.

Closes https://github.com/canonical/pebble/issues/372.

## Manual Tests

### Comparison

| **Tests**                               | **Before**                                                                                                                | **After**                                                                              |
|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
| pebble mkdir  ~/normal -m 777           | umask set to 0022, result is 0755, _not the same as what the user specifies because of umask_                               | umask set to 0022, result is 0777, _not affected by umask_                               |
| pebble mkdir -p  ~/nested/folder -m 777 | umask set to 0022, result is 0755 for both parents and children, _not the same as what the user specifies because of umask_ | umask set to 0022, result is 0777 for both parents and children, _not affected by umask_ |

### Before

Permission _is_ affected by `umask` settings:

```bash
# umask 0022
$ pebble mkdir ~/normal -m 777
$ ll normal/
total 8
drwxr-xr-x  2 ubuntu ubuntu 4096 Jun  6 02:30 ./
$ pebble mkdir -p ~/nested/folder -m 777
$ ll nested/
total 12
drwxr-xr-x  3 ubuntu ubuntu 4096 Jun  6 02:34 ./
drwxr-x--- 19 ubuntu ubuntu 4096 Jun  6 02:34 ../
drwxr-xr-x  2 ubuntu ubuntu 4096 Jun  6 02:34 folder/
```

### After

Permission _isn't_ affected by `umask` anymore:

```bash
# umask 0022
$ pebble mkdir ~/normal -m 777
$ ll normal/
total 8
drwxrwxrwx  2 ubuntu ubuntu 4096 Jun  6 02:31 ./
$ pebble mkdir -p ~/nested/folder -m 777
$ ll nested/
total 12
drwxrwxrwx  3 ubuntu ubuntu 4096 Jun  6 02:32 ./
drwxr-x--- 19 ubuntu ubuntu 4096 Jun  6 02:32 ../
drwxrwxrwx  2 ubuntu ubuntu 4096 Jun  6 02:32 folder/
```
