### PR TITLE
feat(state): core of reading/writing identities in state

### DIFF
--- a/internals/overlord/state/identities.go
+++ b/internals/overlord/state/identities.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 )
 
-// TODO: disallow multiple users with same "local: user-id" value?
-
 // Identity holds the configuration of a single identity.
 type Identity struct {
 	Name   string
@@ -130,6 +128,10 @@ func (s *State) AddIdentities(identities map[string]*Identity) error {
 		sort.Strings(existing)
 		return fmt.Errorf("identities already exist: %s", strings.Join(existing, ", "))
 	}
+	err := verifyUniqueUserIDs(s.identities, identities)
+	if err != nil {
+		return nil
+	}
 
 	for name, identity := range identities {
 		identity.Name = name
@@ -158,6 +160,10 @@ func (s *State) UpdateIdentities(identities map[string]*Identity) error {
 		sort.Strings(missing)
 		return fmt.Errorf("identities missing: %s", strings.Join(missing, ", "))
 	}
+	err := verifyUniqueUserIDs(s.identities, identities)
+	if err != nil {
+		return nil
+	}
 
 	for name, identity := range identities {
 		identity.Name = name
@@ -179,6 +185,10 @@ func (s *State) ReplaceIdentities(identities map[string]*Identity) error {
 				return fmt.Errorf("identity %q invalid: %w", name, err)
 			}
 		}
+	}
+	err := verifyUniqueUserIDs(s.identities, identities)
+	if err != nil {
+		return nil
 	}
 
 	for name, identity := range identities {
@@ -225,4 +235,29 @@ func (s *State) Identities() map[string]*Identity {
 		result[name] = identity
 	}
 	return result
+}
+
+func verifyUniqueUserIDs(existing map[string]*Identity, new map[string]*Identity) error {
+	existingNamesByUserID := make(map[uint32]string)
+	for name, identity := range existing {
+		switch {
+		case identity.Local != nil:
+			existingNamesByUserID[identity.Local.UserID] = name
+		}
+	}
+	for name, identity := range new {
+		if identity == nil {
+			continue // removing identity (for ReplaceIdentities only)
+		}
+		switch {
+		case identity.Local != nil:
+			existingName, ok := existingNamesByUserID[identity.Local.UserID]
+			if ok && name != existingName {
+				return fmt.Errorf("identity %q and %q cannot both have user ID %d",
+					name, existingName, identity.Local.UserID)
+			}
+			existingNamesByUserID[identity.Local.UserID] = name
+		}
+	}
+	return nil
 }

--- a/internals/overlord/state/identities.go
+++ b/internals/overlord/state/identities.go
@@ -47,7 +47,7 @@ type LocalIdentity struct {
 	UserID uint32
 }
 
-// validate checks that identity d is valid, returning an error if not.
+// validate checks that the identity is valid, returning an error if not.
 func (d *Identity) validate() error {
 	if d == nil {
 		return errors.New("identity must not be nil")
@@ -122,7 +122,7 @@ func (d *Identity) UnmarshalJSON(data []byte) error {
 // AddIdentities adds the given identities to the system. It's an error if any
 // of the named identities already exist.
 func (s *State) AddIdentities(identities map[string]*Identity) error {
-	s.writing()
+	s.reading()
 
 	// If any of the named identities already exist, return an error.
 	var existing []string
@@ -151,6 +151,7 @@ func (s *State) AddIdentities(identities map[string]*Identity) error {
 		return err
 	}
 
+	s.writing()
 	s.identities = newIdentities
 	return nil
 }
@@ -158,7 +159,7 @@ func (s *State) AddIdentities(identities map[string]*Identity) error {
 // UpdateIdentities updates the given identities in the system. It's an error
 // if any of the named identities do not exist.
 func (s *State) UpdateIdentities(identities map[string]*Identity) error {
-	s.writing()
+	s.reading()
 
 	// If any of the named identities don't exist, return an error.
 	var missing []string
@@ -187,6 +188,7 @@ func (s *State) UpdateIdentities(identities map[string]*Identity) error {
 		return err
 	}
 
+	s.writing()
 	s.identities = newIdentities
 	return nil
 }
@@ -195,7 +197,7 @@ func (s *State) UpdateIdentities(identities map[string]*Identity) error {
 // given identities (adding those that don't exist), or removes them if the
 // map value is nil.
 func (s *State) ReplaceIdentities(identities map[string]*Identity) error {
-	s.writing()
+	s.reading()
 
 	for name, identity := range identities {
 		if identity != nil {
@@ -221,6 +223,7 @@ func (s *State) ReplaceIdentities(identities map[string]*Identity) error {
 		return err
 	}
 
+	s.writing()
 	s.identities = newIdentities
 	return nil
 }
@@ -228,7 +231,7 @@ func (s *State) ReplaceIdentities(identities map[string]*Identity) error {
 // RemoveIdentities removes the named identities from the system. It's an
 // error if any of the named identities do not exist.
 func (s *State) RemoveIdentities(identities map[string]struct{}) error {
-	s.writing()
+	s.reading()
 
 	// If any of the named identities don't exist, return an error.
 	var missing []string
@@ -242,6 +245,7 @@ func (s *State) RemoveIdentities(identities map[string]struct{}) error {
 		return fmt.Errorf("identities do not exist: %s", strings.Join(missing, ", "))
 	}
 
+	s.writing()
 	for name := range identities {
 		delete(s.identities, name)
 	}
@@ -269,19 +273,19 @@ func (s *State) cloneIdentities() map[string]*Identity {
 }
 
 func verifyUniqueUserIDs(identities map[string]*Identity) error {
-	userIDs := make(map[uint32]string) // maps user IDs to identity name
+	userIDs := make(map[uint32][]string) // maps user ID to identity names
 	for name, identity := range identities {
 		switch {
 		case identity.Local != nil:
-			existingName, ok := userIDs[identity.Local.UserID]
-			if ok {
-				if name > existingName { // ensure error message is stable
-					name, existingName = existingName, name
-				}
-				return fmt.Errorf("identities %q and %q cannot both have user ID %d",
-					name, existingName, identity.Local.UserID)
-			}
-			userIDs[identity.Local.UserID] = name
+			uid := identity.Local.UserID
+			userIDs[uid] = append(userIDs[uid], name)
+		}
+	}
+	for userID, names := range userIDs {
+		if len(names) > 1 {
+			sort.Strings(names) // ensure error message is stable
+			return fmt.Errorf("cannot have multiple identities with user ID %d (%s)",
+				userID, strings.Join(names, ", "))
 		}
 	}
 	return nil

--- a/internals/overlord/state/identities.go
+++ b/internals/overlord/state/identities.go
@@ -55,8 +55,11 @@ func (d *Identity) validate() error {
 
 	switch d.Access {
 	case AdminAccess, ReadAccess, UntrustedAccess:
+	case "":
+		return fmt.Errorf("access value must be specified (%q, %q, or %q)",
+			AdminAccess, ReadAccess, UntrustedAccess)
 	default:
-		return fmt.Errorf("invalid access %q, must be %q, %q, or %q",
+		return fmt.Errorf("invalid access value %q, must be %q, %q, or %q",
 			d.Access, AdminAccess, ReadAccess, UntrustedAccess)
 	}
 

--- a/internals/overlord/state/identities_test.go
+++ b/internals/overlord/state/identities_test.go
@@ -280,9 +280,9 @@ func (s *identitiesSuite) TestAddIdentities(c *C) {
 			Local:  &state.LocalIdentity{UserID: 1000},
 		},
 	})
-	c.Assert(err, ErrorMatches, `identities "bill" and "mary" cannot both have user ID 1000`)
+	c.Assert(err, ErrorMatches, `cannot have multiple identities with user ID 1000 \(bill, mary\)`)
 
-	// Ensure user IDs are unique among the ones being added.
+	// Ensure user IDs are unique among the ones being added (and test >2 with same UID).
 	err = st.AddIdentities(map[string]*state.Identity{
 		"bill": {
 			Access: state.ReadAccess,
@@ -292,8 +292,12 @@ func (s *identitiesSuite) TestAddIdentities(c *C) {
 			Access: state.ReadAccess,
 			Local:  &state.LocalIdentity{UserID: 2000},
 		},
+		"boll": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 2000},
+		},
 	})
-	c.Assert(err, ErrorMatches, `identities "bale" and "bill" cannot both have user ID 2000`)
+	c.Assert(err, ErrorMatches, `cannot have multiple identities with user ID 2000 \(bale, bill, boll\)`)
 }
 
 func (s *identitiesSuite) TestUpdateIdentities(c *C) {
@@ -371,7 +375,7 @@ func (s *identitiesSuite) TestUpdateIdentities(c *C) {
 			Local:  &state.LocalIdentity{UserID: 42},
 		},
 	})
-	c.Assert(err, ErrorMatches, `identities "bob" and "mary" cannot both have user ID 42`)
+	c.Assert(err, ErrorMatches, `cannot have multiple identities with user ID 42 \(bob, mary\)`)
 }
 
 func (s *identitiesSuite) TestReplaceIdentities(c *C) {
@@ -435,7 +439,7 @@ func (s *identitiesSuite) TestReplaceIdentities(c *C) {
 			Local:  &state.LocalIdentity{UserID: 43},
 		},
 	})
-	c.Assert(err, ErrorMatches, `identities "bob" and "mary" cannot both have user ID 43`)
+	c.Assert(err, ErrorMatches, `cannot have multiple identities with user ID 43 \(bob, mary\)`)
 }
 
 func (s *identitiesSuite) TestRemoveIdentities(c *C) {

--- a/internals/overlord/state/identities_test.go
+++ b/internals/overlord/state/identities_test.go
@@ -1,0 +1,533 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"encoding/json"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/overlord/state"
+)
+
+type identitiesSuite struct{}
+
+var _ = Suite(&identitiesSuite{})
+
+// IMPORTANT NOTE: be sure secrets aren't included when adding to this!
+func (s *identitiesSuite) TestMarshalAPI(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	err := st.AddIdentities(map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+	c.Assert(err, IsNil)
+
+	identities := st.Identities()
+	data, err := json.MarshalIndent(identities, "", "    ")
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, `
+{
+    "bob": {
+        "access": "read",
+        "local": {
+            "user-id": 42
+        }
+    },
+    "mary": {
+        "access": "admin",
+        "local": {
+            "user-id": 1000
+        }
+    }
+}`[1:])
+}
+
+func (s *identitiesSuite) TestUnmarshalAPI(c *C) {
+	data := []byte(`
+{
+    "bob": {
+        "access": "read",
+        "local": {
+            "user-id": 42
+        }
+    },
+    "mary": {
+        "access": "admin",
+        "local": {
+            "user-id": 1000
+        }
+    }
+}`)
+	var identities map[string]*state.Identity
+	err := json.Unmarshal(data, &identities)
+	c.Assert(err, IsNil)
+	c.Assert(identities, DeepEquals, map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+}
+
+func (s *identitiesSuite) TestUnmarshalAPIErrors(c *C) {
+	tests := []struct {
+		data  string
+		error string
+	}{{
+		data:  `{"no-type": {"access": "admin"}}`,
+		error: `identity must have at least one type \("local"\)`,
+	}, {
+		data:  `{"invalid-access": {"access": "admin", "local": {}}}`,
+		error: `local identity must specify user-id`,
+	}, {
+		data:  `{"invalid-access": {"access": "foo", "local": {"user-id": 42}}}`,
+		error: `invalid access "foo", must be "admin", "read", or "untrusted"`,
+	}}
+	for _, test := range tests {
+		c.Logf("Input data: %s", test.data)
+		var identities map[string]*state.Identity
+		err := json.Unmarshal([]byte(test.data), &identities)
+		c.Check(err, ErrorMatches, test.error)
+	}
+}
+
+func (s *identitiesSuite) TestMarshalState(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	err := st.AddIdentities(map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+	c.Assert(err, IsNil)
+
+	// Marshal entire state, then pull out just the "identities" key to test that.
+	data, err := json.Marshal(st)
+	c.Assert(err, IsNil)
+	var unmarshalled map[string]any
+	err = json.Unmarshal(data, &unmarshalled)
+	c.Assert(err, IsNil)
+	data, err = json.MarshalIndent(unmarshalled["identities"], "", "    ")
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, `
+{
+    "bob": {
+        "access": "read",
+        "local": {
+            "user-id": 42
+        }
+    },
+    "mary": {
+        "access": "admin",
+        "local": {
+            "user-id": 1000
+        }
+    }
+}`[1:])
+}
+
+func (s *identitiesSuite) TestUnmarshalState(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	data := []byte(`
+{
+    "identities": {
+        "bob": {
+            "access": "read",
+            "local": {
+                "user-id": 42
+            }
+        },
+        "mary": {
+            "access": "admin",
+            "local": {
+                "user-id": 1000
+            }
+        }
+    }
+}`)
+	err := json.Unmarshal(data, &st)
+	c.Assert(err, IsNil)
+	c.Assert(st.Identities(), DeepEquals, map[string]*state.Identity{
+		"bob": {
+			Name:   "bob",
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Name:   "mary",
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+}
+
+func (s *identitiesSuite) TestAddIdentities(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	original := map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	}
+	err := st.AddIdentities(original)
+	c.Assert(err, IsNil)
+
+	// Ensure they were added correctly (and Name fields have been set).
+	identities := st.Identities()
+	c.Assert(identities, DeepEquals, map[string]*state.Identity{
+		"bob": {
+			Name:   "bob",
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Name:   "mary",
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+
+	// Can't add identity names that already exist.
+	err = st.AddIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+	c.Assert(err, ErrorMatches, "identities already exist: bob, mary")
+
+	// Can't add a nil identity.
+	err = st.AddIdentities(map[string]*state.Identity{
+		"bill": nil,
+	})
+	c.Assert(err, ErrorMatches, `identity "bill" invalid: identity must not be nil`)
+
+	// Access value must be valid.
+	err = st.AddIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: "bar",
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+	})
+	c.Assert(err, ErrorMatches, `identity "bill" invalid: invalid access "bar", must be "admin", "read", or "untrusted"`)
+
+	// Must have at least one type.
+	err = st.AddIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: "admin",
+		},
+	})
+	c.Assert(err, ErrorMatches, `identity "bill" invalid: identity must have at least one type \("local"\)`)
+
+	// Ensure user IDs are unique with existing users.
+	err = st.AddIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+	c.Assert(err, ErrorMatches, `identities "bill" and "mary" cannot both have user ID 1000`)
+
+	// Ensure user IDs are unique among the ones being added.
+	err = st.AddIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 2000},
+		},
+		"bale": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 2000},
+		},
+	})
+	c.Assert(err, ErrorMatches, `identities "bale" and "bill" cannot both have user ID 2000`)
+}
+
+func (s *identitiesSuite) TestUpdateIdentities(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	original := map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	}
+	err := st.AddIdentities(original)
+	c.Assert(err, IsNil)
+
+	err = st.UpdateIdentities(map[string]*state.Identity{
+		"bob": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+		"mary": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+	})
+	c.Assert(err, IsNil)
+
+	// Ensure they were updated correctly.
+	identities := st.Identities()
+	c.Assert(identities, DeepEquals, map[string]*state.Identity{
+		"bob": {
+			Name:   "bob",
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+		"mary": {
+			Name:   "mary",
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+	})
+
+	// Can't update identity names that don't exist.
+	err = st.UpdateIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+		"bale": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	})
+	c.Assert(err, ErrorMatches, "identities do not exist: bale, bill")
+
+	// Ensure validation is being done (full testing done in AddIdentity).
+	err = st.UpdateIdentities(map[string]*state.Identity{
+		"bob": nil,
+	})
+	c.Assert(err, ErrorMatches, `identity "bob" invalid: identity must not be nil`)
+
+	// Ensure unique user ID testing is being done (full testing done in AddIdentity).
+	err = st.UpdateIdentities(map[string]*state.Identity{
+		"bob": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+	})
+	c.Assert(err, ErrorMatches, `identities "bob" and "mary" cannot both have user ID 42`)
+}
+
+func (s *identitiesSuite) TestReplaceIdentities(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	original := map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	}
+	err := st.AddIdentities(original)
+	c.Assert(err, IsNil)
+
+	err = st.ReplaceIdentities(map[string]*state.Identity{
+		"bob": nil, // nil means remove it
+		"mary": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+		"newguy": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 44},
+		},
+	})
+	c.Assert(err, IsNil)
+
+	// Ensure they were added/updated/deleted correctly.
+	identities := st.Identities()
+	c.Assert(identities, DeepEquals, map[string]*state.Identity{
+		"mary": {
+			Name:   "mary",
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+		"newguy": {
+			Name:   "newguy",
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 44},
+		},
+	})
+
+	// Ensure validation is being done (full testing done in AddIdentity).
+	err = st.ReplaceIdentities(map[string]*state.Identity{
+		"bill": {
+			Access: "admin",
+		},
+	})
+	c.Assert(err, ErrorMatches, `identity "bill" invalid: identity must have at least one type \("local"\)`)
+
+	// Ensure unique user ID testing is being done (full testing done in AddIdentity).
+	err = st.ReplaceIdentities(map[string]*state.Identity{
+		"bob": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+	})
+	c.Assert(err, ErrorMatches, `identities "bob" and "mary" cannot both have user ID 43`)
+}
+
+func (s *identitiesSuite) TestRemoveIdentities(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	original := map[string]*state.Identity{
+		"bill": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+		"queen": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1001},
+		},
+	}
+	err := st.AddIdentities(original)
+	c.Assert(err, IsNil)
+
+	err = st.RemoveIdentities(map[string]struct{}{
+		"bob":  {},
+		"mary": {},
+	})
+	c.Assert(err, IsNil)
+
+	// Ensure they were removed correctly.
+	identities := st.Identities()
+	c.Assert(identities, DeepEquals, map[string]*state.Identity{
+		"bill": {
+			Name:   "bill",
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 43},
+		},
+		"queen": {
+			Name:   "queen",
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1001},
+		},
+	})
+
+	// Can't remove identity names that don't exist.
+	err = st.RemoveIdentities(map[string]struct{}{
+		"bill": {},
+		"bale": {},
+		"mary": {},
+	})
+	c.Assert(err, ErrorMatches, "identities do not exist: bale, mary")
+}
+
+func (s *identitiesSuite) TestIdentities(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	original := map[string]*state.Identity{
+		"bob": {
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	}
+	err := st.AddIdentities(original)
+	c.Assert(err, IsNil)
+
+	// Ensure it returns correct results.
+	identities := st.Identities()
+	expected := map[string]*state.Identity{
+		"bob": {
+			Name:   "bob",
+			Access: state.ReadAccess,
+			Local:  &state.LocalIdentity{UserID: 42},
+		},
+		"mary": {
+			Name:   "mary",
+			Access: state.AdminAccess,
+			Local:  &state.LocalIdentity{UserID: 1000},
+		},
+	}
+	c.Assert(identities, DeepEquals, expected)
+
+	// Ensure the map was cloned (mutations to first map won't affect second).
+	identities2 := st.Identities()
+	c.Assert(identities2, DeepEquals, expected)
+	identities["changed"] = &state.Identity{}
+	c.Assert(identities2, DeepEquals, expected)
+}

--- a/internals/overlord/state/identities_test.go
+++ b/internals/overlord/state/identities_test.go
@@ -107,7 +107,10 @@ func (s *identitiesSuite) TestUnmarshalAPIErrors(c *C) {
 		error: `local identity must specify user-id`,
 	}, {
 		data:  `{"invalid-access": {"access": "foo", "local": {"user-id": 42}}}`,
-		error: `invalid access "foo", must be "admin", "read", or "untrusted"`,
+		error: `invalid access value "foo", must be "admin", "read", or "untrusted"`,
+	}, {
+		data:  `{"invalid-access": {"local": {"user-id": 42}}}`,
+		error: `access value must be specified \("admin", "read", or "untrusted"\)`,
 	}}
 	for _, test := range tests {
 		c.Logf("Input data: %s", test.data)
@@ -260,7 +263,7 @@ func (s *identitiesSuite) TestAddIdentities(c *C) {
 			Local:  &state.LocalIdentity{UserID: 43},
 		},
 	})
-	c.Assert(err, ErrorMatches, `identity "bill" invalid: invalid access "bar", must be "admin", "read", or "untrusted"`)
+	c.Assert(err, ErrorMatches, `identity "bill" invalid: invalid access value "bar", must be "admin", "read", or "untrusted"`)
 
 	// Must have at least one type.
 	err = st.AddIdentities(map[string]*state.Identity{

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -11,6 +11,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package state_test
 
 import (

--- a/internals/overlord/state/state_test.go
+++ b/internals/overlord/state/state_test.go
@@ -572,6 +572,7 @@ func (ss *stateSuite) TestEmptyStateDataAndCheckpointReadAndSet(c *C) {
 		"tasks",
 		"warnings",
 		"notices",
+		"identities",
 		"cache",
 		"pendingChangeByAttr",
 		"taskHandlers",


### PR DESCRIPTION
This adds code and tests for the state core of identities ([spec OP043](https://docs.google.com/document/d/1nASgUt-piV94i1cpFsbEPRk_xFbZt8AskgL97gh1Dgg/edit#heading=h.a291qhvyhsw3)).

There's a new `map[string]*Identity` in state, which is marshalled via `marshalledIdentity` to disk. The marshalling for API requests is done by the `apiIdentity` type -- these are separate to ensure that the API (default) `MarshalJSON` for `Identity` does not include secrets (in future when we have identity types that include secrets; there's only user-id for now). So that's why there's a few more types and a bit more boilerplate than is necessary right now.

The new public `State` methods are:

* `AddIdentities`: add new identities to the system
* `UpdateIdentities`: update existing identities in the system
* `ReplaceIdentities`: replace the given identities in the system; this allows adding new ones, updating existing ones, and removing identities (nil/null means remove)
* `RemoveIdentities`: remove existing identities in the system
* `Identities`: list all identities

Each of the `FooIdentities` modification functions validates that the identities are valid, and that the user-ids are unique, before applying to state.