### PR TITLE
fix(planstate): don't hold planLock while calling plan-changed listeners

### DIFF
--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -141,7 +141,7 @@ func New(opts *Options) (*Overlord, error) {
 	}
 	o.runner.AddOptionalHandler(matchAnyUnknownTask, handleUnknownTask, nil)
 
-	o.planMgr, err = planstate.NewManager(s, o.runner, o.pebbleDir)
+	o.planMgr, err = planstate.NewManager(o.pebbleDir)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create plan manager: %w", err)
 	}

--- a/internals/overlord/planstate/export_test.go
+++ b/internals/overlord/planstate/export_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package planstate
+
+import "sync"
+
+func (m *PlanManager) PlanLock() sync.Locker {
+	return &m.planLock
+}


### PR DESCRIPTION
Some listeners do quite a bit of stuff (check manager and log manager), and they're defined in packages external to the planstate package, so it's best to avoid holding our plan lock for the duration.

See [spec OP040](https://docs.google.com/document/d/1cmZ5FWz0efglDAxGRciY5GRyD6KfWJCOe-kjWl6auig/edit#heading=h.po9vomna3y7d).

Also:

- PlanManager doesn't use state and runner, so remove them
- Rename planHandlers to changeListeners to match AddChangeListener