### PR TITLE
docs: improvements based on feedback from anne and daniele

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -25,7 +25,7 @@ author = 'Canonical Group Ltd'
 # The title you want to display for the documentation in the sidebar.
 # You might want to include a version number here.
 # To not display any title, set this option to an empty string.
-html_title = project + ' documentation'
+html_title = ''
 
 # The default value uses the current year as the copyright year.
 #

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,9 +1,25 @@
 # How-to guides
 
+These guides will walk you through every step of using Pebble through its complete operations lifecycle.
+
+## Installation
+
+Installation follows a broadly similar pattern on all architectures, and you can choose to install the pre-built binary or build it from the source by yourself.
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
 Install Pebble <install-pebble>
+```
+
+## Service Orchestration
+
+As your needs grow, you may want to orchestrate multiple services.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Manage service dependencies <service-dependencies>
 ```

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started with Pebble
 
-In this tutorial, we will download and install Pebble, configure layers, run the Pebble daemon, and work with layers and services. This tutorial takes about 15 minutes to complete.
+In this tutorial, we will download and install Pebble, configure layers, run the Pebble daemon, and work with layers and services to discover some of Pebble's basic service orchestration capabilities. At the end of the tutorial, we should have two running HTTP servers listening on different ports managed by Pebble. This tutorial takes about 15 minutes to complete.
 
 After this tutorial, you will have a basic understanding of what Pebble is and how to use it to orchestrate services, and you can continue exploring more advanced features and use cases (see {ref}`next_steps`).
 


### PR DESCRIPTION
Minor docs improvements.

Changes:

- Remove "Pebble" from the top left navigation menu.
- Add more context to the Tutorial intro.
- Group how-tos into different groups on the how-to landing page.
