### PR TITLE
test: improve osutil.mkdir test coverage

### DIFF
--- a/internals/osutil/mkdir_test.go
+++ b/internals/osutil/mkdir_test.go
@@ -64,6 +64,16 @@ func (mkdirSuite) TestExistNotOK(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
 }
 
+func (mkdirSuite) TestExistsButNotDir(c *check.C) {
+	tmpDir := c.MkDir()
+
+	_, err := os.Create(tmpDir + "/foo")
+	c.Assert(err, check.IsNil)
+
+	err = osutil.Mkdir(tmpDir+"/foo", 0o755, nil)
+	c.Assert(err, check.ErrorMatches, `.*: not a directory`)
+}
+
 func (mkdirSuite) TestDirEndWithSlash(c *check.C) {
 	tmpDir := c.MkDir()
 
@@ -110,6 +120,18 @@ func (mkdirSuite) TestMakeParentsAndExistNotOK(c *check.C) {
 
 	err = osutil.Mkdir(tmpDir+"/foo/bar", 0o755, nil)
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
+}
+
+func (mkdirSuite) TestParentExistsButNotDir(c *check.C) {
+	tmpDir := c.MkDir()
+
+	_, err := os.Create(tmpDir + "/foo")
+	c.Assert(err, check.IsNil)
+
+	err = osutil.Mkdir(tmpDir+"/foo/bar/", 0o755, &osutil.MkdirOptions{
+		MakeParents: true,
+	})
+	c.Assert(err, check.ErrorMatches, `.*: not a directory`)
 }
 
 func (mkdirSuite) TestChmod(c *check.C) {


### PR DESCRIPTION
Added two more test cases to improve test coverage.

If the path already exists but it's not a directory, a `syscall.ENOTDIR` error is expected.