### PR TITLE
feat(plan): do not allocate unused plan maps

### DIFF
--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -201,8 +201,6 @@ var planTests = []planTest{{
 				Startup:  plan.StartupUnknown,
 			},
 		},
-		Checks:     map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{},
 	}, {
 		Order:       1,
 		Label:       "layer-1",
@@ -251,8 +249,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		Checks:     map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{},
 	}},
 	result: &plan.Layer{
 		Summary:     "Simple override layer.",
@@ -330,8 +326,6 @@ var planTests = []planTest{{
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
 			},
 		},
-		Checks:     map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 	start: map[string][]string{
 		"srv1": {"srv2", "srv1", "srv3"},
@@ -392,8 +386,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		Checks:     map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{},
 	}},
 }, {
 	summary: "Unknown keys are not accepted",
@@ -542,8 +534,6 @@ var planTests = []planTest{{
 				Command:  `cmd -v [ --foo bar -e "x [ y ] z" ]`,
 			},
 		},
-		Checks:     map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{},
 	}},
 }, {
 	summary: `Invalid service command: cannot have any arguments after [ ... ] group`,
@@ -605,7 +595,6 @@ var planTests = []planTest{{
 					working-dir: /root
 `},
 	result: &plan.Layer{
-		Services: map[string]*plan.Service{},
 		Checks: map[string]*plan.Check{
 			"chk-http": {
 				Name:      "chk-http",
@@ -651,7 +640,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 }, {
 	summary: "Checks override replace works correctly",
@@ -695,7 +683,6 @@ var planTests = []planTest{{
 					command: sleep 2
 `},
 	result: &plan.Layer{
-		Services: map[string]*plan.Service{},
 		Checks: map[string]*plan.Check{
 			"chk-http": {
 				Name:      "chk-http",
@@ -728,7 +715,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 }, {
 	summary: "Checks override merge works correctly",
@@ -772,7 +758,6 @@ var planTests = []planTest{{
 						FOO: bar
 `},
 	result: &plan.Layer{
-		Services: map[string]*plan.Service{},
 		Checks: map[string]*plan.Check{
 			"chk-http": {
 				Name:      "chk-http",
@@ -811,7 +796,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 }, {
 	summary: "Timeout is capped at period",
@@ -826,7 +810,6 @@ var planTests = []planTest{{
 					port: 80
 `},
 	result: &plan.Layer{
-		Services: map[string]*plan.Service{},
 		Checks: map[string]*plan.Check{
 			"chk1": {
 				Name:      "chk1",
@@ -840,7 +823,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 }, {
 	summary: "Unset timeout is capped at period",
@@ -854,7 +836,6 @@ var planTests = []planTest{{
 					port: 80
 `},
 	result: &plan.Layer{
-		Services: map[string]*plan.Service{},
 		Checks: map[string]*plan.Check{
 			"chk1": {
 				Name:      "chk1",
@@ -868,7 +849,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 }, {
 	summary: "One of http, tcp, or exec must be present for check",
@@ -972,7 +952,6 @@ var planTests = []planTest{{
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
 			},
 		},
-		Checks: map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1061,7 +1040,6 @@ var planTests = []planTest{{
 				Startup:  plan.StartupEnabled,
 			},
 		},
-		Checks: map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1101,7 +1079,6 @@ var planTests = []planTest{{
 				Startup:  plan.StartupEnabled,
 			},
 		},
-		Checks: map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1145,7 +1122,6 @@ var planTests = []planTest{{
 				BackoffLimit:  plan.OptionalDuration{Value: defaultBackoffLimit},
 			},
 		},
-		Checks: map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1251,10 +1227,8 @@ var planTests = []planTest{{
 					label3: bar23
 `},
 	layers: []*plan.Layer{{
-		Order:    0,
-		Label:    "layer-0",
-		Services: map[string]*plan.Service{},
-		Checks:   map[string]*plan.Check{},
+		Order: 0,
+		Label: "layer-0",
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1278,10 +1252,8 @@ var planTests = []planTest{{
 			},
 		},
 	}, {
-		Order:    1,
-		Label:    "layer-1",
-		Services: map[string]*plan.Service{},
-		Checks:   map[string]*plan.Check{},
+		Order: 1,
+		Label: "layer-1",
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1304,8 +1276,6 @@ var planTests = []planTest{{
 		},
 	}},
 	result: &plan.Layer{
-		Services: map[string]*plan.Service{},
-		Checks:   map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{
 			"tgt1": {
 				Name:     "tgt1",
@@ -1377,8 +1347,6 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		Checks:     map[string]*plan.Check{},
-		LogTargets: map[string]*plan.LogTarget{},
 	},
 }, {
 	summary: "Three layers missing command",


### PR DESCRIPTION
The Pebble plan library currently allocates a new layer in two places:

1. ```ParseLayer(order int, label string, data []byte) (*Layer, error)```
2. ```CombineLayers(layers ...*Layer) (*Layer, error)```

The current approach is to always allocate the plan section (```Services```, ```Checks``` or ```LogTargets```) maps of the layer first, irrespective if the section might be empty or not:

```go
func ParseLayer(order int, label string, data []byte) (*Layer, error) {
    layer := Layer{
        Services:   map[string]*Service{},
        Checks:     map[string]*Check{},
        LogTargets: map[string]*LogTarget{},
    }
    :
```

Since nil maps in Golang supports indexing and ```len()``` we can leave unused maps nil to save a little bit of memory in the process and remove the need for unit test code to instantiate empty maps, although this is not the main motivation.

**Proposed Change:**

1. When combining, only allocate sections once its clear the source layer(s) have a matching section type.
2. When Parsing a YAML, let the unmarshal process allocate when needed for non-empty sections.

**Why:**

While working on plan schema extension support, the current philosophy to always allocate empty sections creates an additional interface method requirement where the plan library has to ask the schema extension for an empty section (concrete backing type), beyond using the ```CombineSections``` and ```ParseSection``` interface methods of the extension.

In order to promote a consistent consumer experience, I would like to create a consistent understanding that your plan section will be ```nil``` if no configuration is present.

**Impact:**

Since none of the current plan consumers seem to make assumptions about a specific top level section map entry, the code already checks for the existence of an entry, or iterate over the entries. Both cases are supported with ```nil``` maps in Go.