### PR TITLE
feat(daemon): allow overriding layers directory in daemon.Options

### DIFF
--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -62,6 +62,10 @@ type Options struct {
 	// Dir is the pebble directory where all setup is found. Defaults to /var/lib/pebble/default.
 	Dir string
 
+	// LayersDir is an optional path for the layers directory.
+	// Defaults to "layers" inside the pebble directory.
+	LayersDir string
+
 	// SocketPath is an optional path for the unix socket used for the client
 	// to communicate with the daemon. Defaults to a hidden (dotted) name inside
 	// the pebble directory.
@@ -836,6 +840,7 @@ func New(opts *Options) (*Daemon, error) {
 
 	ovldOptions := overlord.Options{
 		PebbleDir:      opts.Dir,
+		LayersDir:      opts.LayersDir,
 		RestartHandler: d,
 		ServiceOutput:  opts.ServiceOutput,
 		Extension:      opts.OverlordExtension,

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -68,6 +68,8 @@ type Extension interface {
 type Options struct {
 	// PebbleDir is the path to the pebble directory. It must be provided.
 	PebbleDir string
+	// LayersDir is the path to the layers directory. It defaults to "<PebbleDir>/layers" if empty.
+	LayersDir string
 	// RestartHandler is an optional structure to handle restart requests.
 	RestartHandler restart.Handler
 	// ServiceOutput is an optional output for the logging manager.
@@ -145,7 +147,11 @@ func New(opts *Options) (*Overlord, error) {
 	o.restartMgr = restartMgr
 	o.stateEng.AddManager(restartMgr)
 
-	o.planMgr, err = planstate.NewManager(o.pebbleDir)
+	layersDir := opts.LayersDir
+	if layersDir == "" {
+		layersDir = filepath.Join(opts.PebbleDir, "layers")
+	}
+	o.planMgr, err = planstate.NewManager(layersDir)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create plan manager: %w", err)
 	}

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -32,7 +32,7 @@ func (e *LabelExists) Error() string {
 }
 
 type PlanManager struct {
-	pebbleDir string
+	layersDir string
 
 	planLock sync.Mutex
 	plan     *plan.Plan
@@ -40,9 +40,9 @@ type PlanManager struct {
 	changeListeners []PlanChangedFunc
 }
 
-func NewManager(pebbleDir string) (*PlanManager, error) {
+func NewManager(layersDir string) (*PlanManager, error) {
 	manager := &PlanManager{
-		pebbleDir: pebbleDir,
+		layersDir: layersDir,
 		plan:      &plan.Plan{},
 	}
 	return manager, nil
@@ -53,7 +53,7 @@ func NewManager(pebbleDir string) (*PlanManager, error) {
 // the case of a non-existent layers directory, or no layers in the layers
 // directory, an empty plan is announced to change subscribers.
 func (m *PlanManager) Load() error {
-	plan, err := plan.ReadDir(m.pebbleDir)
+	plan, err := plan.ReadDir(m.layersDir)
 	if err != nil {
 		return err
 	}

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -57,7 +57,7 @@ var loadLayers = []string{`
 
 func (ps *planSuite) TestLoadLayers(c *C) {
 	var err error
-	ps.planMgr, err = planstate.NewManager(ps.pebbleDir)
+	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
 	// Write layers
 	for _, l := range loadLayers {
@@ -85,7 +85,7 @@ services:
 
 func (ps *planSuite) TestAppendLayers(c *C) {
 	var err error
-	ps.planMgr, err = planstate.NewManager(ps.pebbleDir)
+	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
 
 	// Append a layer when there are no layers.
@@ -165,7 +165,7 @@ services:
 
 func (ps *planSuite) TestCombineLayers(c *C) {
 	var err error
-	ps.planMgr, err = planstate.NewManager(ps.pebbleDir)
+	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
 
 	// "Combine" layer with no layers should just append.
@@ -287,7 +287,7 @@ checks:
 
 func (ps *planSuite) TestSetServiceArgs(c *C) {
 	var err error
-	ps.planMgr, err = planstate.NewManager(ps.pebbleDir)
+	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
 
 	// This is the original plan
@@ -328,7 +328,7 @@ services:
 }
 
 func (ps *planSuite) TestChangeListenerAndLocking(c *C) {
-	manager, err := planstate.NewManager(ps.pebbleDir)
+	manager, err := planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
 
 	calls := 0

--- a/internals/overlord/planstate/package_test.go
+++ b/internals/overlord/planstate/package_test.go
@@ -34,7 +34,7 @@ func Test(t *testing.T) { TestingT(t) }
 
 type planSuite struct {
 	planMgr   *planstate.PlanManager
-	pebbleDir string
+	layersDir string
 
 	writeLayerCounter int
 }
@@ -42,10 +42,7 @@ type planSuite struct {
 var _ = Suite(&planSuite{})
 
 func (ps *planSuite) SetUpTest(c *C) {
-	ps.pebbleDir = c.MkDir()
-	planDir := filepath.Join(ps.pebbleDir, "layers")
-	err := os.Mkdir(planDir, 0755)
-	c.Assert(err, IsNil)
+	ps.layersDir = c.MkDir()
 
 	//Reset write layer counter
 	ps.writeLayerCounter = 1
@@ -53,7 +50,7 @@ func (ps *planSuite) SetUpTest(c *C) {
 
 func (ps *planSuite) writeLayer(c *C, layer string) {
 	filename := fmt.Sprintf("%03[1]d-layer-file-%[1]d.yaml", ps.writeLayerCounter)
-	err := os.WriteFile(filepath.Join(ps.pebbleDir, "layers", filename), []byte(layer), 0644)
+	err := os.WriteFile(filepath.Join(ps.layersDir, filename), []byte(layer), 0644)
 	c.Assert(err, IsNil)
 
 	ps.writeLayerCounter++

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1138,11 +1138,10 @@ func ReadLayersDir(dirname string) ([]*Layer, error) {
 	return layers, nil
 }
 
-// ReadDir reads the configuration layers from the "layers" sub-directory in
-// dir, and returns the resulting Plan. If the "layers" sub-directory doesn't
+// ReadDir reads the configuration layers from layersDir,
+// and returns the resulting Plan. If layersDir doesn't
 // exist, it returns a valid Plan with no layers.
-func ReadDir(dir string) (*Plan, error) {
-	layersDir := filepath.Join(dir, "layers")
+func ReadDir(layersDir string) (*Plan, error) {
 	_, err := os.Stat(layersDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1565,7 +1565,7 @@ func (s *S) TestReadDir(c *C) {
 			err := os.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%03d-layer-%d.yaml", i, i)), reindent(yml), 0644)
 			c.Assert(err, IsNil)
 		}
-		sup, err := plan.ReadDir(pebbleDir)
+		sup, err := plan.ReadDir(layersDir)
 		if err == nil {
 			var result *plan.Layer
 			result, err = plan.CombineLayers(sup.Layers...)
@@ -1617,7 +1617,7 @@ func (s *S) TestReadDirBadNames(c *C) {
 		fpath := filepath.Join(layersDir, fname)
 		err := os.WriteFile(fpath, []byte("<ignore>"), 0644)
 		c.Assert(err, IsNil)
-		_, err = plan.ReadDir(pebbleDir)
+		_, err = plan.ReadDir(layersDir)
 		c.Assert(err.Error(), Equals, fmt.Sprintf("invalid layer filename: %q (must look like \"123-some-label.yaml\")", fname))
 		err = os.Remove(fpath)
 		c.Assert(err, IsNil)
@@ -1641,7 +1641,7 @@ func (s *S) TestReadDirDupNames(c *C) {
 			err := os.WriteFile(fpath, []byte("summary: ignore"), 0644)
 			c.Assert(err, IsNil)
 		}
-		_, err = plan.ReadDir(pebbleDir)
+		_, err = plan.ReadDir(layersDir)
 		c.Assert(err.Error(), Equals, fmt.Sprintf("invalid layer filename: %q not unique (have %q already)", fnames[1], fnames[0]))
 		for _, fname := range fnames {
 			fpath := filepath.Join(layersDir, fname)


### PR DESCRIPTION
This allows having the layers directory in a different directory than the "layers" sub-directory inside the pebble directory.

The defaults are unchanged, but one can pass an optional non-empty string in `daemon.Options{LayersDir: ...}` when calling `daemon.New()` to use a custom location for the layers.

This also removes the need to pass `pebbleDir` into `plan` and `planstate`, as it really only needs the `layersDir`.