### PR TITLE
feat(planstate): add plan section support

### DIFF
--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -48,6 +48,12 @@ func NewManager(layersDir string) (*PlanManager, error) {
 	return manager, nil
 }
 
+// RegisterExtension adds a plan extension which extends the plan schema. All
+// extensions must be registered before Load() is called.
+func (m *PlanManager) RegisterExtension(field string, ext plan.LayerSectionExtension) {
+	plan.RegisterExtension(field, ext)
+}
+
 // Load reads plan layers from the pebble directory, combines and validates the
 // final plan, and finally notifies registered managers of the plan update. In
 // the case of a non-existent layers directory, or no layers in the layers
@@ -181,6 +187,7 @@ func (m *PlanManager) updatePlanLayers(layers []*plan.Layer) (*plan.Plan, error)
 		Services:   combined.Services,
 		Checks:     combined.Checks,
 		LogTargets: combined.LogTargets,
+		Sections:   combined.Sections,
 	}
 	err = p.Validate()
 	if err != nil {

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -48,12 +48,6 @@ func NewManager(layersDir string) (*PlanManager, error) {
 	return manager, nil
 }
 
-// RegisterExtension adds a plan extension which extends the plan schema. All
-// extensions must be registered before Load() is called.
-func (m *PlanManager) RegisterExtension(field string, ext plan.LayerSectionExtension) {
-	plan.RegisterExtension(field, ext)
-}
-
 // Load reads plan layers from the pebble directory, combines and validates the
 // final plan, and finally notifies registered managers of the plan update. In
 // the case of a non-existent layers directory, or no layers in the layers

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -110,10 +110,12 @@ var extLoadLayers = []string{`
 `}
 
 func (ps *planSuite) TestExtLoadLayers(c *C) {
+	plan.RegisterExtension(testField, testExtension{})
+	defer plan.UnregisterExtension(testField)
+
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
-	plan.RegisterExtension(testField, testExtension{})
 	// Write layers
 	for _, l := range extLoadLayers {
 		ps.writeLayer(c, string(reindent(l)))
@@ -224,10 +226,12 @@ services:
 }
 
 func (ps *planSuite) TestExtAppendLayers(c *C) {
+	plan.RegisterExtension(testField, testExtension{})
+	defer plan.UnregisterExtension(testField)
+
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
-	plan.RegisterExtension(testField, testExtension{})
 
 	// Append a layer when there are no layers.
 	layer := ps.parseLayer(c, 0, "label1", `
@@ -462,10 +466,12 @@ checks:
 }
 
 func (ps *planSuite) TestExtCombineLayers(c *C) {
+	plan.RegisterExtension(testField, testExtension{})
+	defer plan.UnregisterExtension(testField)
+
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
-	plan.RegisterExtension(testField, testExtension{})
 
 	// "Combine" layer with no layers should just append.
 	layer := ps.parseLayer(c, 0, "label1", `

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -45,52 +45,6 @@ var loadLayers = []string{`
 			summary: Svc1
 			override: replace
 			command: echo svc1
-`, `
-	summary: Layer 2
-	description: Layer 2 desc.
-	services:
-		svc2:
-			summary: Svc2
-			override: replace
-			command: echo svc2
-`}
-
-func (ps *planSuite) TestLoadLayers(c *C) {
-	var err error
-	ps.planMgr, err = planstate.NewManager(ps.layersDir)
-	c.Assert(err, IsNil)
-	// Write layers
-	for _, l := range loadLayers {
-		ps.writeLayer(c, string(reindent(l)))
-	}
-	// Load the plan from the <pebble-dir>/layers directory
-	err = ps.planMgr.Load()
-	c.Assert(err, IsNil)
-	plan := ps.planMgr.Plan()
-	out, err := yaml.Marshal(plan)
-	c.Assert(err, IsNil)
-	c.Assert(len(plan.Layers), Equals, 2)
-	c.Assert(string(out), Equals, `
-services:
-    svc1:
-        summary: Svc1
-        override: replace
-        command: echo svc1
-    svc2:
-        summary: Svc2
-        override: replace
-        command: echo svc2
-`[1:])
-}
-
-var extLoadLayers = []string{`
-	summary: Layer 1
-	description: Layer 1 desc.
-	services:
-		svc1:
-			summary: Svc1
-			override: replace
-			command: echo svc1
 	test-field:
 		test1:
 			override: merge
@@ -109,15 +63,14 @@ var extLoadLayers = []string{`
 			b: something else
 `}
 
-func (ps *planSuite) TestExtLoadLayers(c *C) {
+func (ps *planSuite) TestLoadLayers(c *C) {
 	plan.RegisterExtension(testField, testExtension{})
 	defer plan.UnregisterExtension(testField)
-
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
 	// Write layers
-	for _, l := range extLoadLayers {
+	for _, l := range loadLayers {
 		ps.writeLayer(c, string(reindent(l)))
 	}
 	// Load the plan from the <pebble-dir>/layers directory
@@ -146,89 +99,8 @@ test-field:
 }
 
 func (ps *planSuite) TestAppendLayers(c *C) {
-	var err error
-	ps.planMgr, err = planstate.NewManager(ps.layersDir)
-	c.Assert(err, IsNil)
-
-	// Append a layer when there are no layers.
-	layer := ps.parseLayer(c, 0, "label1", `
-services:
-    svc1:
-        override: replace
-        command: /bin/sh
-`)
-	err = ps.planMgr.AppendLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 1)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/sh
-`[1:])
-	ps.planLayersHasLen(c, 1)
-
-	// Try to append a layer when that label already exists.
-	layer = ps.parseLayer(c, 0, "label1", `
-services:
-    svc1:
-        override: foobar
-        command: /bin/bar
-`)
-	err = ps.planMgr.AppendLayer(layer)
-	c.Assert(err.(*planstate.LabelExists).Label, Equals, "label1")
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/sh
-`[1:])
-	ps.planLayersHasLen(c, 1)
-
-	// Append another layer on top.
-	layer = ps.parseLayer(c, 0, "label2", `
-services:
-    svc1:
-        override: replace
-        command: /bin/bash
-`)
-	err = ps.planMgr.AppendLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 2)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/bash
-`[1:])
-	ps.planLayersHasLen(c, 2)
-
-	// Append a layer with a different service.
-	layer = ps.parseLayer(c, 0, "label3", `
-services:
-    svc2:
-        override: replace
-        command: /bin/foo
-`)
-	err = ps.planMgr.AppendLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 3)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/bash
-    svc2:
-        override: replace
-        command: /bin/foo
-`[1:])
-	ps.planLayersHasLen(c, 3)
-}
-
-func (ps *planSuite) TestExtAppendLayers(c *C) {
 	plan.RegisterExtension(testField, testExtension{})
 	defer plan.UnregisterExtension(testField)
-
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
@@ -344,131 +216,8 @@ test-field:
 }
 
 func (ps *planSuite) TestCombineLayers(c *C) {
-	var err error
-	ps.planMgr, err = planstate.NewManager(ps.layersDir)
-	c.Assert(err, IsNil)
-
-	// "Combine" layer with no layers should just append.
-	layer := ps.parseLayer(c, 0, "label1", `
-services:
-    svc1:
-        override: replace
-        command: /bin/sh
-`)
-	err = ps.planMgr.CombineLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 1)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/sh
-`[1:])
-	ps.planLayersHasLen(c, 1)
-
-	// Combine layer with different label should just append.
-	layer = ps.parseLayer(c, 0, "label2", `
-services:
-    svc2:
-        override: replace
-        command: /bin/foo
-`)
-	err = ps.planMgr.CombineLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 2)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/sh
-    svc2:
-        override: replace
-        command: /bin/foo
-`[1:])
-	ps.planLayersHasLen(c, 2)
-
-	// Combine layer with first layer.
-	layer = ps.parseLayer(c, 0, "label1", `
-services:
-    svc1:
-        override: replace
-        command: /bin/bash
-`)
-	err = ps.planMgr.CombineLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 1)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/bash
-    svc2:
-        override: replace
-        command: /bin/foo
-`[1:])
-	ps.planLayersHasLen(c, 2)
-
-	// Combine layer with second layer.
-	layer = ps.parseLayer(c, 0, "label2", `
-services:
-    svc2:
-        override: replace
-        command: /bin/bar
-`)
-	err = ps.planMgr.CombineLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 2)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/bash
-    svc2:
-        override: replace
-        command: /bin/bar
-`[1:])
-	ps.planLayersHasLen(c, 2)
-
-	// One last append for good measure.
-	layer = ps.parseLayer(c, 0, "label3", `
-services:
-    svc1:
-        override: replace
-        command: /bin/a
-    svc2:
-        override: replace
-        command: /bin/b
-`)
-	err = ps.planMgr.CombineLayer(layer)
-	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 3)
-	c.Assert(ps.planYAML(c), Equals, `
-services:
-    svc1:
-        override: replace
-        command: /bin/a
-    svc2:
-        override: replace
-        command: /bin/b
-`[1:])
-	ps.planLayersHasLen(c, 3)
-
-	// Make sure that layer validation is happening.
-	layer, err = plan.ParseLayer(0, "label4", []byte(`
-checks:
-    bad-check:
-        override: replace
-        level: invalid
-        tcp:
-            port: 8080
-`))
-	c.Check(err, ErrorMatches, `(?s).*plan check.*must be "alive" or "ready".*`)
-}
-
-func (ps *planSuite) TestExtCombineLayers(c *C) {
 	plan.RegisterExtension(testField, testExtension{})
 	defer plan.UnregisterExtension(testField)
-
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -113,7 +113,7 @@ func (ps *planSuite) TestExtLoadLayers(c *C) {
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
-	ps.planMgr.RegisterExtension(testField, testExtension{})
+	plan.RegisterExtension(testField, testExtension{})
 	// Write layers
 	for _, l := range extLoadLayers {
 		ps.writeLayer(c, string(reindent(l)))
@@ -227,7 +227,7 @@ func (ps *planSuite) TestExtAppendLayers(c *C) {
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
-	ps.planMgr.RegisterExtension(testField, testExtension{})
+	plan.RegisterExtension(testField, testExtension{})
 
 	// Append a layer when there are no layers.
 	layer := ps.parseLayer(c, 0, "label1", `
@@ -465,7 +465,7 @@ func (ps *planSuite) TestExtCombineLayers(c *C) {
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
-	ps.planMgr.RegisterExtension(testField, testExtension{})
+	plan.RegisterExtension(testField, testExtension{})
 
 	// "Combine" layer with no layers should just append.
 	layer := ps.parseLayer(c, 0, "label1", `

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -64,8 +64,8 @@ var loadLayers = []string{`
 `}
 
 func (ps *planSuite) TestLoadLayers(c *C) {
-	plan.RegisterExtension(testField, testExtension{})
-	defer plan.UnregisterExtension(testField)
+	plan.RegisterSectionExtension(testField, testExtension{})
+	defer plan.UnregisterSectionExtension(testField)
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
@@ -99,8 +99,8 @@ test-field:
 }
 
 func (ps *planSuite) TestAppendLayers(c *C) {
-	plan.RegisterExtension(testField, testExtension{})
-	defer plan.UnregisterExtension(testField)
+	plan.RegisterSectionExtension(testField, testExtension{})
+	defer plan.UnregisterSectionExtension(testField)
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)
@@ -216,8 +216,8 @@ test-field:
 }
 
 func (ps *planSuite) TestCombineLayers(c *C) {
-	plan.RegisterExtension(testField, testExtension{})
-	defer plan.UnregisterExtension(testField)
+	plan.RegisterSectionExtension(testField, testExtension{})
+	defer plan.UnregisterSectionExtension(testField)
 	var err error
 	ps.planMgr, err = planstate.NewManager(ps.layersDir)
 	c.Assert(err, IsNil)

--- a/internals/overlord/planstate/package_test.go
+++ b/internals/overlord/planstate/package_test.go
@@ -42,8 +42,6 @@ type planSuite struct {
 var _ = Suite(&planSuite{})
 
 func (ps *planSuite) SetUpTest(c *C) {
-	plan.UnregisterExtension(testField)
-
 	ps.layersDir = filepath.Join(c.MkDir(), "layers")
 	err := os.Mkdir(ps.layersDir, 0755)
 	c.Assert(err, IsNil)
@@ -110,7 +108,7 @@ const testField string = "test-field"
 // testExtension implements the LayerSectionExtension interface.
 type testExtension struct{}
 
-func (te testExtension) ParseSection(data yaml.Node) (plan.LayerSection, error) {
+func (te testExtension) ParseSection(data yaml.Node) (plan.Section, error) {
 	ts := &testSection{}
 	err := data.Decode(ts)
 	if err != nil {
@@ -125,7 +123,7 @@ func (te testExtension) ParseSection(data yaml.Node) (plan.LayerSection, error) 
 	return ts, nil
 }
 
-func (te testExtension) CombineSections(sections ...plan.LayerSection) (plan.LayerSection, error) {
+func (te testExtension) CombineSections(sections ...plan.Section) (plan.Section, error) {
 	ts := &testSection{}
 	for _, section := range sections {
 		err := ts.Combine(section)
@@ -161,7 +159,7 @@ func (ts *testSection) IsZero() bool {
 	return ts.Entries == nil
 }
 
-func (ts *testSection) Combine(other plan.LayerSection) error {
+func (ts *testSection) Combine(other plan.Section) error {
 	otherTSection, ok := other.(*testSection)
 	if !ok {
 		return fmt.Errorf("invalid section type")

--- a/internals/overlord/planstate/package_test.go
+++ b/internals/overlord/planstate/package_test.go
@@ -42,7 +42,11 @@ type planSuite struct {
 var _ = Suite(&planSuite{})
 
 func (ps *planSuite) SetUpTest(c *C) {
-	ps.layersDir = c.MkDir()
+	plan.UnregisterExtension(testField)
+
+	ps.layersDir = filepath.Join(c.MkDir(), "layers")
+	err := os.Mkdir(ps.layersDir, 0755)
+	c.Assert(err, IsNil)
 
 	//Reset write layer counter
 	ps.writeLayerCounter = 1
@@ -99,4 +103,120 @@ func reindent(in string) []byte {
 		buf.WriteByte('\n')
 	}
 	return buf.Bytes()
+}
+
+const testField string = "test-field"
+
+// testExtension implements the LayerSectionExtension interface.
+type testExtension struct{}
+
+func (te testExtension) ParseSection(data yaml.Node) (plan.LayerSection, error) {
+	ts := &testSection{}
+	err := data.Decode(ts)
+	if err != nil {
+		return nil, err
+	}
+	// Populate Name.
+	for name, entry := range ts.Entries {
+		if entry != nil {
+			ts.Entries[name].Name = name
+		}
+	}
+	return ts, nil
+}
+
+func (te testExtension) CombineSections(sections ...plan.LayerSection) (plan.LayerSection, error) {
+	ts := &testSection{}
+	for _, section := range sections {
+		err := ts.Combine(section)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ts, nil
+}
+
+func (te testExtension) ValidatePlan(p *plan.Plan) error {
+	// This extension has no dependencies on the Plan to validate.
+	return nil
+}
+
+// testSection is the backing type for testExtension.
+type testSection struct {
+	Entries map[string]*T `yaml:",inline"`
+}
+
+func (ts *testSection) Validate() error {
+	// Fictitious test requirement: fields must start with t
+	prefix := "t"
+	for field, _ := range ts.Entries {
+		if !strings.HasPrefix(field, prefix) {
+			return fmt.Errorf("%q entry names must start with %q", testField, prefix)
+		}
+	}
+	return nil
+}
+
+func (ts *testSection) IsZero() bool {
+	return ts.Entries == nil
+}
+
+func (ts *testSection) Combine(other plan.LayerSection) error {
+	otherTSection, ok := other.(*testSection)
+	if !ok {
+		return fmt.Errorf("invalid section type")
+	}
+
+	for field, entry := range otherTSection.Entries {
+		ts.Entries = makeMapIfNil(ts.Entries)
+		switch entry.Override {
+		case plan.MergeOverride:
+			if old, ok := ts.Entries[field]; ok {
+				copied := old.Copy()
+				copied.Merge(entry)
+				ts.Entries[field] = copied
+				break
+			}
+			fallthrough
+		case plan.ReplaceOverride:
+			ts.Entries[field] = entry.Copy()
+		case plan.UnknownOverride:
+			return &plan.FormatError{
+				Message: fmt.Sprintf(`invalid "override" value for entry %q`, field),
+			}
+		default:
+			return &plan.FormatError{
+				Message: fmt.Sprintf(`unknown "override" value for entry %q`, field),
+			}
+		}
+	}
+	return nil
+}
+
+type T struct {
+	Name     string        `yaml:"-"`
+	Override plan.Override `yaml:"override,omitempty"`
+	A        string        `yaml:"a,omitempty"`
+	B        string        `yaml:"b,omitempty"`
+}
+
+func (t *T) Copy() *T {
+	copied := *t
+	return &copied
+}
+
+func (t *T) Merge(other *T) {
+	if other.A != "" {
+		t.A = other.A
+	}
+	if other.B != "" {
+		t.B = other.B
+	}
+}
+
+func makeMapIfNil[K comparable, V any](m map[K]V) map[K]V {
+	if m == nil {
+		m = make(map[K]V)
+	}
+	return m
 }


### PR DESCRIPTION
Built on top of https://github.com/canonical/pebble/pull/488.

Add section support to the Plan Manager (planstate).