### PR TITLE
fix: note exist-ok behaviour of "mkdir -p" in argument help

### DIFF
--- a/internals/cli/cmd_mkdir.go
+++ b/internals/cli/cmd_mkdir.go
@@ -49,7 +49,7 @@ func init() {
 		Summary:     cmdMkdirSummary,
 		Description: cmdMkdirDescription,
 		ArgsHelp: map[string]string{
-			"-p":      "Create parent directories as needed",
+			"-p":      "Create parent directories as needed, and don't fail if path already exists",
 			"-m":      "Override mode bits (3-digit octal)",
 			"--uid":   "Use specified user ID",
 			"--user":  "Use specified username",


### PR DESCRIPTION
`mkdir -p` (and the underlying API) has also worked this way, this just brings the help string up to date.