### PR TITLE
feat(delay): Add initial delay

### DIFF
--- a/internals/overlord/checkstate/request.go
+++ b/internals/overlord/checkstate/request.go
@@ -25,7 +25,8 @@ type checkDetails struct {
 	Name     string `json:"name"`
 	Failures int    `json:"failures"`
 	// Whether to proceed to next check type when change is ready
-	Proceed bool `json:"proceed,omitempty"`
+	Proceed         bool `json:"proceed,omitempty"`
+	HasInitialDelay bool `json:"hasinitialdelay,omitempty"`
 }
 
 type performConfigKey struct {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -40,6 +40,8 @@ const (
 	defaultCheckPeriod    = 10 * time.Second
 	defaultCheckTimeout   = 3 * time.Second
 	defaultCheckThreshold = 3
+
+	defaultDelayTimeout = 0 * time.Second
 )
 
 type Plan struct {
@@ -311,6 +313,7 @@ type Check struct {
 	Period    OptionalDuration `yaml:"period,omitempty"`
 	Timeout   OptionalDuration `yaml:"timeout,omitempty"`
 	Threshold int              `yaml:"threshold,omitempty"`
+	Delay     OptionalDuration `yaml:"delay,omitempty"`
 
 	// Type-specific check settings (only one of these can be set)
 	HTTP *HTTPCheck `yaml:"http,omitempty"`
@@ -346,6 +349,9 @@ func (c *Check) Merge(other *Check) {
 	}
 	if other.Threshold != 0 {
 		c.Threshold = other.Threshold
+	}
+	if other.Delay.IsSet {
+		c.Delay = other.Delay
 	}
 	if other.HTTP != nil {
 		if c.HTTP == nil {
@@ -676,6 +682,9 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			// action, default is >1 to avoid flapping due to glitches. For
 			// what it's worth, Kubernetes probes uses a default of 3 too.
 			check.Threshold = defaultCheckThreshold
+		}
+		if !check.Delay.IsSet {
+			check.Delay.Value = defaultDelayTimeout
 		}
 	}
 


### PR DESCRIPTION
Adds an option to `checks` to configure an initial delay before starting checks - this is helpful for slow services that might take minutes to start up initially (think Synapse that is a python app that connects to a DB and the more used and federated the home server is, the slower the initial start up). This relates to #145 requested for a similar use case (Indico being a python app with a DB that causes a slow start up time).

I've tested this locally with a toy app as seen in the screenshot, though I haven't written a test yet, I would need some guidance where to put it and how to structure it (provided this PR fits the purpose and moves forward).

![pebble](https://github.com/user-attachments/assets/fb009db3-0527-40e4-bb95-d4cd56c6cdc1)

Thanks!