### PR TITLE
docs: update in this documentation section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Pebble is useful for developers who are building [Juju charms on Kubernetes](htt
 ## In this documentation
 
 ````{grid} 1 1 2 2
-```{grid-item-card} [Tutorials](tutorial/getting-started)
+```{grid-item-card} [Tutorial](tutorial/getting-started)
 **Start here**: a hands-on getting started introduction to Pebble for new users.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,11 @@ Pebble is useful for developers who are building [Juju charms on Kubernetes](htt
 
 ````{grid} 1 1 2 2
 ```{grid-item-card} [Tutorial](tutorial/getting-started)
-**Start here**: a hands-on getting started introduction to Pebble for new users.
+**Start here**: a hands-on introduction to Pebble, guiding you through your first steps using the CLI
 ```
 
 ```{grid-item-card} [How-to guides](how-to/index)
-**Step-by-step guides** covering key operations and common tasks.
+**Step-by-step guides** covering key operations and common tasks
 - [Install Pebble](how-to/install-pebble)
 - [Manage service dependencies](how-to/service-dependencies)
 - [Manage identities](how-to/manage-identities)
@@ -25,7 +25,7 @@ Pebble is useful for developers who are building [Juju charms on Kubernetes](htt
 
 ````{grid} 1 1 2 2
 ```{grid-item-card} [Explanation](explanation/index)
-**Discussion and clarification** of key topics.
+**Discussion and clarification** of key topics
 - [General model](explanation/general-model.md)
 - [API and clients](explanation/api-and-clients.md)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,22 +11,30 @@ Pebble is useful for developers who are building [Juju charms on Kubernetes](htt
 ## In this documentation
 
 ````{grid} 1 1 2 2
-```{grid-item-card} [Tutorial](tutorial/getting-started)
+```{grid-item-card} [Tutorials](tutorial/getting-started)
 **Start here**: a hands-on getting started introduction to Pebble for new users.
 ```
 
 ```{grid-item-card} [How-to guides](how-to/index)
 **Step-by-step guides** covering key operations and common tasks.
+- [Install Pebble](how-to/install-pebble)
+- [Manage service dependencies](how-to/service-dependencies)
+- [Manage identities](how-to/manage-identities)
 ```
 ````
 
 ````{grid} 1 1 2 2
 ```{grid-item-card} [Explanation](explanation/index)
 **Discussion and clarification** of key topics.
+- [General model](explanation/general-model.md)
+- [API and clients](explanation/api-and-clients.md)
 ```
 
 ```{grid-item-card} [Reference](reference/index)
-**Technical information** - specifications, APIs, and architecture.
+**Technical information**
+- [Layer specification](reference/layer-specification)
+- [CLI commands](reference/cli-commands/cli-commands)
+- [Pebble in containers](reference/pebble-in-containers)
 ```
 ````
 


### PR DESCRIPTION
Update the "In this documentation" section on the main page.

Closes https://github.com/canonical/pebble/issues/480.

Changes:

- Add links to highlight important content for how-to, explanations and references.

Preview:

<img width="897" alt="Screenshot 2024-08-15 at 08 24 29" src="https://github.com/user-attachments/assets/25f69e56-6329-4c25-805f-881f890ea577">

Some explanations of my experiments and how I arrived at this version:

- Tutorial: nothing has changed. I wanted to list the tutorial there like the LXD doc does, but since we have only one, it would look weird and the link would be the same as the section title's link, so I left this part untouched.
- How-to: all 3 existing how-to guides there. Since we only had 3, it doesn't make much sense to pick just 2 of the more important ones, so I listed them all.
- Explanations: only "General models" and "API and clients"; "Service dependencies" skipped because of duplication as the how-to.
- Reference, only 3 the most reference-y items. In my first draft, I added 4 more items like "Changes and tasks", "Health check", "Notices", and "Identities", which are all important features. But in that way, the list would be 7 items long and extremely imbalanced visually compared to the left explanation box which has only 2 items. Making it 4-5 items would be less bad, but it's difficult to pick just 1 or 2 from the 4 items I left out to highlight here, so I just left them all out.
