### PR TITLE
docs: enrich the landing page with basic concepts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 _Take control of your internal daemons!_
 
-**Pebble** is an open-source, declarative, client/server service manager that helps you orchestrate a set of local processes as an organised set on UNIX-like operating systems. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services, but it was designed with unique features that help with more specific use cases.
+**Pebble** is a lightweight Linux service manager that helps you orchestrate a set of local processes as an organised set. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services. However, it was designed with unique features such as layered configuration and an HTTP API that help with more specific use cases.
 
 ## Learn the fundamentals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,22 +4,6 @@ _Take control of your internal daemons!_
 
 **Pebble** is a lightweight Linux service manager that helps you orchestrate a set of local processes as an organised set. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services. However, it was designed with unique features such as layered configuration and an HTTP API that help with more specific use cases.
 
-## Learn the fundamentals
-
-Before harnessing the full potential of Pebble, it is beneficial to grasp the underlying technology that powers Pebble and the ecosystem within which Pebble operates. The following section offers valuable links to deepen your understanding:
-
-- Pebble runs on UNIX-like operating systems:
-  - [An Introduction to Linux Basics](https://www.digitalocean.com/community/tutorials/an-introduction-to-linux-basics)
-  - [Multipass tutorial: Ubuntu VMs on demand for any workstation](https://multipass.run/docs/tutorial)
-  - [How to run an Ubuntu Desktop virtual machine using VirtualBox 7](https://ubuntu.com/tutorials/how-to-run-ubuntu-desktop-on-a-virtual-machine-using-virtualbox#1-overview)
-  - [The Linux command line for beginners](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview)
-- Pebble uses YAML for configuration:
-  - [The Official YAML Web Site](https://yaml.org/)
-  - [YAML Tutorial: Everything You Need to Get Started in Minutes](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started)
-- If you are using Pebble with Juju and Charms:
-  - [Juju Documentation](https://juju.is/docs/juju)
-  - [Charm SDK Documentation](https://juju.is/docs/sdk)
-
 ## In this documentation
 
 ````{grid} 1 1 2 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@
 
 It helps you orchestrate a set of local processes as an organised set. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services. However, it was designed with unique features such as layered configuration and an HTTP API that help with more specific use cases.
 
-Pebble fulfils the need for streamlined, dependable, and secure service management. It empowers you to efficiently operate your services with ease, resolve service interdependencies, configure tailored health checks to automatically restart services upon failure, and gain insightful visibility into Pebble server events for a comprehensive understanding of operational dynamics. Pebble also supports simple identity and access control, ensuring secure usage in shared environments.
+If you need a way to manage one or more services in a container, or as a non-root user on a machine, Pebble might be for you. It handles service logs, service dependencies, and allows you to set up ongoing health checks. Plus, it has an "HTTP over unix socket" API for all operations, with simple UID-based access control.
 
-Pebble caters to a diverse user base managing services both locally and within containerised environments, offering a robust solution for your workload management needs. It is also extensively used alongside [Juju and Charms](https://juju.is/).
+Pebble is useful for developers who are building [Juju charms on Kubernetes](https://juju.is/docs/sdk/from-zero-to-hero-write-your-first-kubernetes-charm), creating [Rocks](https://documentation.ubuntu.com/rockcraft/en/latest/explanation/rocks/) or Docker images, or orchestrating services in the virtual machine.
 
 ## In this documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,23 @@
 
 _Take control of your internal daemons!_
 
-**Pebble** helps you to orchestrate a set of local service processes as an organised set. It resembles well known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services, but it was designed with unique features that help with more specific use cases.
+**Pebble** is an open-source, declarative, client/server service manager that helps you orchestrate a set of local processes as an organised set on UNIX-like operating systems. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services, but it was designed with unique features that help with more specific use cases.
+
+## Learn the fundamentals
+
+Before harnessing the full potential of Pebble, it is beneficial to grasp the underlying technology that powers Pebble and the ecosystem within which Pebble operates. The following section offers valuable links to deepen your understanding:
+
+- Pebble runs on UNIX-like operating systems:
+  - [An Introduction to Linux Basics](https://www.digitalocean.com/community/tutorials/an-introduction-to-linux-basics)
+  - [Multipass tutorial: Ubuntu VMs on demand for any workstation](https://multipass.run/docs/tutorial)
+  - [How to run an Ubuntu Desktop virtual machine using VirtualBox 7](https://ubuntu.com/tutorials/how-to-run-ubuntu-desktop-on-a-virtual-machine-using-virtualbox#1-overview)
+  - [The Linux command line for beginners](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview)
+- Pebble uses YAML for configuration:
+  - [The Official YAML Web Site](https://yaml.org/)
+  - [YAML Tutorial: Everything You Need to Get Started in Minutes](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started)
+- If you are using Pebble with Juju and Charms:
+  - [Juju Documentation](https://juju.is/docs/juju)
+  - [Charm SDK Documentation](https://juju.is/docs/sdk)
 
 ## In this documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,12 @@
 # Pebble
 
-_Take control of your internal daemons!_
+**Pebble** is a lightweight Linux service manager.
 
-**Pebble** is a lightweight Linux service manager that helps you orchestrate a set of local processes as an organised set. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services. However, it was designed with unique features such as layered configuration and an HTTP API that help with more specific use cases.
+It helps you orchestrate a set of local processes as an organised set. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services. However, it was designed with unique features such as layered configuration and an HTTP API that help with more specific use cases.
+
+Pebble fulfils the need for streamlined, dependable, and secure service management. It empowers you to efficiently operate your services with ease, resolve service interdependencies, configure tailored health checks to automatically restart services upon failure, and gain insightful visibility into Pebble server events for a comprehensive understanding of operational dynamics. Pebble also supports simple identity and access control, ensuring secure usage in shared environments.
+
+Pebble caters to a diverse user base managing services both locally and within containerised environments, offering a robust solution for your workload management needs. It is also extensively used alongside [Juju and Charms](https://juju.is/).
 
 ## In this documentation
 


### PR DESCRIPTION
Improve the definition of Pebble and add fundamentals.

In the current version, it only describes what Pebble can do, but most product docs start with defining "what it is", like `supervisor`, `runit`, etc, so I expanded the definition a little bit.

Also added a section as prerequisite. Maybe it is not necessary, please provide your feedback. I think it doesn't hurt because it has a few links to ubuntu.com.

Closes https://github.com/canonical/pebble/issues/465.