### PR TITLE
fix: actually turn off child subreaping in reaper.Stop

### DIFF
--- a/internals/reaper/reaper.go
+++ b/internals/reaper/reaper.go
@@ -65,6 +65,12 @@ func Stop() error {
 	}
 	mutex.Unlock()
 
+	// Disable receiving of SIGCHLD before we stop the loop that handles them.
+	err := setChildSubreaper(0)
+	if err != nil {
+		return err
+	}
+
 	reaperTomb.Kill(nil)
 	reaperTomb.Wait()
 	reaperTomb = tomb.Tomb{}
@@ -72,11 +78,6 @@ func Stop() error {
 	mutex.Lock()
 	started = false
 	mutex.Unlock()
-
-	err := setChildSubreaper(0)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
Previously we weren't actually turning off child subreaping at the OS level in `reaper.Stop`, so it didn't reverse `reaper.Start`. Fix this, and also simplify the error handling a little.

This almost certainly didn't cause problems, because as soon as the Pebble process exits it doesn't matter. But it wouldn't have turned it off in tests, and it's just the Right Thing To Do.

Fixes #412