### PR TITLE
feat(overlord): reversed order of manager stop

### DIFF
--- a/internals/overlord/stateengine.go
+++ b/internals/overlord/stateengine.go
@@ -180,8 +180,8 @@ func (se *StateEngine) Stop() {
 	}
 	for _, m := range se.managers {
 		if stopper, ok := m.(StateStopper); ok {
-			logger.Debugf("state engine: stopping %T", m)
-			stopper.Stop()
+			defer stopper.Stop()
+			defer logger.Debugf("state engine: stopping %T", m)
 		}
 	}
 	se.stopped = true

--- a/internals/overlord/stateengine.go
+++ b/internals/overlord/stateengine.go
@@ -178,10 +178,14 @@ func (se *StateEngine) Stop() {
 	if se.stopped {
 		return
 	}
-	for _, m := range se.managers {
+	// Stop managers in reverse order to how they were added. Managers should
+	// not have dependencies on each other, but stopping in reverse order is
+	// least surprising.
+	for i := len(se.managers) - 1; i >= 0; i-- {
+		m := se.managers[i]
 		if stopper, ok := m.(StateStopper); ok {
-			defer stopper.Stop()
-			defer logger.Debugf("state engine: stopping %T", m)
+			logger.Debugf("State engine is stopping %T", m)
+			stopper.Stop()
 		}
 	}
 	se.stopped = true

--- a/internals/overlord/stateengine_test.go
+++ b/internals/overlord/stateengine_test.go
@@ -167,7 +167,7 @@ func (ses *stateEngineSuite) TestStop(c *C) {
 	calls = []string{}
 
 	se.Stop()
-	c.Check(calls, DeepEquals, []string{"stop:mgr1", "stop:mgr2"})
+	c.Check(calls, DeepEquals, []string{"stop:mgr2", "stop:mgr1"})
 	se.Stop()
 	c.Check(calls, HasLen, 2)
 


### PR DESCRIPTION
Currently managers are started and stopped in a FIFO (first in, first out) order, but I would expect managers to behave more like a stack, in that they are started and stopped in a LIFO (last in first out) order. So the stopping of the managers should be done in reverse.

See this image:
![image](https://github.com/canonical/pebble/assets/9417983/a6ac225c-8246-43bd-bcd6-1857e90b2ff9)

Why? Because what if manager M2 started after manager M1 depends on some functionality from M1? Stopping M1 before stopping M2 might lead to unexpected and undefined behavior.

I chose to implement this behavior with the `defer` keyword [as it behaves in a LIFO manner](https://go.dev/tour/flowcontrol/13), but this could also be done by reverse iterating over the slice. I found the `defer` approach to be more concise, but feel free to correct me.

@benhoyt could you please take a look at this and advise me if I'm missing something?

