### PR TITLE
fix(cmdstate): don't store execSetup and environment in state

### DIFF
--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -70,13 +70,13 @@ type execution struct {
 }
 
 func (m *CommandManager) doExec(task *state.Task, tomb *tomb.Tomb) error {
-	var setup execSetup
 	st := task.State()
 	st.Lock()
-	err := task.Get("exec-setup", &setup)
+	setupObj := st.Cached(execSetupKey{task.ID()})
 	st.Unlock()
-	if err != nil {
-		return fmt.Errorf("cannot get exec setup object for task %q: %v", task.ID(), err)
+	setup, ok := setupObj.(*execSetup)
+	if !ok || setup == nil {
+		return fmt.Errorf("internal error: cannot get exec setup object for task %q", task.ID())
 	}
 
 	// Set up the object that will track the execution.

--- a/internals/overlord/cmdstate/request.go
+++ b/internals/overlord/cmdstate/request.go
@@ -138,7 +138,7 @@ func Exec(st *state.State, args *ExecArgs) (*state.Task, ExecMetadata, error) {
 		GroupID:     args.GroupID,
 		WorkingDir:  workingDir,
 	}
-	task.Set("exec-setup", &setup)
+	st.Cache(execSetupKey{task.ID()}, &setup)
 
 	metadata := ExecMetadata{
 		TaskID:      task.ID(),


### PR DESCRIPTION
Per #411, the environment (and other task data) can get quite large for exec objects. Given that exec commands are one-shot and only relevant for the current run of Pebble, there's no need to persist them.

Note that none of this data is in "api-data" so it's not accessible via the API at all right now, and so this is a non-breaking change.

Later if we want to make exec tasks a bit more introspectable we can add the command line or other fields to "api-data" (but we shouldn't add the entire environment).

Fixes #411.