### PR TITLE
perf(daemon): avoid acquiring state lock (twice!) for every API request

### DIFF
--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -262,6 +262,9 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *C) {
 }
 
 func (s *daemonSuite) TestCommandRestartingState(c *C) {
+	if !includeMaintenance {
+		c.Skip("includeMaintenance disabled")
+	}
 	d := s.newDaemon(c)
 
 	cmd := &Command{d: d, ReadAccess: OpenAccess{}}
@@ -312,6 +315,9 @@ func (s *daemonSuite) TestCommandRestartingState(c *C) {
 }
 
 func (s *daemonSuite) TestFillsWarnings(c *C) {
+	if !includeWarningsSummary {
+		c.Skip("includeWarningsSummary disabled")
+	}
 	d := s.newDaemon(c)
 
 	cmd := &Command{d: d, ReadAccess: OpenAccess{}}


### PR DESCRIPTION
In daemon.Command.ServeHTTP, at the end of every request we acquire the state lock twice, once for including the maintenance (restart) info in the response, and once for including the warnings summary. We don't use either maintenance/restarts or warnings in Pebble at all, so let's just turn that off.

We could rip out those features completely, but the APIs need to stay for backwards compatibility, and it's possible we'll want them later, so let's just disable them and their tests for now.

Locking and unlocking the state for reading isn't very expensive, but if something else has locked the state for writing (for example, creating/updating a Change or Task), API requests won't be able to acquire the lock till the relatively slow operation of serialising and writing state is finished. Per #366, that can sometimes be over 1s when the system is under load.

Fixes #366