### PR TITLE
fix(snap): set Pebble version before snap builds

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -30,6 +30,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+
+      # Generate the version for the local snap build.
+      - run: go generate ./cmd
+
       - name: Build ${{ env.SNAP_NAME }} Snap
         id: build-snap
         uses: snapcore/action-build@v1.1.3
@@ -69,6 +77,16 @@ jobs:
           echo '${{ secrets.LP_CREDENTIALS }}' > ${lp_creds_path}/launchpad-credentials
           git config --global user.email "${{ secrets.PEBBLE_DEV_MAILING_LIST}}"
           git config --global user.name "pebble-dev"
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+
+      # Ensure Snapcraft will ship the generated version files to LP.
+      - run: |
+          go generate ./cmd
+          git add -f ./cmd/VERSION ./cmd/version_generated.go
 
       - name: Build ${{ env.SNAP_NAME }} Snap for ${{ matrix.arch }}
         id: build-snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,11 +34,10 @@ parts:
     source: .
     build-snaps:
       - go/1.22/stable
-    # TODO(benhoyt): temporarily remove "go generate" step so that version
-    #                is pulled directly from version.go in Git
-    # override-build: |
-    #   go generate ./cmd
-    #   CGO_ENABLED=0 go build -trimpath -ldflags=-w -ldflags=-s -o $CRAFT_PART_INSTALL/bin/pebble ./cmd/pebble
+    # The snap build relies on the cmd/version*.go files within the source path.
+    # For proper versioning, run "go generate ./cmd/" before building the snap.
+    # If doing a "snapcraft remote-build", ensure you've also run
+    # "git add -f ./cmd/VERSION ./cmd/version_generated.go".
     override-build: |
       CGO_ENABLED=0 go build -trimpath -ldflags=-w -ldflags=-s -o $CRAFT_PART_INSTALL/bin/pebble ./cmd/pebble
 


### PR DESCRIPTION
# Problem

When doing a `snapcraft remote-build`, Snapcraft will create a copy of the project in Launchpad before running the snap build.
The **problem** is that Snapcraft seems to ignore tags while creating the copy of the project, which means the `go generate ./cmd` in the `snapcraft.yaml`'s `override-build` will never dynamically generate the right version.

# Solution

This PR enforces the execution of `go generate ./cmd` as a pre-requisite for running the snap build. I.e., for both local and remote builds, `go generate ./cmd` must be run first, such that the `VERSION` and `version_generated.go` files are staged in the repo, prior to the snap build, such that the `override-build` script can simply rely on that information and thus ignore the missing Git refs in the LP's project.