### PR TITLE
fix: avoid legacy Snapcraft location for LP creds

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -64,9 +64,9 @@ jobs:
 
       - name: Set LP credentials for remote build
         run: |
-          lp_creds_path="$HOME/.local/share/snapcraft/provider/launchpad"
+          lp_creds_path="$HOME/.local/share/snapcraft/"
           mkdir -p $lp_creds_path
-          echo '${{ secrets.LP_CREDENTIALS }}' > ${lp_creds_path}/credentials
+          echo '${{ secrets.LP_CREDENTIALS }}' > ${lp_creds_path}/launchpad-credentials
           git config --global user.email "${{ secrets.PEBBLE_DEV_MAILING_LIST}}"
           git config --global user.name "pebble-dev"
 


### PR DESCRIPTION
Fixes https://github.com/canonical/pebble/actions/runs/9392436751/job/25867410242

Recent [CI runs](https://github.com/canonical/pebble/actions/runs/9392436751/job/25867410242) started failing as Snapcraft is no longer considering the legacy location for Launchpad credentials, "$XDG_DATA_DIR/snapcraft/provider/launchpad/credentials".

This PR changes the snap.yml such that it now uses "$XDG_DATA_DIR/snapcraft/launchpad-credentials" instead.  

Reference: https://git.launchpad.net/snapcraft/commit/?id=83b67923d11200bc8dd8e75ec46df2644d70659d