### PR TITLE
fix(overlord): pebble hangs with a read-only file system when starting the daemon

### DIFF
--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -125,7 +125,7 @@ func New(opts *Options) (*Overlord, error) {
 		return nil, fmt.Errorf("directory %q does not exist", o.pebbleDir)
 	}
 	if !osutil.IsWritable(o.pebbleDir) {
-		return nil, fmt.Errorf("no write permission in directory %q", o.pebbleDir)
+		return nil, fmt.Errorf("directory %q not writable", o.pebbleDir)
 	}
 
 	statePath := filepath.Join(o.pebbleDir, cmd.StateFile)

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -124,6 +124,10 @@ func New(opts *Options) (*Overlord, error) {
 	if !osutil.IsDir(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q does not exist", o.pebbleDir)
 	}
+	if !osutil.IsWritable(o.pebbleDir) {
+		return nil, fmt.Errorf("no write permission in directory %q", o.pebbleDir)
+	}
+
 	statePath := filepath.Join(o.pebbleDir, cmd.StateFile)
 
 	backend := &overlordStateBackend{
@@ -256,7 +260,6 @@ func loadState(statePath string, restartHandler restart.Handler, backend state.B
 		patch.Init(s)
 		return s, restartMgr, nil
 	}
-
 	r, err := os.Open(statePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot read the state file: %s", err)

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -293,7 +293,6 @@ func (s *State) Unlock() {
 			return
 		}
 
-		// Let the user know what's going on if the backend writes failed.
 		logger.Noticef("Cannot write state file, retrying: %v", err)
 
 		time.Sleep(unlockCheckpointRetryInterval)


### PR DESCRIPTION
Fix an issue where the Pebble daemon fails to start with a read-only file system.

Closes https://github.com/canonical/pebble/issues/462.

Changes:
- Check if Pebble dir is writable before creating the overlord state backend.
- Add some logging when backend writes fail to enhance user experience.
- Listen for interrupt signals when state unlock retries because of backend writes failure.