### PR TITLE
feat(planstate): make plan propagation safer

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -199,16 +199,6 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 		return err
 	}
 
-	if rcmd.Args != nil {
-		mappedArgs, err := convertArgs(rcmd.Args)
-		if err != nil {
-			return err
-		}
-		if err := d.SetServiceArgs(mappedArgs); err != nil {
-			return err
-		}
-	}
-
 	// Run sanity check now, if anything goes wrong with the
 	// check we go into "degraded" mode where we always report
 	// the given error to any client.
@@ -225,6 +215,20 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	d.Version = cmd.Version
 	if err := d.Start(); err != nil {
 		return err
+	}
+
+	// When we reach this point, we know every overlord manager has received a
+	// state engine StartUp() and at least one Ensure() call. This also guarantees
+	// the plan has been loaded and propagated to every change listener.
+
+	if rcmd.Args != nil {
+		mappedArgs, err := convertArgs(rcmd.Args)
+		if err != nil {
+			return err
+		}
+		if err := d.SetServiceArgs(mappedArgs); err != nil {
+			return err
+		}
 	}
 
 	watchdog, err := runWatchdog(d)

--- a/internals/daemon/api_services_test.go
+++ b/internals/daemon/api_services_test.go
@@ -73,6 +73,7 @@ func (s *apiSuite) TestServicesStart(c *C) {
 	writeTestLayer(s.pebbleDir, servicesLayer)
 	d := s.daemon(c)
 	st := d.overlord.State()
+	s.startOverlord()
 
 	soon := 0
 	restore := FakeStateEnsureBefore(func(st *state.State, d time.Duration) {
@@ -120,6 +121,7 @@ func (s *apiSuite) TestServicesStop(c *C) {
 	writeTestLayer(s.pebbleDir, servicesLayer)
 	d := s.daemon(c)
 	st := d.overlord.State()
+	s.startOverlord()
 
 	soon := 0
 	restore := FakeStateEnsureBefore(func(st *state.State, d time.Duration) {
@@ -167,6 +169,7 @@ func (s *apiSuite) TestServicesAutoStart(c *C) {
 	writeTestLayer(s.pebbleDir, servicesLayer)
 	d := s.daemon(c)
 	st := d.overlord.State()
+	s.startOverlord()
 
 	soon := 0
 	restore := FakeStateEnsureBefore(func(st *state.State, d time.Duration) {
@@ -209,6 +212,7 @@ func (s *apiSuite) TestServicesGet(c *C) {
 	// Setup
 	writeTestLayer(s.pebbleDir, servicesLayer)
 	s.daemon(c)
+	s.startOverlord()
 
 	// Execute
 	req, err := http.NewRequest("GET", "/v1/services", nil)
@@ -238,6 +242,7 @@ func (s *apiSuite) TestServicesRestart(c *C) {
 	writeTestLayer(s.pebbleDir, servicesLayer)
 	d := s.daemon(c)
 	st := d.overlord.State()
+	s.startOverlord()
 
 	soon := 0
 	restore := FakeStateEnsureBefore(func(st *state.State, d time.Duration) {
@@ -287,6 +292,7 @@ func (s *apiSuite) TestServicesReplan(c *C) {
 	writeTestLayer(s.pebbleDir, servicesLayer)
 	d := s.daemon(c)
 	st := d.overlord.State()
+	s.startOverlord()
 
 	soon := 0
 	restore := FakeStateEnsureBefore(func(st *state.State, d time.Duration) {
@@ -334,6 +340,7 @@ services:
 `)
 	d := s.daemon(c)
 	st := d.overlord.State()
+	s.startOverlord()
 	restore := FakeStateEnsureBefore(func(st *state.State, d time.Duration) {})
 	defer restore()
 

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -1345,7 +1345,10 @@ func (s *daemonSuite) TestWritesRequireAdminAccess(c *C) {
 }
 
 func (s *daemonSuite) TestAPIAccessLevels(c *C) {
-	_ = s.newDaemon(c)
+	d := s.newDaemon(c)
+	d.Init()
+	c.Assert(d.Start(), IsNil)
+	defer d.Stop(nil)
 
 	tests := []struct {
 		method string

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -371,7 +371,7 @@ func (o *Overlord) Loop() {
 			}
 		}
 	})
-	o.ensureWaitRun()
+	o.waitEnsureRun()
 }
 
 func (o *Overlord) ensureDidRun() {
@@ -383,22 +383,22 @@ func (o *Overlord) ensureDidRun() {
 	}
 }
 
-// ensureWaitRun waits until StateEngine.Ensure() was called at least once.
-func (o *Overlord) ensureWaitRun() {
+// waitEnsureRun waits until StateEngine.Ensure() was called at least once.
+func (o *Overlord) waitEnsureRun() {
 	select {
 	case <-o.ensureRun:
 	case <-o.loopTomb.Dying():
 	}
 }
 
-func (o *Overlord) CanStandby() (ensured bool) {
+func (o *Overlord) CanStandby() bool {
 	select {
 	case <-o.ensureRun:
 		// Already closed. Ensure already ran at least once.
-		ensured = true
+		return true
 	default:
+		return false
 	}
-	return ensured
 }
 
 // Stop stops the ensure loop and the managers under the StateEngine.

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -29,7 +29,9 @@ func (ps *planSuite) TestLoadInvalidPebbleDir(c *C) {
 	ps.planMgr, err = planstate.NewManager("/invalid/path")
 	c.Assert(err, IsNil)
 	// Load the plan from the <pebble-dir>/layers directory
-	err = ps.planMgr.Load()
+	err = ps.planMgr.StartUp()
+	c.Assert(err, IsNil)
+	err = ps.planMgr.Ensure()
 	c.Assert(err, IsNil)
 	plan := ps.planMgr.Plan()
 	out, err := yaml.Marshal(plan)
@@ -64,7 +66,9 @@ func (ps *planSuite) TestLoadLayers(c *C) {
 		ps.writeLayer(c, string(reindent(l)))
 	}
 	// Load the plan from the <pebble-dir>/layers directory
-	err = ps.planMgr.Load()
+	err = ps.planMgr.StartUp()
+	c.Assert(err, IsNil)
+	err = ps.planMgr.Ensure()
 	c.Assert(err, IsNil)
 	plan := ps.planMgr.Plan()
 	out, err := yaml.Marshal(plan)
@@ -350,7 +354,9 @@ services:
         override: replace
         command: echo svc1
 `)
-		err = manager.Load()
+		err = manager.StartUp()
+		c.Assert(err, IsNil)
+		err = manager.Ensure()
 		c.Assert(err, IsNil)
 
 		layer1 := ps.parseLayer(c, 0, "label1", `


### PR DESCRIPTION
The original Pebble plan was part of the service manager, only concerned with services. The plan was lazy loaded, so the first service manager public method called (internally or over the HTTP API) would result in plan layers getting loaded, combined and propagated. This scheme was later extended to support additional managers, which also added the ```PlanChanged``` subscription mechanism. Subscribed managers would receive updates of the plan on the initial load and subsequent runtime changes, due to layers ```add```ed using the HTTP API.

[The plan manager](https://github.com/canonical/pebble/pull/387) decoupled the Pebble Plan from the service manager. The first version of the plan manager simply loaded the plan from disk as early as possible, before the HTTP API endpoints were activated. However, since the load also triggered a ```PlanChanged``` update to all subscribed managers, these managers received an update of the plan before the State Engine was running. This resulted in [extra code](https://github.com/canonical/pebble/blob/1f50b018ce2a34fb60a442c2a1cdfca70c16f9cd/internals/overlord/checkstate/manager.go#L167) required in ```checkstate``` to defer calling ```Ensure()``` inside the ```PlanChanged``` callback.

The following changes are proposed:

1. Adapt the planstate load and plan changed notifications to only use standard State Engine events ```StartUp()``` and ```Ensure()``` during startup. Note that because we now guarantee a call to Ensure before the HTTP API is enabled, it is safe to do the initial load and propagate lock-less (care has to be taken so external callers do to call us before the state engine is running).

2. Make a change to the overlord to only enable the HTTP API endpoints once both ```StartUp``` and at least one ```Ensure()``` pass was completed. Note that this does not impact startup performance of managers, but would ensure external HTTP API calls, and self-calls (i.e. autostart) would only happen after ```StartUp``` and at least one ```Ensure()``` completed, giving managers a guarantee on startup behaviour. 

Performing a simple startup duration test from the application entrypoint until HTTP API is enabled resulted in no measurable difference.