### PR TITLE
fix: initialize socketPath to prevent stale cache

### DIFF
--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -69,6 +69,7 @@ func (s *daemonSuite) SetUpTest(c *C) {
 		c.Fatalf("cannot start reaper: %v", err)
 	}
 
+	s.socketPath = ""
 	s.pebbleDir = c.MkDir()
 	s.statePath = filepath.Join(s.pebbleDir, cmd.StateFile)
 	systemdSdNotify = func(notif string) error {


### PR DESCRIPTION
`daemonSuite.socketPath` appears to be assigned outside of the test, but only when it has a default value, which results in a stale `socketPath` value in this test.

```go
>  github.com/canonical/pebble/internals/daemon.(*daemonSuite).TestAddCommand() ./internals/daemon/daemon_test.go:186 (PC: 0xc17eef)
   181:	}
   182:	
   183:	func (s *daemonSuite) TestAddCommand(c *C) {
   184:		const endpoint = "/v1/addedendpoint"
   185:		var handler fakeHandler
=> 186:		getCallback := func(c *Command, r *http.Request, s *UserState) Response {
   187:			handler.cmd = c
   188:			return &handler
   189:		}
   190:		command := Command{
   191:			Path:       endpoint,
(dlv) print s
("*github.com/canonical/pebble/internals/daemon.daemonSuite")(0xc0000d4b80)
*github.com/canonical/pebble/internals/daemon.daemonSuite {
	pebbleDir: "/tmp/check-3911358415/1",
	socketPath: "/tmp/check-3190005390/10/custom.socket",
	httpAddress: ":0",
	statePath: "/tmp/check-3911358415/1/.pebble.state",
	authorized: false,
	err: error nil,
	notified: []string len: 0, cap: 0, nil,
	restoreBackends: nil,}
(dlv) q
```
Notice that in the above, the value in `socketpath` is not a subdirectory of the value in `pebbleDir`.


Running `go test -count=2 -v ./internals/daemon -check.v` with this fix now passes:
```go
--- PASS: Test (7.22s)
PASS
ok  	github.com/canonical/pebble/internals/daemon	13.431s
```
Fixes #282.