### PR TITLE
feat(daemon): add Err() to retrieve the tomb death reason

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -292,7 +292,7 @@ out:
 			break out
 		case <-d.Dying():
 			// something called Stop()
-			logger.Noticef("Server exiting!")
+			logger.Noticef("Server exiting! Reason: %v", d.Err())
 			break out
 		case <-checkTicker:
 			if err := sanityCheck(); err == nil {

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -776,6 +776,12 @@ func (d *Daemon) Dying() <-chan struct{} {
 	return d.tomb.Dying()
 }
 
+// Err returns the death reason, or ErrStillAlive
+// if the tomb is not in a dying or dead state.
+func (d *Daemon) Err() error {
+	return d.tomb.Err()
+}
+
 func clearReboot(st *state.State) {
 	// FIXME See notes in the state package. This logic should be
 	// centralized in the overlord which is the orchestrator. Right


### PR DESCRIPTION
Daemon has a `.Dying()` method that mirrors the [`Tomb.Dying()`](https://pkg.go.dev/gopkg.in/tomb.v2#Tomb.Dying) API, but not `.Err()` for the [`Tomb.Err()`](https://pkg.go.dev/gopkg.in/tomb.v2#Tomb.Err) API. Add a `.Err()` pass-through function and print out the server exit reason for easier debugging should one of the daemon tomb goroutines die.