### PR TITLE
refactor(state): avoid need for state lock in LatestWarningTime

### DIFF
--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -248,10 +248,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			rsp.transmitMaintenance(errorKindDaemonRestart, "daemon is stopping to wait for socket activation")
 		}
 		if rsp.Type != ResponseTypeError {
-			st := c.d.state
-			st.Lock()
-			latest := st.LatestWarningTime()
-			st.Unlock()
+			latest := c.d.state.LatestWarningTime()
 			rsp.addWarningsToMeta(latest)
 		}
 	}

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -418,7 +418,7 @@ func (s *State) flattenNotices(filter *NoticeFilter) []*Notice {
 func (s *State) unflattenNotices(flat []*Notice) {
 	now := time.Now()
 	s.notices = make(map[noticeKey]*Notice)
-	latestWarningTime := time.Time{}
+	var latestWarningTime time.Time
 	for _, n := range flat {
 		if n.expired(now) {
 			continue

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -270,6 +270,13 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 	notice.lastData = options.Data
 	notice.repeatAfter = options.RepeatAfter
 
+	// Update the latest warning time cache if needed. There's no need to
+	// actually update atomically here, because the state lock is held.
+	if notice.noticeType == WarningNotice && notice.lastRepeated.After(s.LatestWarningTime()) {
+		latestWarningTime := notice.lastRepeated
+		s.latestWarningTime.Store(&latestWarningTime)
+	}
+
 	if newOrRepeated {
 		s.noticeCond.Broadcast()
 	}
@@ -371,18 +378,14 @@ func (s *State) Notices(filter *NoticeFilter) []*Notice {
 
 // LatestWarningTime returns the most recent time a warning notice was
 // repeated, or the zero value if there are no warnings.
+//
+// The state lock does not need to be held when calling this method.
 func (s *State) LatestWarningTime() time.Time {
-	s.reading()
-
-	// TODO(benhoyt): optimise with an in-memory atomic cache when warnings are added (or pruned),
-	//                to avoid having to acquire the state lock on every request
-	var latest time.Time
-	for _, notice := range s.notices {
-		if notice.noticeType == WarningNotice && notice.lastRepeated.After(latest) {
-			latest = notice.lastRepeated
-		}
+	t := s.latestWarningTime.Load()
+	if t == nil {
+		return time.Time{}
 	}
-	return latest
+	return *t
 }
 
 // Notice returns a single notice by ID, or nil if not found.
@@ -415,6 +418,7 @@ func (s *State) flattenNotices(filter *NoticeFilter) []*Notice {
 func (s *State) unflattenNotices(flat []*Notice) {
 	now := time.Now()
 	s.notices = make(map[noticeKey]*Notice)
+	latestWarningTime := time.Time{}
 	for _, n := range flat {
 		if n.expired(now) {
 			continue
@@ -422,7 +426,11 @@ func (s *State) unflattenNotices(flat []*Notice) {
 		userID, hasUserID := n.UserID()
 		uniqueKey := noticeKey{hasUserID, userID, n.noticeType, n.key}
 		s.notices[uniqueKey] = n
+		if n.noticeType == WarningNotice && n.lastRepeated.After(latestWarningTime) {
+			latestWarningTime = n.lastRepeated
+		}
 	}
+	s.latestWarningTime.Store(&latestWarningTime)
 }
 
 // WaitNotices waits for notices that match the filter to exist or occur,

--- a/internals/overlord/state/state_test.go
+++ b/internals/overlord/state/state_test.go
@@ -795,7 +795,6 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.MarshalJSON() },
 		func() { st.Prune(time.Now(), time.Hour, time.Hour, 100) },
 		func() { st.TaskCount() },
-		func() { st.LatestWarningTime() },
 	}
 
 	for i, f := range reads {


### PR DESCRIPTION
 This means that not every request/response needs to acquire the state lock, as shown by the removal of the custom response type in the /v1/health endpoint.

Note that there's a test, TestHealthStateLockNotHeldSuccess, that specifically tests that the state lock is not held during /v1/health requests. If we accidentally introduce locking again, that will fail.

Fixes #366.