### PR TITLE
feat(plan): use lanes to start services with dependencies

### DIFF
--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -144,18 +144,18 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 		taskSet.AddAll(stopTasks)
 		taskSet.AddAll(startTasks)
 	case "replan":
-		var stopNames, startNames [][]string
-		stopNames, startNames, err = servmgr.Replan()
+		var stopLanes, startLanes [][]string
+		stopLanes, startLanes, err = servmgr.Replan()
 		if err != nil {
 			break
 		}
 		var stopTasks *state.TaskSet
-		stopTasks, err = servstate.Stop(st, stopNames)
+		stopTasks, err = servstate.Stop(st, stopLanes)
 		if err != nil {
 			break
 		}
 		var startTasks *state.TaskSet
-		startTasks, err = servstate.Start(st, startNames)
+		startTasks, err = servstate.Start(st, startLanes)
 		if err != nil {
 			break
 		}
@@ -166,13 +166,13 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 
 		// Populate a list of services affected by the replan for summary.
 		replanned := make(map[string]bool)
-		for _, row := range stopNames {
-			for _, v := range row {
+		for _, lane := range stopLanes {
+			for _, v := range lane {
 				replanned[v] = true
 			}
 		}
-		for _, row := range startNames {
-			for _, v := range row {
+		for _, lane := range startLanes {
+			for _, v := range lane {
 				replanned[v] = true
 			}
 		}
@@ -237,15 +237,15 @@ func intersectOrdered(left []string, orderedRight [][]string) [][]string {
 	}
 
 	var out [][]string
-	for _, row := range orderedRight {
-		var intersectRow []string
-		for _, v := range row {
+	for _, lane := range orderedRight {
+		var intersectLane []string
+		for _, v := range lane {
 			if m[v] {
-				intersectRow = append(intersectRow, v)
+				intersectLane = append(intersectLane, v)
 			}
 		}
-		if len(intersectRow) > 0 {
-			out = append(out, intersectRow)
+		if len(intersectLane) > 0 {
+			out = append(out, intersectLane)
 		}
 	}
 	return out

--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -111,7 +111,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 		if err != nil {
 			break
 		}
-		taskSet, err = servstate.Start(st, services)
+		taskSet, err = servstate.Start(st, services, servmgr)
 	case "stop":
 		services, err = servmgr.StopOrder(payload.Services)
 		if err != nil {
@@ -134,7 +134,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 			break
 		}
 		var startTasks *state.TaskSet
-		startTasks, err = servstate.Start(st, services)
+		startTasks, err = servstate.Start(st, services, servmgr)
 		if err != nil {
 			break
 		}
@@ -154,7 +154,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 			break
 		}
 		var startTasks *state.TaskSet
-		startTasks, err = servstate.Start(st, startNames)
+		startTasks, err = servstate.Start(st, startNames, servmgr)
 		if err != nil {
 			break
 		}

--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2014-2024 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -191,8 +191,8 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 	// Use the original requested service name for the summary, not the
 	// resolved one. But do use the resolved set for the count.
 	var summary string
-	for _, names := range lanes {
-		services = append(services, names...)
+	for _, row := range lanes {
+		services = append(services, row...)
 	}
 	switch {
 	case len(taskSet.Tasks()) == 0:
@@ -244,7 +244,9 @@ func intersectOrdered(left []string, orderedRight [][]string) [][]string {
 				intersectRow = append(intersectRow, v)
 			}
 		}
-		out = append(out, intersectRow)
+		if len(intersectRow) > 0 {
+			out = append(out, intersectRow)
+		}
 	}
 	return out
 }

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -210,8 +210,8 @@ func (m *ServiceManager) DefaultServiceNames() ([]string, error) {
 	}
 
 	var result []string
-	for _, row := range lanes {
-		result = append(result, row...)
+	for _, lane := range lanes {
+		result = append(result, lane...)
 	}
 	return result, err
 }

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -260,8 +260,8 @@ func (m *ServiceManager) ServiceLogs(services []string, last int) (map[string]se
 	return iterators, nil
 }
 
-// Replan returns a list of services to stop and services to start because
-// their plans had changed between when they started and this call.
+// Replan returns a list of services in lanes to stop and services to start
+// because their plans had changed between when they started and this call.
 func (m *ServiceManager) Replan() ([][]string, [][]string, error) {
 	currentPlan := m.getPlan()
 	m.servicesLock.Lock()
@@ -352,7 +352,7 @@ func (m *ServiceManager) CheckFailed(name string) {
 // manager is terminated. If it starts just after (before the main process
 // exits), it would generate a runtime error as the reaper would already be dead.
 // This function returns a slice of service names to stop, in dependency order,
-// put in separate lanes.
+// put in lanes.
 func servicesToStop(m *ServiceManager) ([][]string, error) {
 	currentPlan := m.getPlan()
 	// Get all service names in plan.

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -204,19 +204,28 @@ func (m *ServiceManager) DefaultServiceNames() ([]string, error) {
 		}
 	}
 
-	return currentPlan.StartOrder(names)
+	lanes, err := currentPlan.StartOrder(names)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, row := range lanes {
+		result = append(result, row...)
+	}
+	return result, err
 }
 
 // StartOrder returns the provided services, together with any required
-// dependencies, in the proper order for starting them all up.
-func (m *ServiceManager) StartOrder(services []string) ([]string, error) {
+// dependencies, in the proper order, put in lanes, for starting them all up.
+func (m *ServiceManager) StartOrder(services []string) ([][]string, error) {
 	currentPlan := m.getPlan()
 	return currentPlan.StartOrder(services)
 }
 
 // StopOrder returns the provided services, together with any dependants,
-// in the proper order for stopping them all.
-func (m *ServiceManager) StopOrder(services []string) ([]string, error) {
+// in the proper order, put in lanes, for stopping them all.
+func (m *ServiceManager) StopOrder(services []string) ([][]string, error) {
 	currentPlan := m.getPlan()
 	return currentPlan.StopOrder(services)
 }
@@ -253,7 +262,7 @@ func (m *ServiceManager) ServiceLogs(services []string, last int) (map[string]se
 
 // Replan returns a list of services to stop and services to start because
 // their plans had changed between when they started and this call.
-func (m *ServiceManager) Replan() ([]string, []string, error) {
+func (m *ServiceManager) Replan() ([][]string, [][]string, error) {
 	currentPlan := m.getPlan()
 	m.servicesLock.Lock()
 	defer m.servicesLock.Unlock()
@@ -278,7 +287,7 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 		}
 	}
 
-	stop, err := currentPlan.StopOrder(stop)
+	stopLanes, err := currentPlan.StopOrder(stop)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,12 +297,12 @@ func (m *ServiceManager) Replan() ([]string, []string, error) {
 		}
 	}
 
-	start, err = currentPlan.StartOrder(start)
+	startLanes, err := currentPlan.StartOrder(start)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return stop, start, nil
+	return stopLanes, startLanes, nil
 }
 
 func (m *ServiceManager) SendSignal(services []string, signal string) error {
@@ -342,8 +351,9 @@ func (m *ServiceManager) CheckFailed(name string) {
 // exit. If it starts just before, it would continue to run after the service
 // manager is terminated. If it starts just after (before the main process
 // exits), it would generate a runtime error as the reaper would already be dead.
-// This function returns a slice of service names to stop, in dependency order.
-func servicesToStop(m *ServiceManager) ([]string, error) {
+// This function returns a slice of service names to stop, in dependency order,
+// put in separate lanes.
+func servicesToStop(m *ServiceManager) ([][]string, error) {
 	currentPlan := m.getPlan()
 	// Get all service names in plan.
 	services := make([]string, 0, len(currentPlan.Services))
@@ -360,12 +370,18 @@ func servicesToStop(m *ServiceManager) ([]string, error) {
 	// Filter down to only those that are running or in backoff
 	m.servicesLock.Lock()
 	defer m.servicesLock.Unlock()
-	var notStopped []string
-	for _, name := range stop {
-		s := m.services[name]
-		if s != nil && (s.state == stateRunning || s.state == stateBackoff) {
-			notStopped = append(notStopped, name)
+	var result [][]string
+	for _, services := range stop {
+		var notStopped []string
+		for _, name := range services {
+			s := m.services[name]
+			if s != nil && (s.state == stateRunning || s.state == stateBackoff) {
+				notStopped = append(notStopped, name)
+			}
+		}
+		if len(notStopped) > 0 {
+			result = append(result, notStopped)
 		}
 	}
-	return notStopped, nil
+	return result, nil
 }

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2014-2024 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -351,17 +351,8 @@ services:
 
 	stops, starts, err := s.manager.Replan()
 	c.Assert(err, IsNil)
-	for _, row := range stops {
-		if len(row) > 0 {
-			c.Check(row, DeepEquals, []string{"test2", "test1"})
-		}
-	}
-
-	for _, row := range starts {
-		if len(row) > 0 {
-			c.Check(row, DeepEquals, []string{"test1", "test2"})
-		}
-	}
+	c.Check(stops, DeepEquals, [][]string{{"test2", "test1"}})
+	c.Check(starts, DeepEquals, [][]string{{"test1", "test2"}})
 
 	s.stopTestServices(c)
 }

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -1820,7 +1820,7 @@ func (s *S) testServiceLogs(c *C, outputs map[string]string) {
 
 func (s *S) startServices(c *C, services []string) *state.Change {
 	s.st.Lock()
-	ts, err := servstate.Start(s.st, services)
+	ts, err := servstate.Start(s.st, services, s.manager)
 	c.Check(err, IsNil)
 	chg := s.st.NewChange("test", "Start test")
 	chg.AddAll(ts)

--- a/internals/overlord/servstate/request.go
+++ b/internals/overlord/servstate/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/pebble/internals/overlord/state"
+	"github.com/canonical/pebble/internals/plan"
 )
 
 // ServiceRequest holds the details required to perform service tasks.
@@ -11,21 +12,77 @@ type ServiceRequest struct {
 	Name string
 }
 
+func get_or_create_lane(s *state.State, service *plan.Service, service_lane_mapping map[string]int) int {
+	// if the service has been mapped to a lane
+	if lane, ok := service_lane_mapping[service.Name]; ok {
+		return lane
+	}
+
+	// if any dependency has been mapped to a lane
+	all_dependencies := append(append(service.Requires, service.Before...), service.After...)
+	for _, dependency := range all_dependencies {
+		if lane, ok := service_lane_mapping[dependency]; ok {
+			return lane
+		}
+	}
+
+	// neither the service itself nor any of its dependencies is mapped to an existing lane
+	return s.NewLane()
+}
+
+func joinLane(s *state.State, task *state.Task, service *plan.Service, service_lane_mapping map[string]int, lane_tasks_mapping map[int][]*state.Task) {
+	lane := get_or_create_lane(s, service, service_lane_mapping)
+	
+	task.JoinLane(lane)
+
+	// map task to lane
+	if _, ok := lane_tasks_mapping[lane]; !ok {
+		lane_tasks_mapping[lane] = nil
+	}
+	lane_tasks_mapping[lane] = append(lane_tasks_mapping[lane], task)
+
+	service_lane_mapping[service.Name] = lane
+	all_dependencies := append(append(service.Requires, service.Before...), service.After...)
+	for _, dependency := range all_dependencies {
+		service_lane_mapping[dependency] = lane
+	}
+}
+
+func handleWaitFor(lane_tasks_mapping map[int][]*state.Task) {
+	for _, tasks := range lane_tasks_mapping {
+		for i := 1; i < len(tasks); i++ {
+			tasks[i].WaitFor(tasks[i-1])
+		}
+	}
+}
+
 // Start creates and returns a task set for starting the given services.
-func Start(s *state.State, services []string) (*state.TaskSet, error) {
+func Start(s *state.State, names []string, m *ServiceManager) (*state.TaskSet, error) {
+	fmt.Println(names)
+	services := m.getPlan().Services
+	service_lane_mapping := make(map[string]int)
+	lane_tasks_mapping := make(map[int][]*state.Task)
+
 	var tasks []*state.Task
-	for _, name := range services {
+
+	for _, name := range names {
+		service, ok := services[name]
+		if !ok {
+			return nil, fmt.Errorf("service %q does not exist", name)
+		}
+
 		task := s.NewTask("start", fmt.Sprintf("Start service %q", name))
 		req := ServiceRequest{
 			Name: name,
 		}
 		task.Set("service-request", &req)
-		if len(tasks) > 0 {
-			// TODO Allow non-dependent services to start in parallel.
-			task.WaitFor(tasks[len(tasks)-1])
-		}
+		joinLane(s, task, service, service_lane_mapping, lane_tasks_mapping)
+
 		tasks = append(tasks, task)
 	}
+
+	handleWaitFor(lane_tasks_mapping)
+
 	return state.NewTaskSet(tasks...), nil
 }
 

--- a/internals/overlord/servstate/request.go
+++ b/internals/overlord/servstate/request.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/canonical/pebble/internals/overlord/state"
-	"github.com/canonical/pebble/internals/plan"
 )
 
 // ServiceRequest holds the details required to perform service tasks.
@@ -12,94 +11,46 @@ type ServiceRequest struct {
 	Name string
 }
 
-func get_or_create_lane(s *state.State, service *plan.Service, service_lane_mapping map[string]int) int {
-	// if the service has been mapped to a lane
-	if lane, ok := service_lane_mapping[service.Name]; ok {
-		return lane
-	}
-
-	// if any dependency has been mapped to a lane
-	all_dependencies := append(append(service.Requires, service.Before...), service.After...)
-	for _, dependency := range all_dependencies {
-		if lane, ok := service_lane_mapping[dependency]; ok {
-			return lane
-		}
-	}
-
-	// neither the service itself nor any of its dependencies is mapped to an existing lane
-	return s.NewLane()
-}
-
-func joinLane(s *state.State, task *state.Task, service *plan.Service, service_lane_mapping map[string]int, lane_tasks_mapping map[int][]*state.Task) {
-	lane := get_or_create_lane(s, service, service_lane_mapping)
-
-	task.JoinLane(lane)
-
-	// map task to lane
-	if _, ok := lane_tasks_mapping[lane]; !ok {
-		lane_tasks_mapping[lane] = nil
-	}
-	lane_tasks_mapping[lane] = append(lane_tasks_mapping[lane], task)
-
-	// map the service's dependencies to the same lane
-	service_lane_mapping[service.Name] = lane
-	all_dependencies := append(append(service.Requires, service.Before...), service.After...)
-	for _, dependency := range all_dependencies {
-		service_lane_mapping[dependency] = lane
-	}
-}
-
-func handleWaitFor(lane_tasks_mapping map[int][]*state.Task) {
-	for _, tasks := range lane_tasks_mapping {
-		for i := 1; i < len(tasks); i++ {
-			tasks[i].WaitFor(tasks[i-1])
-		}
-	}
-}
-
 // Start creates and returns a task set for starting the given services.
-func Start(s *state.State, names []string, m *ServiceManager) (*state.TaskSet, error) {
-	services := m.getPlan().Services
-	service_lane_mapping := make(map[string]int)
-	lane_tasks_mapping := make(map[int][]*state.Task)
-
+func Start(s *state.State, lanes [][]string) (*state.TaskSet, error) {
 	var tasks []*state.Task
-
-	for _, name := range names {
-		service, ok := services[name]
-		if !ok {
-			return nil, fmt.Errorf("service %q does not exist", name)
+	for _, services := range lanes {
+		lane := s.NewLane()
+		for i, name := range services {
+			task := s.NewTask("start", fmt.Sprintf("Start service %q", name))
+			req := ServiceRequest{
+				Name: name,
+			}
+			task.Set("service-request", &req)
+			task.JoinLane(lane)
+			// Wait for the previous task in the same lane.
+			if i > 0 {
+				task.WaitFor(tasks[len(tasks)-1])
+			}
+			tasks = append(tasks, task)
 		}
-
-		task := s.NewTask("start", fmt.Sprintf("Start service %q", name))
-		req := ServiceRequest{
-			Name: name,
-		}
-		task.Set("service-request", &req)
-		joinLane(s, task, service, service_lane_mapping, lane_tasks_mapping)
-
-		tasks = append(tasks, task)
 	}
-
-	handleWaitFor(lane_tasks_mapping)
-
 	return state.NewTaskSet(tasks...), nil
 }
 
 // Stop creates and returns a task set for stopping the given services.
-func Stop(s *state.State, services []string) (*state.TaskSet, error) {
+func Stop(s *state.State, lanes [][]string) (*state.TaskSet, error) {
 	var tasks []*state.Task
-	for _, name := range services {
-		task := s.NewTask("stop", fmt.Sprintf("Stop service %q", name))
-		req := ServiceRequest{
-			Name: name,
+	for _, services := range lanes {
+		lane := s.NewLane()
+		for i, name := range services {
+			task := s.NewTask("stop", fmt.Sprintf("Stop service %q", name))
+			req := ServiceRequest{
+				Name: name,
+			}
+			task.Set("service-request", &req)
+			task.JoinLane(lane)
+			// Wait for the previous task in the same lane.
+			if i > 0 {
+				task.WaitFor(tasks[len(tasks)-1])
+			}
+			tasks = append(tasks, task)
 		}
-		task.Set("service-request", &req)
-		if len(tasks) > 1 {
-			// TODO Allow non-dependent services to stop in parallel.
-			task.WaitFor(tasks[len(tasks)-1])
-		}
-		tasks = append(tasks, task)
 	}
 	return state.NewTaskSet(tasks...), nil
 }
@@ -107,18 +58,18 @@ func Stop(s *state.State, services []string) (*state.TaskSet, error) {
 // StopRunning creates and returns a task set for stopping all running
 // services. It returns a nil *TaskSet if there are no services to stop.
 func StopRunning(s *state.State, m *ServiceManager) (*state.TaskSet, error) {
-	services, err := servicesToStop(m)
+	lanes, err := servicesToStop(m)
 	if err != nil {
 		return nil, err
 	}
-	if len(services) == 0 {
+	if len(lanes) == 0 {
 		return nil, nil
 	}
 
 	// One change to stop them all.
 	s.Lock()
 	defer s.Unlock()
-	taskSet, err := Stop(s, services)
+	taskSet, err := Stop(s, lanes)
 	if err != nil {
 		return nil, err
 	}

--- a/internals/overlord/servstate/request.go
+++ b/internals/overlord/servstate/request.go
@@ -32,7 +32,7 @@ func get_or_create_lane(s *state.State, service *plan.Service, service_lane_mapp
 
 func joinLane(s *state.State, task *state.Task, service *plan.Service, service_lane_mapping map[string]int, lane_tasks_mapping map[int][]*state.Task) {
 	lane := get_or_create_lane(s, service, service_lane_mapping)
-	
+
 	task.JoinLane(lane)
 
 	// map task to lane

--- a/internals/overlord/servstate/request.go
+++ b/internals/overlord/servstate/request.go
@@ -41,6 +41,7 @@ func joinLane(s *state.State, task *state.Task, service *plan.Service, service_l
 	}
 	lane_tasks_mapping[lane] = append(lane_tasks_mapping[lane], task)
 
+	// map the service's dependencies to the same lane
 	service_lane_mapping[service.Name] = lane
 	all_dependencies := append(append(service.Requires, service.Before...), service.After...)
 	for _, dependency := range all_dependencies {
@@ -58,7 +59,6 @@ func handleWaitFor(lane_tasks_mapping map[int][]*state.Task) {
 
 // Start creates and returns a task set for starting the given services.
 func Start(s *state.State, names []string, m *ServiceManager) (*state.TaskSet, error) {
-	fmt.Println(names)
 	services := m.getPlan().Services
 	service_lane_mapping := make(map[string]int)
 	lane_tasks_mapping := make(map[int][]*state.Task)

--- a/internals/overlord/servstate/request_test.go
+++ b/internals/overlord/servstate/request_test.go
@@ -18,7 +18,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internals/overlord/servstate"
-	. "github.com/canonical/pebble/internals/testutil"
 )
 
 func (s *S) TestStart(c *C) {
@@ -57,7 +56,7 @@ services:
 	c.Assert(err, IsNil)
 	c.Assert(req.Name, Equals, "two")
 
-	c.Assert(tasks[0].Lanes()[0], IntNotEqual, tasks[1].Lanes()[0])
+	c.Assert(tasks[0].Lanes()[0], Not(Equals), tasks[1].Lanes()[0])
 }
 
 func (s *S) TestStartInTheSameLaneAfter(c *C) {

--- a/internals/overlord/servstate/request_test.go
+++ b/internals/overlord/servstate/request_test.go
@@ -68,13 +68,13 @@ services:
         override: replace
         command: /bin/sh -c "echo one; sleep 10"
         startup: enabled
+        requires:
+            - two
 
     two:
         override: replace
         command: /bin/sh -c "echo two; sleep 10"
         startup: enabled
-        requires:
-            - one
         after:
             - one
 `

--- a/internals/overlord/servstate/request_test.go
+++ b/internals/overlord/servstate/request_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2014-2024 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -18,13 +18,30 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internals/overlord/servstate"
+	. "github.com/canonical/pebble/internals/testutil"
 )
 
 func (s *S) TestStart(c *C) {
+	s.newServiceManager(c)
+	layer := `
+services:
+    one:
+        override: replace
+        command: /bin/sh -c "echo one; sleep 10"
+        startup: enabled
+
+    two:
+        override: replace
+        command: /bin/sh -c "echo two; sleep 10"
+        startup: enabled
+`
+	s.planAddLayer(c, layer)
+	s.planChanged(c)
+
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	tset, err := servstate.Start(s.st, []string{"one", "two"})
+	tset, err := servstate.Start(s.st, []string{"one", "two"}, s.manager)
 	c.Assert(err, IsNil)
 
 	tasks := tset.Tasks()
@@ -39,6 +56,94 @@ func (s *S) TestStart(c *C) {
 	req, err = servstate.TaskServiceRequest(tasks[1])
 	c.Assert(err, IsNil)
 	c.Assert(req.Name, Equals, "two")
+
+	c.Assert(tasks[0].Lanes()[0], IntNotEqual, tasks[1].Lanes()[0])
+}
+
+func (s *S) TestStartInTheSameLaneAfter(c *C) {
+	s.newServiceManager(c)
+	layer := `
+services:
+    one:
+        override: replace
+        command: /bin/sh -c "echo one; sleep 10"
+        startup: enabled
+
+    two:
+        override: replace
+        command: /bin/sh -c "echo two; sleep 10"
+        startup: enabled
+        requires:
+            - one
+        after:
+            - one
+`
+	s.planAddLayer(c, layer)
+	s.planChanged(c)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	tset, err := servstate.Start(s.st, []string{"one", "two"}, s.manager)
+	c.Assert(err, IsNil)
+
+	tasks := tset.Tasks()
+	c.Assert(len(tasks), Equals, 2)
+
+	c.Assert(tasks[0].Kind(), Equals, "start")
+	req, err := servstate.TaskServiceRequest(tasks[0])
+	c.Assert(err, IsNil)
+	c.Assert(req.Name, Equals, "one")
+
+	c.Assert(tasks[1].Kind(), Equals, "start")
+	req, err = servstate.TaskServiceRequest(tasks[1])
+	c.Assert(err, IsNil)
+	c.Assert(req.Name, Equals, "two")
+
+	c.Assert(tasks[0].Lanes()[0], Equals, tasks[1].Lanes()[0])
+}
+
+func (s *S) TestStartInTheSameLaneBefore(c *C) {
+	s.newServiceManager(c)
+	layer := `
+services:
+    one:
+        override: replace
+        command: /bin/sh -c "echo one; sleep 10"
+        startup: enabled
+        requires:
+            - two
+        before:
+            - two
+
+    two:
+        override: replace
+        command: /bin/sh -c "echo two; sleep 10"
+        startup: enabled
+`
+	s.planAddLayer(c, layer)
+	s.planChanged(c)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	tset, err := servstate.Start(s.st, []string{"one", "two"}, s.manager)
+	c.Assert(err, IsNil)
+
+	tasks := tset.Tasks()
+	c.Assert(len(tasks), Equals, 2)
+
+	c.Assert(tasks[0].Kind(), Equals, "start")
+	req, err := servstate.TaskServiceRequest(tasks[0])
+	c.Assert(err, IsNil)
+	c.Assert(req.Name, Equals, "one")
+
+	c.Assert(tasks[1].Kind(), Equals, "start")
+	req, err = servstate.TaskServiceRequest(tasks[1])
+	c.Assert(err, IsNil)
+	c.Assert(req.Name, Equals, "two")
+
+	c.Assert(tasks[0].Lanes()[0], Equals, tasks[1].Lanes()[0])
 }
 
 func (s *S) TestStop(c *C) {

--- a/internals/overlord/servstate/request_test.go
+++ b/internals/overlord/servstate/request_test.go
@@ -41,7 +41,7 @@ services:
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	tset, err := servstate.Start(s.st, []string{"one", "two"}, s.manager)
+	tset, err := servstate.Start(s.st, [][]string{{"one"}, {"two"}})
 	c.Assert(err, IsNil)
 
 	tasks := tset.Tasks()
@@ -84,7 +84,7 @@ services:
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	tset, err := servstate.Start(s.st, []string{"one", "two"}, s.manager)
+	tset, err := servstate.Start(s.st, [][]string{{"one", "two"}})
 	c.Assert(err, IsNil)
 
 	tasks := tset.Tasks()
@@ -127,7 +127,7 @@ services:
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	tset, err := servstate.Start(s.st, []string{"one", "two"}, s.manager)
+	tset, err := servstate.Start(s.st, [][]string{{"one", "two"}})
 	c.Assert(err, IsNil)
 
 	tasks := tset.Tasks()
@@ -150,7 +150,7 @@ func (s *S) TestStop(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	tset, err := servstate.Stop(s.st, []string{"one", "two"})
+	tset, err := servstate.Stop(s.st, [][]string{{"one", "two"}})
 	c.Assert(err, IsNil)
 
 	tasks := tset.Tasks()

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Canonical Ltd
+// Copyright (c) 2024 Canonical Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -946,7 +946,7 @@ func (p *Plan) StopOrder(names []string) ([][]string, error) {
 	return createLanes(orderedNames, p.Services)
 }
 
-func getOrCreateLane(current_lane int, service *Service, serviceLaneMapping map[string]int) int {
+func getOrCreateLane(currentLane int, service *Service, serviceLaneMapping map[string]int) int {
 	// if the service has been mapped to a lane
 	if lane, ok := serviceLaneMapping[service.Name]; ok {
 		return lane
@@ -960,7 +960,7 @@ func getOrCreateLane(current_lane int, service *Service, serviceLaneMapping map[
 	}
 
 	// neither the service itself nor any of its dependencies is mapped to an existing lane
-	return current_lane + 1
+	return currentLane + 1
 }
 
 func mapServiceToLane(service *Service, lane int, serviceLaneMapping map[string]int) {
@@ -976,7 +976,7 @@ func createLanes(names []string, services map[string]*Service) ([][]string, erro
 	serviceLaneMapping := make(map[string]int)
 
 	// Map all services into lanes.
-	var lane = 0
+	var lane = -1
 	for _, name := range names {
 		service, ok := services[name]
 		if !ok {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -924,16 +924,78 @@ func (p *Plan) Validate() error {
 // services to be properly started, in the order that they must be started.
 // An error is returned when a provided service name does not exist, or there
 // is an order cycle involving the provided service or its dependencies.
-func (p *Plan) StartOrder(names []string) ([]string, error) {
-	return order(p.Services, names, false)
+func (p *Plan) StartOrder(names []string) ([][]string, error) {
+	orderedNames, err := order(p.Services, names, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return createLanes(orderedNames, p.Services)
 }
 
 // StopOrder returns the required services that must be stopped for the named
 // services to be properly stopped, in the order that they must be stopped.
 // An error is returned when a provided service name does not exist, or there
 // is an order cycle involving the provided service or its dependencies.
-func (p *Plan) StopOrder(names []string) ([]string, error) {
-	return order(p.Services, names, true)
+func (p *Plan) StopOrder(names []string) ([][]string, error) {
+	orderedNames, err := order(p.Services, names, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return createLanes(orderedNames, p.Services)
+}
+
+func getOrCreateLane(current_lane int, service *Service, serviceLaneMapping map[string]int) int {
+	// if the service has been mapped to a lane
+	if lane, ok := serviceLaneMapping[service.Name]; ok {
+		return lane
+	}
+
+	// if any dependency has been mapped to a lane
+	for _, dependency := range service.Requires {
+		if lane, ok := serviceLaneMapping[dependency]; ok {
+			return lane
+		}
+	}
+
+	// neither the service itself nor any of its dependencies is mapped to an existing lane
+	return current_lane + 1
+}
+
+func mapServiceToLane(service *Service, lane int, serviceLaneMapping map[string]int) {
+	serviceLaneMapping[service.Name] = lane
+
+	// map the service's dependencies to the same lane
+	for _, dependency := range service.Requires {
+		serviceLaneMapping[dependency] = lane
+	}
+}
+
+func createLanes(names []string, services map[string]*Service) ([][]string, error) {
+	serviceLaneMapping := make(map[string]int)
+
+	// Map all services into lanes.
+	var lane = 0
+	for _, name := range names {
+		service, ok := services[name]
+		if !ok {
+			return nil, &FormatError{
+				Message: fmt.Sprintf("service %q does not exist", name),
+			}
+		}
+
+		lane = getOrCreateLane(lane, service, serviceLaneMapping)
+		mapServiceToLane(service, lane, serviceLaneMapping)
+	}
+
+	// Create lanes
+	lanes := make([][]string, lane+1)
+	for _, service := range names {
+		lane := serviceLaneMapping[service]
+		lanes[lane] = append(lanes[lane], service)
+	}
+	return lanes, nil
 }
 
 func order(services map[string]*Service, names []string, stop bool) ([]string, error) {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -949,18 +949,22 @@ func (p *Plan) StopOrder(names []string) ([][]string, error) {
 func getOrCreateLane(currentLane int, service *Service, serviceLaneMapping map[string]int) int {
 	// if the service has been mapped to a lane
 	if lane, ok := serviceLaneMapping[service.Name]; ok {
+		mapServiceToLane(service, lane, serviceLaneMapping)
 		return lane
 	}
 
 	// if any dependency has been mapped to a lane
 	for _, dependency := range service.Requires {
 		if lane, ok := serviceLaneMapping[dependency]; ok {
+			mapServiceToLane(service, lane, serviceLaneMapping)
 			return lane
 		}
 	}
 
 	// neither the service itself nor any of its dependencies is mapped to an existing lane
-	return currentLane + 1
+	lane := currentLane + 1
+	mapServiceToLane(service, lane, serviceLaneMapping)
+	return lane
 }
 
 func mapServiceToLane(service *Service, lane int, serviceLaneMapping map[string]int) {
@@ -986,7 +990,6 @@ func createLanes(names []string, services map[string]*Service) ([][]string, erro
 		}
 
 		lane = getOrCreateLane(lane, service, serviceLaneMapping)
-		mapServiceToLane(service, lane, serviceLaneMapping)
 	}
 
 	// Create lanes

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1966,7 +1966,7 @@ func (s *S) TestStartStopOrderSingleLane(c *C) {
 				Override: "replace",
 				Command:  `cmd`,
 				Requires: []string{"srv2"},
-				Before: []string{"srv2"},
+				Before:   []string{"srv2"},
 				Startup:  plan.StartupEnabled,
 			},
 			"srv2": {
@@ -1974,7 +1974,7 @@ func (s *S) TestStartStopOrderSingleLane(c *C) {
 				Override: "replace",
 				Command:  `cmd`,
 				Requires: []string{"srv3"},
-				Before: []string{"srv3"},
+				Before:   []string{"srv3"},
 				Startup:  plan.StartupEnabled,
 			},
 			"srv3": {
@@ -1989,7 +1989,7 @@ func (s *S) TestStartStopOrderSingleLane(c *C) {
 	}
 
 	p := plan.Plan{Services: layer.Services}
-	
+
 	lanes, err := p.StartOrder([]string{"srv1", "srv2", "srv3"})
 	c.Assert(err, IsNil)
 	c.Assert(len(lanes), Equals, 1)
@@ -2030,7 +2030,7 @@ func (s *S) TestStartStopOrderMultipleLanes(c *C) {
 	}
 
 	p := plan.Plan{Services: layer.Services}
-	
+
 	lanes, err := p.StartOrder([]string{"srv1", "srv2", "srv3"})
 	c.Assert(err, IsNil)
 	c.Assert(len(lanes), Equals, 3)

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1427,15 +1427,23 @@ func (s *S) TestParseLayer(c *C) {
 			if err == nil {
 				for name, order := range test.start {
 					p := plan.Plan{Services: result.Services}
-					names, err := p.StartOrder([]string{name})
+					lanes, err := p.StartOrder([]string{name})
 					c.Assert(err, IsNil)
-					c.Assert(names, DeepEquals, order)
+					for _, names := range lanes {
+						if len(names) > 0 {
+							c.Assert(names, DeepEquals, order)
+						}
+					}
 				}
 				for name, order := range test.stop {
 					p := plan.Plan{Services: result.Services}
-					names, err := p.StopOrder([]string{name})
+					lanes, err := p.StopOrder([]string{name})
 					c.Assert(err, IsNil)
-					c.Assert(names, DeepEquals, order)
+					for _, names := range lanes {
+						if len(names) > 0 {
+							c.Assert(names, DeepEquals, order)
+						}
+					}
 				}
 			}
 			if err == nil {
@@ -1575,15 +1583,23 @@ func (s *S) TestReadDir(c *C) {
 			if err == nil {
 				for name, order := range test.start {
 					p := plan.Plan{Services: result.Services}
-					names, err := p.StartOrder([]string{name})
+					lanes, err := p.StartOrder([]string{name})
 					c.Assert(err, IsNil)
-					c.Assert(names, DeepEquals, order)
+					for _, names := range lanes {
+						if len(names) > 0 {
+							c.Assert(names, DeepEquals, order)
+						}
+					}
 				}
 				for name, order := range test.stop {
 					p := plan.Plan{Services: result.Services}
-					names, err := p.StopOrder([]string{name})
+					lanes, err := p.StopOrder([]string{name})
 					c.Assert(err, IsNil)
-					c.Assert(names, DeepEquals, order)
+					for _, names := range lanes {
+						if len(names) > 0 {
+							c.Assert(names, DeepEquals, order)
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When starting services, put services that depend on each other (before/after/requires) in the same lane. If there is no dependency, put it in a stand-alone lane. Tasks only wait for tasks defined in the same lane.

Fixes https://github.com/canonical/pebble/issues/231.

## Logic

The logic is as follows:

- get services from plan so that before/after/requires can be fetched
- if a service doesn't depend on other services or isn't dependent by other services (it doesn't have before/after/requires, and it doesn't show up in other services' before/after/requires), put it in a single lane
- if a service has dependencies (before/after/requires), all these dependencies will be put in the same lane as the service itself
- tasks only wait for tasks of the same lane. Since the input is already sorted, the latter tasks of the same lane only need to wait for the previous task in the same lane.

## Tests

I mainly ran three types of test. The first is the one mentioned in https://github.com/canonical/pebble/issues/231: 

```yaml
services:
  a:
    override: replace
    command: sh -c "sleep 999"
    startup: enabled
  b:
    override: replace
    command: sh -c "exit 123"
    startup: enabled
  c:
    override: replace
    command: sh -c "sleep 999"
    startup: enabled
```

With this feature, service C won't be in "hold" status, but rather, started. Logs:

```bash
2024-07-23T17:24:56.172Z [pebble] Started daemon.
2024-07-23T17:24:56.182Z [pebble] POST /v1/services 2.781792ms 202
2024-07-23T17:24:56.185Z [pebble] Service "a" starting: sh -c "sleep 999"
2024-07-23T17:24:56.185Z [pebble] Service "b" starting: sh -c "exit 123"
2024-07-23T17:24:56.186Z [pebble] Service "c" starting: sh -c "sleep 999"
2024-07-23T17:24:56.189Z [pebble] Change 1 task (Start service "b") failed: cannot start service: exited quickly with code 123
2024-07-23T17:24:57.190Z [pebble] GET /v1/changes/1/wait 1.005492792s 200
2024-07-23T17:24:57.190Z [pebble] Started default services with change 1.
2024-07-23T17:25:01.404Z [pebble] GET /v1/services?names= 120.625µs 200
^C2024-07-23T17:25:21.617Z [pebble] Exiting on interrupt signal.
2024-07-23T17:25:21.621Z [pebble] Stopping all running services.
2024-07-23T17:25:21.628Z [pebble] Service "c" stopped
2024-07-23T17:25:21.628Z [pebble] Service "a" stopped
```

As a second test, if C depends on B, C is still in "hold" because they are in the same lane:

```yaml
services:
  a:
    override: replace
    command: sh -c "sleep 999"
    startup: enabled
  b:
    override: replace
    command: sh -c "exit 123"
    startup: enabled
  c:
    override: replace
    command: sh -c "sleep 999"
    startup: enabled
    requires:
      - b
```

Logs:

```bash
2024-07-23T17:25:37.799Z [pebble] Started daemon.
2024-07-23T17:25:37.810Z [pebble] POST /v1/services 2.859792ms 202
2024-07-23T17:25:37.813Z [pebble] Service "a" starting: sh -c "sleep 999"
2024-07-23T17:25:37.813Z [pebble] Service "b" starting: sh -c "exit 123"
2024-07-23T17:25:37.816Z [pebble] Change 1 task (Start service "b") failed: cannot start service: exited quickly with code 123
2024-07-23T17:25:38.819Z [pebble] GET /v1/changes/1/wait 1.005558292s 200
2024-07-23T17:25:38.820Z [pebble] Started default services with change 1.
2024-07-23T17:25:47.218Z [pebble] GET /v1/services?names= 103.208µs 200
^C2024-07-23T17:26:19.741Z [pebble] Exiting on interrupt signal.
2024-07-23T17:26:19.745Z [pebble] Stopping all running services.
2024-07-23T17:26:19.752Z [pebble] Service "a" stopped
```

As a third test, I tested the "requires + before" combination:

```yaml
services:
  a:
    override: replace
    command: sh -c "exit 123"
    startup: enabled
    requires:
      - b
    before:
      - b
  b:
    override: replace
    command: sh -c "sleep 999"
    startup: enabled
```

Logs:

```bash
2024-07-23T17:26:23.145Z [pebble] Started daemon.
2024-07-23T17:26:23.154Z [pebble] POST /v1/services 2.873792ms 202
2024-07-23T17:26:23.157Z [pebble] Service "a" starting: sh -c "exit 123"
2024-07-23T17:26:23.161Z [pebble] Change 1 task (Start service "a") failed: cannot start service: exited quickly with code 123
2024-07-23T17:26:23.167Z [pebble] GET /v1/changes/1/wait 12.322667ms 200
2024-07-23T17:26:23.167Z [pebble] Started default services with change 1.
2024-07-23T17:26:26.642Z [pebble] GET /v1/services?names= 583.833µs 200
^C2024-07-23T17:26:52.384Z [pebble] Exiting on interrupt signal.
```
