### PR TITLE
feat(plan): add plan section support

### DIFF
--- a/internals/plan/export_test.go
+++ b/internals/plan/export_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package plan
+
+var LayerBuiltins = layerBuiltins

--- a/internals/plan/export_test.go
+++ b/internals/plan/export_test.go
@@ -14,4 +14,4 @@
 
 package plan
 
-var LayerBuiltins = layerBuiltins
+var BuiltinSections = builtinSections

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -353,7 +353,7 @@ func (s *S) TestPlanExtensions(c *C) {
 	defer func() {
 		// Remove remaining registered extensions.
 		for _, field := range registeredExtensions {
-			plan.UnregisterExtension(field)
+			plan.UnregisterSectionExtension(field)
 		}
 	}()
 
@@ -363,7 +363,7 @@ nexttest:
 
 		// Unregister extensions from previous test iteraton.
 		for _, field := range registeredExtensions {
-			plan.UnregisterExtension(field)
+			plan.UnregisterSectionExtension(field)
 		}
 		registeredExtensions = []string{}
 
@@ -380,7 +380,7 @@ nexttest:
 						err = fmt.Errorf("%v", r)
 					}
 				}()
-				plan.RegisterExtension(e.field, e.ext)
+				plan.RegisterSectionExtension(e.field, e.ext)
 				registeredExtensions = append(registeredExtensions, e.field)
 				return nil
 			}()
@@ -430,11 +430,11 @@ nexttest:
 // registration and follows the built-in sections which are ordered
 // the same way they are defined in the Plan struct.
 func (s *S) TestSectionOrderExt(c *C) {
-	plan.RegisterExtension("x-field", &xExtension{})
-	plan.RegisterExtension("y-field", &yExtension{})
+	plan.RegisterSectionExtension("x-field", &xExtension{})
+	plan.RegisterSectionExtension("y-field", &yExtension{})
 	defer func() {
-		plan.UnregisterExtension("x-field")
-		plan.UnregisterExtension("y-field")
+		plan.UnregisterSectionExtension("x-field")
+		plan.UnregisterSectionExtension("y-field")
 	}()
 
 	layer, err := plan.ParseLayer(1, "label", reindent(`

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -190,7 +190,7 @@ var extensionTests = []struct {
 					a: a
 					b: b`,
 	}},
-	error: "cannot validate layer section .* cannot accept entry not starting .*",
+	error: ".*cannot accept entry not starting.*",
 }, {
 	summary: "Load file layers with section validation failure #2",
 	extensions: []extension{{
@@ -209,7 +209,7 @@ var extensionTests = []struct {
 			x-field:
 				x1:`,
 	}},
-	error: "cannot validate layer section .* cannot have nil entry .*",
+	error: ".*cannot have nil entry.*",
 }, {
 	summary: "Load file layers failed plan validation",
 	extensions: []extension{{
@@ -244,7 +244,7 @@ var extensionTests = []struct {
 					a: a
 					b: b`,
 	}},
-	error: "cannot validate plan section .* cannot find .* as required by .*",
+	error: ".*cannot find.*",
 }, {
 	summary: "Check empty section omits entry",
 	extensions: []extension{{

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -42,16 +42,15 @@ type planResult struct {
 }
 
 var extensionTests = []struct {
-	extensions             map[string]plan.LayerSectionExtension
-	layers                 []*inputLayer
-	errorString            string
-	combinedPlanResult     *planResult
-	combinedPlanResultYaml string
+	extensions map[string]plan.LayerSectionExtension
+	layers     []*inputLayer
+	error      string
+	result     *planResult
+	resultYaml string
 }{
 	// Index 0: No Sections
 	{
-		combinedPlanResultYaml: string(reindent(`
-			{}`)),
+		resultYaml: "{}\n",
 	},
 	// Index 1: Sections with empty YAML
 	{
@@ -59,12 +58,11 @@ var extensionTests = []struct {
 			"x-field": &xExtension{},
 			"y-field": &yExtension{},
 		},
-		combinedPlanResult: &planResult{
+		result: &planResult{
 			x: &xSection{},
 			y: &ySection{},
 		},
-		combinedPlanResultYaml: string(reindent(`
-			{}`)),
+		resultYaml: "{}\n",
 	},
 	// Index 2: Load file layers invalid section
 	{
@@ -73,7 +71,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-xy",
 				yaml: `
@@ -83,7 +81,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		errorString: "cannot parse layer .*: unknown section .*",
+		error: "cannot parse layer .*: unknown section .*",
 	},
 	// Index 3: Load file layers not unique order
 	{
@@ -92,7 +90,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-1",
 				yaml: `
@@ -100,7 +98,7 @@ var extensionTests = []struct {
 					description: desc
 				`,
 			},
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-2",
 				yaml: `
@@ -109,7 +107,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		errorString: "invalid layer filename: .* not unique .*",
+		error: "invalid layer filename: .* not unique .*",
 	},
 	// Index 4: Load file layers not unique label
 	{
@@ -118,7 +116,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-xy",
 				yaml: `
@@ -126,7 +124,7 @@ var extensionTests = []struct {
 					description: desc
 				`,
 			},
-			&inputLayer{
+			{
 				order: 2,
 				label: "layer-xy",
 				yaml: `
@@ -135,7 +133,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		errorString: "invalid layer filename: .* not unique .*",
+		error: "invalid layer filename: .* not unique .*",
 	},
 	// Index 5: Load file layers with empty section
 	{
@@ -144,7 +142,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-x",
 				yaml: `
@@ -152,7 +150,7 @@ var extensionTests = []struct {
 					description: desc-x
 				`,
 			},
-			&inputLayer{
+			{
 				order: 2,
 				label: "layer-y",
 				yaml: `
@@ -161,11 +159,11 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		combinedPlanResult: &planResult{
+		result: &planResult{
 			x: &xSection{},
 			y: &ySection{},
 		},
-		combinedPlanResultYaml: string("{}\n"),
+		resultYaml: "{}\n",
 	},
 	// Index 6: Load file layers with section validation failure #1
 	{
@@ -174,7 +172,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-x",
 				yaml: `
@@ -188,7 +186,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		errorString: "cannot validate layer section .* cannot accept entry not starting .*",
+		error: "cannot validate layer section .* cannot accept entry not starting .*",
 	},
 	// Index 7: Load file layers with section validation failure #2
 	{
@@ -197,7 +195,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-x",
 				yaml: `
@@ -208,7 +206,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		errorString: "cannot validate layer section .* cannot have nil entry .*",
+		error: "cannot validate layer section .* cannot have nil entry .*",
 	},
 	// Index 8: Load file layers failed plan validation
 	{
@@ -217,7 +215,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-x",
 				yaml: `
@@ -232,7 +230,7 @@ var extensionTests = []struct {
 							  - y2
 				`,
 			},
-			&inputLayer{
+			{
 				order: 2,
 				label: "layer-y",
 				yaml: `
@@ -246,7 +244,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		errorString: "cannot validate plan section .* cannot find .* as required by .*",
+		error: "cannot validate plan section .* cannot find .* as required by .*",
 	},
 	// Index 9: Check empty section omits entry
 	{
@@ -255,7 +253,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-x",
 				yaml: `
@@ -264,7 +262,7 @@ var extensionTests = []struct {
 					x-field:
 				`,
 			},
-			&inputLayer{
+			{
 				order: 2,
 				label: "layer-y",
 				yaml: `
@@ -274,12 +272,11 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		combinedPlanResult: &planResult{
+		result: &planResult{
 			x: &xSection{},
 			y: &ySection{},
 		},
-		combinedPlanResultYaml: string(reindent(`
-			{}`)),
+		resultYaml: "{}\n",
 	},
 	// Index 10: Load file layers
 	{
@@ -288,7 +285,7 @@ var extensionTests = []struct {
 			"y-field": &yExtension{},
 		},
 		layers: []*inputLayer{
-			&inputLayer{
+			{
 				order: 1,
 				label: "layer-x",
 				yaml: `
@@ -303,7 +300,7 @@ var extensionTests = []struct {
 							  - y1
 				`,
 			},
-			&inputLayer{
+			{
 				order: 2,
 				label: "layer-y",
 				yaml: `
@@ -317,7 +314,7 @@ var extensionTests = []struct {
 				`,
 			},
 		},
-		combinedPlanResult: &planResult{
+		result: &planResult{
 			x: &xSection{
 				Entries: map[string]*X{
 					"x1": &X{
@@ -342,7 +339,7 @@ var extensionTests = []struct {
 				},
 			},
 		},
-		combinedPlanResultYaml: string(reindent(`
+		resultYaml: string(reindent(`
 			x-field:
 				x1:
 					override: replace
@@ -374,16 +371,16 @@ func (s *S) TestPlanExtensions(c *C) {
 
 		// Load the plan layer from disk (parse, combine and validate).
 		p, err := plan.ReadDir(layersDir)
-		if planTest.errorString != "" || err != nil {
+		if planTest.error != "" || err != nil {
 			// Expected error.
-			c.Assert(err, ErrorMatches, planTest.errorString)
+			c.Assert(err, ErrorMatches, planTest.error)
 		} else {
 			if _, ok := planTest.extensions[xField]; ok {
 				// Verify "x-field" data.
 				var x *xSection
 				x = p.Section(xField).(*xSection)
 				c.Assert(err, IsNil)
-				c.Assert(x.Entries, DeepEquals, planTest.combinedPlanResult.x.Entries)
+				c.Assert(x.Entries, DeepEquals, planTest.result.x.Entries)
 			}
 
 			if _, ok := planTest.extensions[yField]; ok {
@@ -391,13 +388,13 @@ func (s *S) TestPlanExtensions(c *C) {
 				var y *ySection
 				y = p.Section(yField).(*ySection)
 				c.Assert(err, IsNil)
-				c.Assert(y.Entries, DeepEquals, planTest.combinedPlanResult.y.Entries)
+				c.Assert(y.Entries, DeepEquals, planTest.result.y.Entries)
 			}
 
 			// Verify combined plan YAML.
 			planYAML, err := yaml.Marshal(p)
 			c.Assert(err, IsNil)
-			c.Assert(string(planYAML), Equals, planTest.combinedPlanResultYaml)
+			c.Assert(string(planYAML), Equals, planTest.resultYaml)
 		}
 
 		// Unregister test extensions.

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -35,8 +35,8 @@ type inputLayer struct {
 }
 
 // PlanResult represents the final content of a combined plan. Since this
-// package exclusively focuses extensions, all built-in sections are empty
-// and ignored in the test results.
+// test file exclusively focuses on extensions, all built-in sections are
+// empty and ignored in the test results.
 type planResult struct {
 	x *xSection
 	y *ySection

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -381,7 +381,7 @@ func (s *S) TestPlanExtensions(c *C) {
 			if _, ok := planTest.extensions[xField]; ok {
 				// Verify "x-field" data.
 				var x *xSection
-				err = p.Section(xField, &x)
+				x = p.Section(xField).(*xSection)
 				c.Assert(err, IsNil)
 				c.Assert(x.Entries, DeepEquals, planTest.combinedPlanResult.x.Entries)
 			}
@@ -389,7 +389,7 @@ func (s *S) TestPlanExtensions(c *C) {
 			if _, ok := planTest.extensions[yField]; ok {
 				// Verify "y-field" data.
 				var y *ySection
-				err = p.Section(yField, &y)
+				y = p.Section(yField).(*ySection)
 				c.Assert(err, IsNil)
 				c.Assert(y.Entries, DeepEquals, planTest.combinedPlanResult.y.Entries)
 			}
@@ -451,19 +451,10 @@ func (x xExtension) CombineSections(sections ...plan.LayerSection) (plan.LayerSe
 
 func (x xExtension) ValidatePlan(p *plan.Plan) error {
 	var xs *xSection
-	err := p.Section(xField, &xs)
-	if err != nil {
-		return err
-	}
+	xs = p.Section(xField).(*xSection)
 	if xs != nil {
 		var ys *ySection
-		err = p.Section(yField, &ys)
-		if err != nil {
-			return err
-		}
-		if ys == nil {
-			return fmt.Errorf("cannot validate %v field without %v field", xField, yField)
-		}
+		ys = p.Section(yField).(*ySection)
 
 		// Test dependency: Make sure every Y field in X refer to an existing Y entry.
 		for xEntryField, xEntryValue := range xs.Entries {

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -1,0 +1,689 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/pebble/internals/plan"
+)
+
+type inputLayer struct {
+	order int
+	label string
+	yaml  string
+}
+
+// PlanResult represents the final content of a combined plan. Since this
+// package exclusively focuses extensions, all built-in sections are empty
+// and ignored in the test results.
+type planResult struct {
+	x *xSection
+	y *ySection
+}
+
+var extensionTests = []struct {
+	extensions             map[string]plan.LayerSectionExtension
+	layers                 []*inputLayer
+	errorString            string
+	combinedPlanResult     *planResult
+	combinedPlanResultYaml string
+}{
+	// Index 0: No Sections
+	{
+		combinedPlanResultYaml: string(reindent(`
+			{}`)),
+	},
+	// Index 1: Sections with empty YAML
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		combinedPlanResult: &planResult{
+			x: &xSection{},
+			y: &ySection{},
+		},
+		combinedPlanResultYaml: string(reindent(`
+			{}`)),
+	},
+	// Index 2: Load file layers invalid section
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-xy",
+				yaml: `
+					summary: xy
+					description: desc
+					invalid:
+				`,
+			},
+		},
+		errorString: "cannot parse layer .*: unknown section .*",
+	},
+	// Index 3: Load file layers not unique order
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-1",
+				yaml: `
+					summary: xy
+					description: desc
+				`,
+			},
+			&inputLayer{
+				order: 1,
+				label: "layer-2",
+				yaml: `
+					summary: xy
+					description: desc
+				`,
+			},
+		},
+		errorString: "invalid layer filename: .* not unique .*",
+	},
+	// Index 4: Load file layers not unique label
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-xy",
+				yaml: `
+					summary: xy
+					description: desc
+				`,
+			},
+			&inputLayer{
+				order: 2,
+				label: "layer-xy",
+				yaml: `
+					summary: xy
+					description: desc
+				`,
+			},
+		},
+		errorString: "invalid layer filename: .* not unique .*",
+	},
+	// Index 5: Load file layers with empty section
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-x",
+				yaml: `
+					summary: x
+					description: desc-x
+				`,
+			},
+			&inputLayer{
+				order: 2,
+				label: "layer-y",
+				yaml: `
+					summary: y
+					description: desc-y
+				`,
+			},
+		},
+		combinedPlanResult: &planResult{
+			x: &xSection{},
+			y: &ySection{},
+		},
+		combinedPlanResultYaml: string("{}\n"),
+	},
+	// Index 6: Load file layers with section validation failure #1
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-x",
+				yaml: `
+					summary: x
+					description: desc-x
+					x-field:
+						z1:
+							override: replace
+							a: a
+							b: b
+				`,
+			},
+		},
+		errorString: "cannot validate layer section .* cannot accept entry not starting .*",
+	},
+	// Index 7: Load file layers with section validation failure #2
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-x",
+				yaml: `
+					summary: x
+					description: desc-x
+					x-field:
+						x1:
+				`,
+			},
+		},
+		errorString: "cannot validate layer section .* cannot have nil entry .*",
+	},
+	// Index 8: Load file layers failed plan validation
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-x",
+				yaml: `
+					summary: x
+					description: desc-x
+					x-field:
+						x1:
+							override: replace
+							a: a
+							b: b
+							y-field:
+							  - y2
+				`,
+			},
+			&inputLayer{
+				order: 2,
+				label: "layer-y",
+				yaml: `
+					summary: y
+					description: desc-y
+					y-field:
+						y1:
+							override: replace
+							a: a
+							b: b
+				`,
+			},
+		},
+		errorString: "cannot validate plan section .* cannot find .* as required by .*",
+	},
+	// Index 9: Check empty section omits entry
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-x",
+				yaml: `
+					summary: x
+					description: desc-x
+					x-field:
+				`,
+			},
+			&inputLayer{
+				order: 2,
+				label: "layer-y",
+				yaml: `
+					summary: y
+					description: desc-y
+					y-field:
+				`,
+			},
+		},
+		combinedPlanResult: &planResult{
+			x: &xSection{},
+			y: &ySection{},
+		},
+		combinedPlanResultYaml: string(reindent(`
+			{}`)),
+	},
+	// Index 10: Load file layers
+	{
+		extensions: map[string]plan.LayerSectionExtension{
+			"x-field": &xExtension{},
+			"y-field": &yExtension{},
+		},
+		layers: []*inputLayer{
+			&inputLayer{
+				order: 1,
+				label: "layer-x",
+				yaml: `
+					summary: x
+					description: desc-x
+					x-field:
+						x1:
+							override: replace
+							a: a
+							b: b
+							y-field:
+							  - y1
+				`,
+			},
+			&inputLayer{
+				order: 2,
+				label: "layer-y",
+				yaml: `
+					summary: y
+					description: desc-y
+					y-field:
+						y1:
+							override: replace
+							a: a
+							b: b
+				`,
+			},
+		},
+		combinedPlanResult: &planResult{
+			x: &xSection{
+				Entries: map[string]*X{
+					"x1": &X{
+						Name:     "x1",
+						Override: plan.ReplaceOverride,
+						A:        "a",
+						B:        "b",
+						Y: []string{
+							"y1",
+						},
+					},
+				},
+			},
+			y: &ySection{
+				Entries: map[string]*Y{
+					"y1": &Y{
+						Name:     "y1",
+						Override: plan.ReplaceOverride,
+						A:        "a",
+						B:        "b",
+					},
+				},
+			},
+		},
+		combinedPlanResultYaml: string(reindent(`
+			x-field:
+				x1:
+					override: replace
+					a: a
+					b: b
+					y-field:
+						- y1
+			y-field:
+				y1:
+					override: replace
+					a: a
+					b: b`)),
+	},
+}
+
+func (s *S) TestPlanExtensions(c *C) {
+	for testIndex, planTest := range extensionTests {
+		c.Logf("Running TestPlanExtensions with test data index %v", testIndex)
+
+		// Write layers to test directory.
+		layersDir := filepath.Join(c.MkDir(), "layers")
+		s.writeLayerFiles(c, layersDir, planTest.layers)
+		var p *plan.Plan
+
+		// Register test extensions.
+		for field, extension := range planTest.extensions {
+			plan.RegisterExtension(field, extension)
+		}
+
+		// Load the plan layer from disk (parse, combine and validate).
+		p, err := plan.ReadDir(layersDir)
+		if planTest.errorString != "" || err != nil {
+			// Expected error.
+			c.Assert(err, ErrorMatches, planTest.errorString)
+		} else {
+			if _, ok := planTest.extensions[xField]; ok {
+				// Verify "x-field" data.
+				var x *xSection
+				err = p.Section(xField, &x)
+				c.Assert(err, IsNil)
+				c.Assert(x.Entries, DeepEquals, planTest.combinedPlanResult.x.Entries)
+			}
+
+			if _, ok := planTest.extensions[yField]; ok {
+				// Verify "y-field" data.
+				var y *ySection
+				err = p.Section(yField, &y)
+				c.Assert(err, IsNil)
+				c.Assert(y.Entries, DeepEquals, planTest.combinedPlanResult.y.Entries)
+			}
+
+			// Verify combined plan YAML.
+			planYAML, err := yaml.Marshal(p)
+			c.Assert(err, IsNil)
+			c.Assert(string(planYAML), Equals, planTest.combinedPlanResultYaml)
+		}
+
+		// Unregister test extensions.
+		for field, _ := range planTest.extensions {
+			plan.UnregisterExtension(field)
+		}
+	}
+}
+
+// writeLayerFiles writes layer files of a test to disk.
+func (s *S) writeLayerFiles(c *C, layersDir string, inputs []*inputLayer) {
+	err := os.MkdirAll(layersDir, 0755)
+	c.Assert(err, IsNil)
+
+	for _, input := range inputs {
+		err := ioutil.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%03d-%s.yaml", input.order, input.label)), reindent(input.yaml), 0644)
+		c.Assert(err, IsNil)
+	}
+}
+
+const xField string = "x-field"
+
+// xExtension implements the LayerSectionExtension interface.
+type xExtension struct{}
+
+func (x xExtension) ParseSection(data yaml.Node) (plan.LayerSection, error) {
+	xs := &xSection{}
+	err := data.Decode(xs)
+	if err != nil {
+		return nil, err
+	}
+	// Propagate the name.
+	for name, entry := range xs.Entries {
+		if entry != nil {
+			xs.Entries[name].Name = name
+		}
+	}
+	return xs, nil
+}
+
+func (x xExtension) CombineSections(sections ...plan.LayerSection) (plan.LayerSection, error) {
+	xs := &xSection{}
+	for _, section := range sections {
+		err := xs.Combine(section)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return xs, nil
+}
+
+func (x xExtension) ValidatePlan(p *plan.Plan) error {
+	var xs *xSection
+	err := p.Section(xField, &xs)
+	if err != nil {
+		return err
+	}
+	if xs != nil {
+		var ys *ySection
+		err = p.Section(yField, &ys)
+		if err != nil {
+			return err
+		}
+		if ys == nil {
+			return fmt.Errorf("cannot validate %v field without %v field", xField, yField)
+		}
+
+		// Test dependency: Make sure every Y field in X refer to an existing Y entry.
+		for xEntryField, xEntryValue := range xs.Entries {
+			for _, yReference := range xEntryValue.Y {
+				found := false
+				for yEntryField, _ := range ys.Entries {
+					if yReference == yEntryField {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("cannot find ySection entry %v as required by xSection entry %v ", yReference, xEntryField)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// xSection is the backing type for xExtension.
+type xSection struct {
+	Entries map[string]*X `yaml:",inline,omitempty"`
+}
+
+func (xs *xSection) Validate() error {
+	for field, entry := range xs.Entries {
+		if entry == nil {
+			return fmt.Errorf("cannot have nil entry for %q", field)
+		}
+		// Fictitious test requirement: entry names must start with x
+		if !strings.HasPrefix(field, "x") {
+			return fmt.Errorf("cannot accept entry not starting with letter 'x'")
+		}
+	}
+	return nil
+}
+
+func (xs *xSection) IsZero() bool {
+	return xs.Entries == nil
+}
+
+func (xs *xSection) Combine(other plan.LayerSection) error {
+	otherxSection, ok := other.(*xSection)
+	if !ok {
+		return fmt.Errorf("cannot combine incompatible section type")
+	}
+
+	for field, entry := range otherxSection.Entries {
+		xs.Entries = makeMapIfNil(xs.Entries)
+		switch entry.Override {
+		case plan.MergeOverride:
+			if old, ok := xs.Entries[field]; ok {
+				copied := old.Copy()
+				copied.Merge(entry)
+				xs.Entries[field] = copied
+				break
+			}
+			fallthrough
+		case plan.ReplaceOverride:
+			xs.Entries[field] = entry.Copy()
+		case plan.UnknownOverride:
+			return &plan.FormatError{
+				Message: fmt.Sprintf(`invalid "override" value for entry %q`, field),
+			}
+		default:
+			return &plan.FormatError{
+				Message: fmt.Sprintf(`unknown "override" value for entry %q`, field),
+			}
+		}
+	}
+	return nil
+}
+
+type X struct {
+	Name     string        `yaml:"-"`
+	Override plan.Override `yaml:"override,omitempty"`
+	A        string        `yaml:"a,omitempty"`
+	B        string        `yaml:"b,omitempty"`
+	C        string        `yaml:"c,omitempty"`
+	Y        []string      `yaml:"y-field,omitempty"`
+}
+
+func (x *X) Copy() *X {
+	copied := *x
+	copied.Y = append([]string(nil), x.Y...)
+	return &copied
+}
+
+func (x *X) Merge(other *X) {
+	if other.A != "" {
+		x.A = other.A
+	}
+	if other.B != "" {
+		x.B = other.B
+	}
+	if other.C != "" {
+		x.C = other.C
+	}
+	x.Y = append(x.Y, other.Y...)
+}
+
+const yField string = "y-field"
+
+// yExtension implements the LayerSectionExtension interface.
+type yExtension struct{}
+
+func (y yExtension) ParseSection(data yaml.Node) (plan.LayerSection, error) {
+	ys := &ySection{}
+	err := data.Decode(ys)
+	if err != nil {
+		return nil, err
+	}
+	// Propagate the name.
+	for name, entry := range ys.Entries {
+		if entry != nil {
+			ys.Entries[name].Name = name
+		}
+	}
+	return ys, nil
+}
+
+func (y yExtension) CombineSections(sections ...plan.LayerSection) (plan.LayerSection, error) {
+	ys := &ySection{}
+	for _, section := range sections {
+		err := ys.Combine(section)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ys, nil
+}
+
+func (y yExtension) ValidatePlan(p *plan.Plan) error {
+	// This extension has no dependencies on the Plan to validate.
+	return nil
+}
+
+// ySection is the backing type for yExtension.
+type ySection struct {
+	Entries map[string]*Y `yaml:",inline,omitempty"`
+}
+
+func (ys *ySection) Validate() error {
+	for field, entry := range ys.Entries {
+		if entry == nil {
+			return fmt.Errorf("cannot have nil entry for %q", field)
+		}
+		// Fictitious test requirement: entry names must start with y
+		if !strings.HasPrefix(field, "y") {
+			return fmt.Errorf("cannot accept entry not starting with letter 'y'")
+		}
+	}
+	return nil
+}
+
+func (ys *ySection) IsZero() bool {
+	return ys.Entries == nil
+}
+
+func (ys *ySection) Combine(other plan.LayerSection) error {
+	otherySection, ok := other.(*ySection)
+	if !ok {
+		return fmt.Errorf("cannot combine incompatible section type")
+	}
+
+	for field, entry := range otherySection.Entries {
+		ys.Entries = makeMapIfNil(ys.Entries)
+		switch entry.Override {
+		case plan.MergeOverride:
+			if old, ok := ys.Entries[field]; ok {
+				copied := old.Copy()
+				copied.Merge(entry)
+				ys.Entries[field] = copied
+				break
+			}
+			fallthrough
+		case plan.ReplaceOverride:
+			ys.Entries[field] = entry.Copy()
+		case plan.UnknownOverride:
+			return &plan.FormatError{
+				Message: fmt.Sprintf(`invalid "override" value for entry %q`, field),
+			}
+		default:
+			return &plan.FormatError{
+				Message: fmt.Sprintf(`unknown "override" value for entry %q`, field),
+			}
+		}
+	}
+	return nil
+}
+
+type Y struct {
+	Name     string        `yaml:"-"`
+	Override plan.Override `yaml:"override,omitempty"`
+	A        string        `yaml:"a,omitempty"`
+	B        string        `yaml:"b,omitempty"`
+	C        string        `yaml:"c,omitempty"`
+}
+
+func (y *Y) Copy() *Y {
+	copied := *y
+	return &copied
+}
+
+func (y *Y) Merge(other *Y) {
+	if other.A != "" {
+		y.A = other.A
+	}
+	if other.B != "" {
+		y.B = other.B
+	}
+	if other.C != "" {
+		y.C = other.C
+	}
+}
+
+func makeMapIfNil[K comparable, V any](m map[K]V) map[K]V {
+	if m == nil {
+		m = make(map[K]V)
+	}
+	return m
+}

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -426,8 +426,9 @@ nexttest:
 }
 
 // TestSectionOrderExt ensures built-in and extension section ordering
-// does not change. Extensions are ordered according to the order of
-// registration.
+// rules are maintained. Extensions are ordered according to the order of
+// registration and follows the built-in sections which are ordered
+// the same way they are defined in the Plan struct.
 func (s *S) TestSectionOrderExt(c *C) {
 	plan.RegisterExtension("x-field", &xExtension{})
 	plan.RegisterExtension("y-field", &yExtension{})

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -954,10 +954,10 @@ func (layer *Layer) Validate() error {
 		}
 	}
 
-	for field, section := range layer.Sections {
+	for _, section := range layer.Sections {
 		err := section.Validate()
 		if err != nil {
-			return fmt.Errorf("cannot validate layer section %q: %w", field, err)
+			return err
 		}
 	}
 
@@ -1055,10 +1055,10 @@ func (p *Plan) Validate() error {
 	}
 
 	// Each section extension must validate the combined plan.
-	for field, extension := range sectionExtensions {
+	for _, extension := range sectionExtensions {
 		err = extension.ValidatePlan(p)
 		if err != nil {
-			return fmt.Errorf("cannot validate plan section %q: %w", field, err)
+			return err
 		}
 	}
 

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -683,9 +683,7 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		var err error
 		combined.Sections[field], err = extension.CombineSections(sections...)
 		if err != nil {
-			return nil, &FormatError{
-				Message: fmt.Sprintf("cannot combine section %q: %v", field, err),
-			}
+			return nil, err
 		}
 	}
 
@@ -1307,9 +1305,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 			// Section unmarshal rules are defined by the extension itself.
 			layer.Sections[field], err = extension.ParseSection(section)
 			if err != nil {
-				return nil, &FormatError{
-					Message: fmt.Sprintf("cannot parse layer %q section %q: %v", label, field, err),
-				}
+				return nil, err
 			}
 		}
 	}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1253,7 +1253,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		"checks":      &layer.Checks,
 		"log-targets": &layer.LogTargets,
 	}
-	// Make sure builtinSections contains the exact same fields as expected
+	// Make sure builtins contains the exact same fields as expected
 	// in the Layer type.
 	if !mapMatchKeys(builtins, builtinSections) {
 		panic("internal error: parsed fields and layer fields differ")

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -32,6 +32,31 @@ import (
 	"github.com/canonical/pebble/internals/osutil"
 )
 
+// LayerSectionExtension allows the plan layer schema to be extended without
+// adding centralised schema knowledge to the plan library.
+type LayerSectionExtension interface {
+	// ParseSection returns a newly allocated concrete type containing the
+	// unmarshalled section content.
+	ParseSection(data yaml.Node) (LayerSection, error)
+
+	// CombineSections returns a newly allocated concrete type containing the
+	// result of combining the supplied sections in order.
+	CombineSections(sections ...LayerSection) (LayerSection, error)
+
+	// ValidatePlan takes the complete plan as input, and allows the
+	// extension to validate the plan. This can be used for cross section
+	// dependency validation.
+	ValidatePlan(plan *Plan) error
+}
+
+type LayerSection interface {
+	// Ask the section to validate itself.
+	Validate() error
+
+	// Returns true if the section is empty.
+	IsZero() bool
+}
+
 const (
 	defaultBackoffDelay  = 500 * time.Millisecond
 	defaultBackoffFactor = 2.0
@@ -42,11 +67,80 @@ const (
 	defaultCheckThreshold = 3
 )
 
+// layerExtensions keeps a map of registered extensions.
+var layerExtensions = map[string]LayerSectionExtension{}
+
+// RegisterExtension adds a plan schema extension. All registrations must be
+// done before the plan library is used.
+func RegisterExtension(field string, ext LayerSectionExtension) error {
+	if _, ok := layerExtensions[field]; ok {
+		return fmt.Errorf("internal error: extension %q already registered", field)
+	}
+	layerExtensions[field] = ext
+	return nil
+}
+
+// UnregisterExtension removes a plan schema extension. This is only
+// intended for use by tests during cleanup.
+func UnregisterExtension(field string) {
+	delete(layerExtensions, field)
+}
+
 type Plan struct {
 	Layers     []*Layer              `yaml:"-"`
 	Services   map[string]*Service   `yaml:"services,omitempty"`
 	Checks     map[string]*Check     `yaml:"checks,omitempty"`
 	LogTargets map[string]*LogTarget `yaml:"log-targets,omitempty"`
+
+	Sections map[string]LayerSection `yaml:",inline"`
+}
+
+// Section retrieves a section from the plan.
+func (p *Plan) Section(field string, out interface{}) error {
+	if _, found := layerExtensions[field]; !found {
+		return fmt.Errorf("cannot find registered extension for field %q", field)
+	}
+
+	outVal := reflect.ValueOf(out)
+	if outVal.Kind() != reflect.Ptr || outVal.IsNil() {
+		return fmt.Errorf("cannot read non pointer to section type %q", outVal.Kind())
+	}
+
+	section, exists := p.Sections[field]
+	if !exists {
+		return fmt.Errorf("internal error: section %q is nil", field)
+	}
+
+	sectionVal := reflect.ValueOf(section)
+	sectionType := sectionVal.Type()
+	outValPtrType := outVal.Elem().Type()
+	if !sectionType.AssignableTo(outValPtrType) {
+		return fmt.Errorf("cannot assign value of type %s to out argument of type %s", sectionType, outValPtrType)
+	}
+	outVal.Elem().Set(sectionVal)
+	return nil
+}
+
+// MarshalYAML implements an override for top level omitempty tags handling.
+// This is required since Sections are based on an inlined map, for which
+// omitempty and inline together is not currently supported.
+func (p *Plan) MarshalYAML() (interface{}, error) {
+	marshalData := make(map[string]interface{})
+	if len(p.Services) != 0 {
+		marshalData["services"] = p.Services
+	}
+	if len(p.LogTargets) != 0 {
+		marshalData["log-targets"] = p.LogTargets
+	}
+	if len(p.Checks) != 0 {
+		marshalData["checks"] = p.Checks
+	}
+	for field, section := range p.Sections {
+		if !section.IsZero() {
+			marshalData[field] = section
+		}
+	}
+	return marshalData, nil
 }
 
 type Layer struct {
@@ -57,6 +151,8 @@ type Layer struct {
 	Services    map[string]*Service   `yaml:"services,omitempty"`
 	Checks      map[string]*Check     `yaml:"checks,omitempty"`
 	LogTargets  map[string]*LogTarget `yaml:"log-targets,omitempty"`
+
+	Sections map[string]LayerSection `yaml:",inline"`
 }
 
 type Service struct {
@@ -559,7 +655,29 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 		Services:   make(map[string]*Service),
 		Checks:     make(map[string]*Check),
 		LogTargets: make(map[string]*LogTarget),
+		Sections:   make(map[string]LayerSection),
 	}
+
+	// Combine the same sections from each layer. Note that we do this before
+	// the layers length check because we need the extension to provide us with
+	// a zero value section, even if no layers are supplied (similar to the
+	// allocations taking place above for the built-in types).
+	for field, extension := range layerExtensions {
+		var sections []LayerSection
+		for _, layer := range layers {
+			if section := layer.Sections[field]; section != nil {
+				sections = append(sections, section)
+			}
+		}
+		var err error
+		combined.Sections[field], err = extension.CombineSections(sections...)
+		if err != nil {
+			return nil, &FormatError{
+				Message: fmt.Sprintf(`cannot combine section %q: %v`, field, err),
+			}
+		}
+	}
+
 	if len(layers) == 0 {
 		return combined, nil
 	}
@@ -825,11 +943,18 @@ func (layer *Layer) Validate() error {
 		}
 	}
 
+	for field, section := range layer.Sections {
+		err := section.Validate()
+		if err != nil {
+			return fmt.Errorf("cannot validate layer section %q: %w", field, err)
+		}
+	}
+
 	return nil
 }
 
-// Validate checks that the combined layers form a valid plan.
-// See also Layer.Validate, which checks that the individual layers are valid.
+// Validate checks that the combined layers form a valid plan. See also
+// Layer.Validate, which checks that the individual layers are valid.
 func (p *Plan) Validate() error {
 	for name, service := range p.Services {
 		if service.Command == "" {
@@ -917,6 +1042,15 @@ func (p *Plan) Validate() error {
 	if err != nil {
 		return err
 	}
+
+	// Each section extension must validate the combined plan.
+	for field, extension := range layerExtensions {
+		err = extension.ValidatePlan(p)
+		if err != nil {
+			return fmt.Errorf("cannot validate plan section %q: %w", field, err)
+		}
+	}
+
 	return nil
 }
 
@@ -1085,19 +1219,84 @@ func (p *Plan) checkCycles() error {
 }
 
 func ParseLayer(order int, label string, data []byte) (*Layer, error) {
-	layer := Layer{
-		Services:   map[string]*Service{},
-		Checks:     map[string]*Check{},
-		LogTargets: map[string]*LogTarget{},
+	layer := &Layer{
+		Services:   make(map[string]*Service),
+		Checks:     make(map[string]*Check),
+		LogTargets: make(map[string]*LogTarget),
+		Sections:   make(map[string]LayerSection),
 	}
-	dec := yaml.NewDecoder(bytes.NewBuffer(data))
-	dec.KnownFields(true)
-	err := dec.Decode(&layer)
+
+	// The following manual approach is required because:
+	//
+	// 1. Extended sections are YAML inlined, and also do not have a
+	// concrete type at this level, we cannot simply unmarshal the layer
+	// in one step.
+	//
+	// 2. We honor KnownFields = true behaviour for non extended schema
+	// sections, and at the top field level, which includes Section field
+	// names.
+	builtinSections := map[string]interface{}{
+		"summary":     &layer.Summary,
+		"description": &layer.Description,
+		"services":    &layer.Services,
+		"checks":      &layer.Checks,
+		"log-targets": &layer.LogTargets,
+	}
+
+	layerSections := make(map[string]yaml.Node)
+	// Deliberately pre-allocate at least an empty yaml.Node for every
+	// extension section. Extension sections that have unmarshalled
+	// will update the respective node, while non-existing sections
+	// will at least have an empty node. This means we can consistently
+	// let the extension allocate and decode the yaml node for all sections,
+	// and in the case where it is zero, we get an empty backing type instance.
+	for field, _ := range layerExtensions {
+		layerSections[field] = yaml.Node{}
+	}
+	err := yaml.Unmarshal(data, &layerSections)
 	if err != nil {
 		return nil, &FormatError{
 			Message: fmt.Sprintf("cannot parse layer %q: %v", label, err),
 		}
 	}
+
+	for field, section := range layerSections {
+		if _, builtin := builtinSections[field]; builtin {
+			// The following issue prevents us from using the yaml.Node decoder
+			// with KnownFields = true behaviour. Once one of the proposals get
+			// merged, we can remove the intermediate Marshal step.
+			// https://github.com/go-yaml/yaml/issues/460
+			data, err := yaml.Marshal(&section)
+			if err != nil {
+				return nil, fmt.Errorf("internal error: cannot marshal %v section: %w", field, err)
+			}
+			dec := yaml.NewDecoder(bytes.NewReader(data))
+			dec.KnownFields(true)
+			if err = dec.Decode(builtinSections[field]); err != nil {
+				return nil, &FormatError{
+					Message: fmt.Sprintf("cannot parse layer %q section %q: %v", label, field, err),
+				}
+			}
+		} else {
+			if extension, ok := layerExtensions[field]; ok {
+				// Section unmarshal rules are defined by the extension itself.
+				layer.Sections[field], err = extension.ParseSection(section)
+				if err != nil {
+					return nil, &FormatError{
+						Message: fmt.Sprintf("cannot parse layer %q section %q: %v", label, field, err),
+					}
+				}
+			} else {
+				// At the top level we do not ignore keys we do not understand.
+				// This preserves the current Pebble behaviour of decoding with
+				// KnownFields = true.
+				return nil, &FormatError{
+					Message: fmt.Sprintf("cannot parse layer %q: unknown section %q", label, field),
+				}
+			}
+		}
+	}
+
 	layer.Order = order
 	layer.Label = label
 
@@ -1125,7 +1324,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		return nil, err
 	}
 
-	return &layer, err
+	return layer, err
 }
 
 func validServiceAction(action ServiceAction, additionalValid ...ServiceAction) bool {
@@ -1228,6 +1427,7 @@ func ReadDir(layersDir string) (*Plan, error) {
 		Services:   combined.Services,
 		Checks:     combined.Checks,
 		LogTargets: combined.LogTargets,
+		Sections:   combined.Sections,
 	}
 	err = plan.Validate()
 	if err != nil {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1251,11 +1251,6 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 		"checks":      &layer.Checks,
 		"log-targets": &layer.LogTargets,
 	}
-	// Make sure builtins contains the exact same fields as expected
-	// in the Layer type.
-	if !mapMatchKeys(builtins, builtinSections) {
-		panic("internal error: parsed fields and layer fields differ")
-	}
 
 	sections := make(map[string]yaml.Node)
 	// Deliberately pre-allocate at least an empty yaml.Node for every
@@ -1338,20 +1333,6 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	}
 
 	return layer, err
-}
-
-// mapMatchKeys returns true if the key list supplied is an exact match of the
-// keys in the map (ordering is ignored).
-func mapMatchKeys[M ~map[K]V, K comparable, V any](inMap M, keyList []K) bool {
-	if len(inMap) != len(keyList) {
-		return false
-	}
-	for key, _ := range inMap {
-		if !slices.Contains(keyList, key) {
-			return false
-		}
-	}
-	return true
 }
 
 func validServiceAction(action ServiceAction, additionalValid ...ServiceAction) bool {

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -73,6 +73,10 @@ var layerExtensions = map[string]LayerSectionExtension{}
 // RegisterExtension adds a plan schema extension. All registrations must be
 // done before the plan library is used.
 func RegisterExtension(field string, ext LayerSectionExtension) {
+	switch field {
+	case "summary", "description", "services", "checks", "log-targets":
+		panic(fmt.Sprintf("internal error: extension %q already used as built-in field", field))
+	}
 	if _, ok := layerExtensions[field]; ok {
 		panic(fmt.Sprintf("internal error: extension %q already registered", field))
 	}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -81,11 +81,11 @@ var (
 // the YAML fields exposed in the Layer type, to catch inconsistencies.
 var builtinSections = []string{"summary", "description", "services", "checks", "log-targets"}
 
-// RegisterExtension adds a plan schema extension. All registrations must be
+// RegisterSectionExtension adds a plan schema extension. All registrations must be
 // done before the plan library is used. The order in which extensions are
 // registered determines the order in which the sections are marshalled.
 // Extension sections are marshalled after the built-in sections.
-func RegisterExtension(field string, ext SectionExtension) {
+func RegisterSectionExtension(field string, ext SectionExtension) {
 	if slices.Contains(builtinSections, field) {
 		panic(fmt.Sprintf("internal error: extension %q already used as built-in field", field))
 	}
@@ -96,9 +96,9 @@ func RegisterExtension(field string, ext SectionExtension) {
 	sectionExtensionsOrder = append(sectionExtensionsOrder, field)
 }
 
-// UnregisterExtension removes a plan schema extension. This is only
+// UnregisterSectionExtension removes a plan schema extension. This is only
 // intended for use by tests during cleanup.
-func UnregisterExtension(field string) {
+func UnregisterSectionExtension(field string) {
 	delete(sectionExtensions, field)
 	sectionExtensionsOrder = slices.DeleteFunc(sectionExtensionsOrder, func(n string) bool {
 		return n == field

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -95,30 +95,11 @@ type Plan struct {
 	Sections map[string]LayerSection `yaml:",inline"`
 }
 
-// Section retrieves a section from the plan.
-func (p *Plan) Section(field string, out interface{}) error {
-	if _, found := layerExtensions[field]; !found {
-		return fmt.Errorf("cannot find registered extension for field %q", field)
-	}
-
-	outVal := reflect.ValueOf(out)
-	if outVal.Kind() != reflect.Ptr || outVal.IsNil() {
-		return fmt.Errorf("cannot read non pointer to section type %q", outVal.Kind())
-	}
-
-	section, exists := p.Sections[field]
-	if !exists {
-		return fmt.Errorf("internal error: section %q is nil", field)
-	}
-
-	sectionVal := reflect.ValueOf(section)
-	sectionType := sectionVal.Type()
-	outValPtrType := outVal.Elem().Type()
-	if !sectionType.AssignableTo(outValPtrType) {
-		return fmt.Errorf("cannot assign value of type %s to out argument of type %s", sectionType, outValPtrType)
-	}
-	outVal.Elem().Set(sectionVal)
-	return nil
+// Section retrieves a section from the plan. If Section is called
+// before the plan is loaded, or with an unregistered field, this method
+// will return nil.
+func (p *Plan) Section(field string) LayerSection {
+	return p.Sections[field]
 }
 
 // MarshalYAML implements an override for top level omitempty tags handling.

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1255,7 +1255,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	}
 	// Make sure builtinSections contains the exact same fields as expected
 	// in the Layer type.
-	if !mapHasKeys(builtinSections, layerBuiltins) {
+	if !mapMatchKeys(builtinSections, layerBuiltins) {
 		panic("internal error: parsed fields and layer fields differ")
 	}
 
@@ -1344,14 +1344,14 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	return layer, err
 }
 
-// mapHasKeys returns true if the key list supplied is an exact match of the
+// mapMatchKeys returns true if the key list supplied is an exact match of the
 // keys in the map (ordering is ignored).
-func mapHasKeys[M ~map[K]V, K comparable, V any](inMap M, keyList []K) bool {
+func mapMatchKeys[M ~map[K]V, K comparable, V any](inMap M, keyList []K) bool {
 	if len(inMap) != len(keyList) {
 		return false
 	}
-	for _, key := range keyList {
-		if _, ok := inMap[key]; !ok {
+	for key, _ := range inMap {
+		if !slices.Contains(keyList, key) {
 			return false
 		}
 	}

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -2110,7 +2110,8 @@ func firstLetterToLower(s string) string {
 	return string(r)
 }
 
-// TestSectionOrder ensures built-in section order is maintained.
+// TestSectionOrder ensures built-in section order is maintained
+// during Plan marshal operations.
 func (s *S) TestSectionOrder(c *C) {
 	layer, err := plan.ParseLayer(1, "label", reindent(`
 	checks:

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -206,7 +206,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	}, {
 		Order:       1,
 		Label:       "layer-1",
@@ -257,7 +257,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	}},
 	result: &plan.Layer{
 		Summary:     "Simple override layer.",
@@ -337,7 +337,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 	start: map[string][]string{
 		"srv1": {"srv2", "srv1", "srv3"},
@@ -400,7 +400,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	}},
 }, {
 	summary: "Unknown keys are not accepted",
@@ -551,7 +551,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	}},
 }, {
 	summary: `Invalid service command: cannot have any arguments after [ ... ] group`,
@@ -660,7 +660,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 }, {
 	summary: "Checks override replace works correctly",
@@ -738,7 +738,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 }, {
 	summary: "Checks override merge works correctly",
@@ -822,7 +822,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 }, {
 	summary: "Timeout is capped at period",
@@ -852,7 +852,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 }, {
 	summary: "Unset timeout is capped at period",
@@ -881,7 +881,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 }, {
 	summary: "One of http, tcp, or exec must be present for check",
@@ -1002,7 +1002,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	},
 }, {
 	summary: "Overriding log targets",
@@ -1099,7 +1099,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	}, {
 		Label: "layer-1",
 		Order: 1,
@@ -1138,7 +1138,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	}},
 	result: &plan.Layer{
 		Services: map[string]*plan.Service{
@@ -1184,7 +1184,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	},
 }, {
 	summary: "Log target requires type field",
@@ -1294,7 +1294,7 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	}, {
 		Order:    1,
 		Label:    "layer-1",
@@ -1320,7 +1320,7 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	}},
 	result: &plan.Layer{
 		Services: map[string]*plan.Service{},
@@ -1348,7 +1348,7 @@ var planTests = []planTest{{
 				},
 			},
 		},
-		Sections: map[string]plan.LayerSection{},
+		Sections: map[string]plan.Section{},
 	},
 }, {
 	summary: "Reserved log target labels",
@@ -1399,7 +1399,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
-		Sections:   map[string]plan.LayerSection{},
+		Sections:   map[string]plan.Section{},
 	},
 }, {
 	summary: "Three layers missing command",

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -2076,9 +2076,9 @@ func (s *S) TestStartStopOrderMultipleLanes(c *C) {
 // reflects the same YAML fields as exposed in the Layer type.
 func (s *S) TestLayerBuiltinCompatible(c *C) {
 	fields := structYamlFields(plan.Layer{})
-	c.Assert(len(fields), Equals, len(plan.LayerBuiltins))
+	c.Assert(len(fields), Equals, len(plan.BuiltinSections))
 	for _, field := range structYamlFields(plan.Layer{}) {
-		c.Assert(slices.Contains(plan.LayerBuiltins, field), Equals, true)
+		c.Assert(slices.Contains(plan.BuiltinSections, field), Equals, true)
 	}
 }
 

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -2077,7 +2077,7 @@ func (s *S) TestStartStopOrderMultipleLanes(c *C) {
 func (s *S) TestLayerBuiltinCompatible(c *C) {
 	fields := structYamlFields(plan.Layer{})
 	c.Assert(len(fields), Equals, len(plan.BuiltinSections))
-	for _, field := range structYamlFields(plan.Layer{}) {
+	for _, field := range fields {
 		c.Assert(slices.Contains(plan.BuiltinSections, field), Equals, true)
 	}
 }

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -203,6 +203,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	}, {
 		Order:       1,
 		Label:       "layer-1",
@@ -253,6 +254,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	}},
 	result: &plan.Layer{
 		Summary:     "Simple override layer.",
@@ -332,6 +334,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 	start: map[string][]string{
 		"srv1": {"srv2", "srv1", "srv3"},
@@ -394,6 +397,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	}},
 }, {
 	summary: "Unknown keys are not accepted",
@@ -477,7 +481,7 @@ var planTests = []planTest{{
 	`},
 }, {
 	summary: `Invalid backoff-delay duration`,
-	error:   `cannot parse layer "layer-0": invalid duration "foo"`,
+	error:   `cannot parse layer "layer-0" section "services": invalid duration "foo"`,
 	input: []string{`
 		services:
 			"svc1":
@@ -507,7 +511,7 @@ var planTests = []planTest{{
 	`},
 }, {
 	summary: `Invalid backoff-factor`,
-	error:   `cannot parse layer "layer-0": invalid floating-point number "foo"`,
+	error:   `cannot parse layer "layer-0" section "services": invalid floating-point number "foo"`,
 	input: []string{`
 		services:
 			"svc1":
@@ -544,6 +548,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	}},
 }, {
 	summary: `Invalid service command: cannot have any arguments after [ ... ] group`,
@@ -652,6 +657,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Checks override replace works correctly",
@@ -729,6 +735,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Checks override merge works correctly",
@@ -812,6 +819,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Timeout is capped at period",
@@ -841,6 +849,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Unset timeout is capped at period",
@@ -869,6 +878,7 @@ var planTests = []planTest{{
 			},
 		},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "One of http, tcp, or exec must be present for check",
@@ -989,6 +999,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Overriding log targets",
@@ -1085,6 +1096,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	}, {
 		Label: "layer-1",
 		Order: 1,
@@ -1123,6 +1135,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	}},
 	result: &plan.Layer{
 		Services: map[string]*plan.Service{
@@ -1168,6 +1181,7 @@ var planTests = []planTest{{
 				Override: plan.MergeOverride,
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Log target requires type field",
@@ -1277,6 +1291,7 @@ var planTests = []planTest{{
 				},
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	}, {
 		Order:    1,
 		Label:    "layer-1",
@@ -1302,6 +1317,7 @@ var planTests = []planTest{{
 				},
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	}},
 	result: &plan.Layer{
 		Services: map[string]*plan.Service{},
@@ -1329,6 +1345,7 @@ var planTests = []planTest{{
 				},
 			},
 		},
+		Sections: map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Reserved log target labels",
@@ -1379,6 +1396,7 @@ var planTests = []planTest{{
 		},
 		Checks:     map[string]*plan.Check{},
 		LogTargets: map[string]*plan.LogTarget{},
+		Sections:   map[string]plan.LayerSection{},
 	},
 }, {
 	summary: "Three layers missing command",
@@ -1452,6 +1470,7 @@ func (s *S) TestParseLayer(c *C) {
 					Services:   result.Services,
 					Checks:     result.Checks,
 					LogTargets: result.LogTargets,
+					Sections:   result.Sections,
 				}
 				err = p.Validate()
 			}
@@ -1494,6 +1513,7 @@ services:
 		Services:   combined.Services,
 		Checks:     combined.Checks,
 		LogTargets: combined.LogTargets,
+		Sections:   combined.Sections,
 	}
 	err = p.Validate()
 	c.Assert(err, ErrorMatches, `services in before/after loop: .*`)
@@ -1534,6 +1554,7 @@ services:
 		Services:   combined.Services,
 		Checks:     combined.Checks,
 		LogTargets: combined.LogTargets,
+		Sections:   combined.Sections,
 	}
 	err = p.Validate()
 	c.Check(err, ErrorMatches, `plan must define "command" for service "srv1"`)
@@ -1885,6 +1906,8 @@ func (s *S) TestMergeServiceContextNoContext(c *C) {
 		Group:       "grp",
 		WorkingDir:  "/working/dir",
 	}
+	// This test ensures an empty service name results in no lookup, and
+	// simply leaves the provided context unchanged.
 	merged, err := plan.MergeServiceContext(nil, "", overrides)
 	c.Assert(err, IsNil)
 	c.Check(merged, DeepEquals, overrides)


### PR DESCRIPTION
The plan library was originally written as a configuration schema for the services manager (servstate). Over time the need arose to support configurations for other managers such as checks (checkstate) and log-targets (logstate). The configuration schema for these managers, closely related to the services manager, has since also been built in to the plan library.

The services manager and its related checks and log-targets functionality will always be part of the Pebble core. However, as Pebble is getting more functionality (additional managers) and also used as a core in derivative projects, a more modular and dynamic approach to extending the schema is needed.

Add an the ```SectionExtension``` interface for use by managers who wishes to register a schema extension during Pebble startup.

Inside each layer, top level entries are now referred to as ```sections``` (built-in sections includes ```summary```, ```description```, ```services```, ```log-targets``` and ```checks```).

Each section has an associated ```field``` that is the top level key, and if supplied by an extension, an opaque backing type ```Section```.

**SectionExtension interface:**

```
// SectionExtension allows the plan layer schema to be extended without
// adding centralised schema knowledge to the plan library.
type SectionExtension interface {
	// ParseSection returns a newly allocated concrete type containing the
	// unmarshalled section content.
	ParseSection(data yaml.Node) (LayerSection, error)

	// CombineSections returns a newly allocated concrete type containing the
	// result of combining the supplied sections in order.
	CombineSections(sections ...LayerSection) (LayerSection, error)

	// ValidatePlan takes the complete plan as input, and allows the
	// extension to validate the plan. This can be used for cross section
	// dependency validation.
	ValidatePlan(plan *Plan) error
}

type Section interface {
	// Validate checks whether the section is valid, returning an error if not.
	Validate() error
	
        // IsZero reports whether the section is empty.
	IsZero() bool
}
```

**Example usage:**

```
// New SectionExtension type
type fooExtension struct{}
func (f *fooExtension) ParseSection(data yaml.Node) (LayerSection, error) {...}
func (f *fooExtension) CombineSections(sections ...LayerSection) (LayerSection, error) {...}
func (f *fooExtension) ValidatePlan(plan *Plan) error {...}

// New Section type
type FooSection struct {
    Entries map[string]Bar `yaml:",inline,omitempty"`
}
type Bar struct {
    Name string `yaml:"name,omitempty"`
}
func (s *FooSection) Validate() error {...}
func (s *FooSection) IsZero() bool {...}
```
```
// Early startup
plan.RegisterExtension("foo", &fooExtension{})
:
// Load layers containing new section
newPlan := plan.ReadDir(layersDir)
:
// Show plan
yaml.Marshal(newPlan)
```
Example YAML output:
```
foo:
    bar1:
           name: test1
    bar2:
           name: test2          
```