### PR TITLE
docs: update tutorial according to review

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -7,7 +7,7 @@ After this tutorial, you will have a basic understanding of what Pebble is and h
 ## Prerequisites
 
 - A Linux machine.
-- Python3 (used to run basic HTTP servers as sample services managed by Pebble).
+- Python 3.x (used to run basic HTTP servers as sample services managed by Pebble).
 
 ## Download and install Pebble
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -7,6 +7,7 @@ After this tutorial, you will have a basic understanding of what Pebble is and h
 ## Prerequisites
 
 - A Linux machine.
+- Python3 (used to run basic HTTP servers as sample services managed by Pebble).
 
 ## Download and install Pebble
 
@@ -86,7 +87,7 @@ This starts the Pebble daemon itself, as well as all the services that are marke
 ...
 ```
 
-As you can see from the log, our HTTP server has been started too, which can be verified by running `curl localhost:8080` in another terminal tab.
+As we can see from the log, our HTTP server has been started too, which can be verified by running `curl localhost:8080` in another terminal tab.
 
 ```{note}
 To exit the Pebble daemon, press Ctrl-C (which sends an "interrupt" signal to the process).
@@ -94,7 +95,7 @@ To exit the Pebble daemon, press Ctrl-C (which sends an "interrupt" signal to th
 
 ## View, start and stop services
 
-While the Pebble daemon is running, you can view the status of services by opening another terminal tab and running:
+While the Pebble daemon is running, we can view the status of services by opening another terminal tab and running:
 
 ```bash
 pebble services
@@ -115,7 +116,7 @@ http-server  enabled  active   today at 11:30 UTC
 To stop one or more running services, run `pebble stop <service1> <service2>.`
 ```
 
-You can stop the running `http-server` service by running:
+We can stop the running `http-server` service by running:
 
 ```bash
 pebble stop http-server


### PR DESCRIPTION
Minor changes to the tutorial according to Anne's suggestion.

Closes https://github.com/canonical/pebble/issues/464.

This PR makes sure:

- [x] It starts with a clear description of what the learner can expect to achieve from the tutorial
- [x] The language of the tutorial assures the user that the instructor is on the same journey (“we”, not just “you”)
- [x] The tutorial is reproducible with a mock setup which can easily be duplicated for the target user (a mock HTTP server instead of unknown services)
- [x] It focuses on a single installation method and does not provide alternatives to users
- [x] Tutorial is broken down into multiple smaller, logical steps and (where necessary) guides the user to observe the expected outcome at each step
- [x] The amount of explanation is minimal and generally limited to necessary topics for the learner; links are used to connect the user to further reading on related topics
- [x] Listing Python as a prerequisite to spell out early on so that users don't fail halfway through the tutorial because they can't run `http.serve`