### PR TITLE
fix: make Client.Pull properly handle API errors

### DIFF
--- a/client/files.go
+++ b/client/files.go
@@ -550,7 +550,16 @@ func (client *Client) Pull(opts *PullOptions) error {
 		return fmt.Errorf("cannot parse Content-Type: %w", err)
 	}
 	if mediaType != "multipart/form-data" {
-		// Not an error response after all.
+		// If it's not multipart, it's likely an API error, so try parsing it as such.
+		var serverResp response
+		err := decodeInto(resp.Body, &serverResp)
+		if err != nil {
+			return fmt.Errorf("expected a multipart response, got %q", mediaType)
+		}
+		err = serverResp.err()
+		if err != nil {
+			return err
+		}
 		return fmt.Errorf("expected a multipart response, got %q", mediaType)
 	}
 

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -774,6 +774,20 @@ func (cs *clientSuite) TestPullFailsWithNonMultipartResponse(c *C) {
 	c.Assert(err, ErrorMatches, `expected a multipart response, got "text/plain"`)
 }
 
+func (cs *clientSuite) TestPullFailsWithErrorResponse(c *C) {
+	cs.header = http.Header{}
+	cs.header.Set("Content-Type", "application/json")
+	cs.rsp = `{"type":"error","status-code":401,"status":"Unauthorized","result":{"message":"access denied","kind":"login-required"}}`
+
+	// Check response
+	var targetBuf bytes.Buffer
+	err := cs.cli.Pull(&client.PullOptions{
+		Path:   "/foo/bar.dat",
+		Target: &targetBuf,
+	})
+	c.Assert(err, ErrorMatches, "access denied")
+}
+
 func (cs *clientSuite) TestPullFailsWithInvalidMultipartResponse(c *C) {
 	cs.header = http.Header{}
 	cs.header.Set("Content-Type", "multipart/form-data")


### PR DESCRIPTION
Currently the `Client.Pull` method is immediately checking the content type for multipart, but we should also check for a regular API error. This PR fixes that.

Before (in case of permission denied error):

```
$ pebble pull /etc/hosts hosts
error: expected a multipart response, got "application/json"
```

After:

```
$ pebble pull /etc/hosts hosts
error: access denied (try with sudo)
```

Fixes #413