### PR TITLE
fix(snap): build snap with Go 1.22 to fix CVE-2024-24790

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.20/stable
+      - go/1.22/stable
     override-build: |
       go generate ./cmd
       CGO_ENABLED=0 go build -trimpath -ldflags=-w -ldflags=-s -o $CRAFT_PART_INSTALL/bin/pebble ./cmd/pebble


### PR DESCRIPTION
Although not shown in the CI (because Trivy is being run with `trivy fs`, which [doesn't consider the Pebble binary](https://aquasecurity.github.io/trivy/v0.24.4/vulnerability/detection/language/)), there currently is a reported CVE in the Pebble snap (CVE-2024-24790).

This CVE seems to have been fixed on newer versions of Go, but we are still using Go 1.20 to build the Pebble snap.

This PR bumps this build dependency to Go 1.22.