### PR TITLE
fix(timeutil): remove unreachable panic() call

### DIFF
--- a/internals/timeutil/human.go
+++ b/internals/timeutil/human.go
@@ -52,9 +52,7 @@ func delta(then, now time.Time) int {
 func humanTimeSince(then, now time.Time, cutoffDays int) string {
 	d := delta(then, now)
 	switch {
-	case d < -cutoffDays || d > cutoffDays:
-		return then.Format("2006-01-02")
-	case d < -1:
+	case d < -1 && d >= -cutoffDays:
 		return fmt.Sprintf(then.Format("%d days ago, at 15:04 MST"), -d)
 	case d == -1:
 		return then.Format("yesterday at 15:04 MST")
@@ -62,10 +60,9 @@ func humanTimeSince(then, now time.Time, cutoffDays int) string {
 		return then.Format("today at 15:04 MST")
 	case d == 1:
 		return then.Format("tomorrow at 15:04 MST")
-	case d > 1:
+	case d > 1 && d <= cutoffDays:
 		return fmt.Sprintf(then.Format("in %d days, at 15:04 MST"), d)
 	default:
-		// the following message is brought to you by Joel Armando, the self-described awesome and sexy mathematician.
-		panic("you have broken the law of trichotomy! ℤ is no longer totally ordered! chaos ensues!")
+		return then.Format("2006-01-02")
 	}
 }


### PR DESCRIPTION
This has been added in upstream snapd back in the day here:

* https://github.com/snapcore/snapd/pull/4775

Move conditionals to the correct `case` where they belong (e.g. `>= -cutoffDays` belongs to the "%d days ago", ...), and then just naturally move the non-special case of `then.Format("2006-01-02")` to the `default` case.

Looking at compiler explorer, it seems like Go (gc 1.21 on x86_64) can optimize out the old version's `panic()`, so it's just dead code in the source (as it should be): https://godbolt.org/z/fxqTzYfPv