### PR TITLE
ci: add a monthly (or on demand) TIOBE reporting workflow

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v4
-  
+
       - name: Install dependencies
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
@@ -23,7 +23,7 @@ jobs:
       # We could store a report from the regular run, but this is cheap to do and keeps this isolated.
       - name: Test and generate coverage report
         run: |
-          go test -race -coverprofile=coverage.out ./...
+          go test -coverprofile=coverage.out ./...
           gocov convert coverage.out > coverage.json
           # Annoyingly, the coverage.xml file needs to be in a .coverage folder.
           mkdir .coverage

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Install dependencies
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
-          go get github.com/axw/gocov/gocov
-          go get github.com/AlekSi/gocov-xml
+          go install github.com/axw/gocov/gocov@v1.1.0
+          go install github.com/AlekSi/gocov-xml@v1.1.0
 
       # We could store a report from the regular run, but this is cheap to do and keeps this isolated.
       - name: Test and generate coverage report

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -1,0 +1,39 @@
+name: TIOBE Quality Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 7 1 * *'
+
+jobs:
+  TICS:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+  
+      - name: Install dependencies
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+          go get github.com/axw/gocov/gocov
+          go get github.com/AlekSi/gocov-xml
+
+      # We could store a report from the regular run, but this is cheap to do and keeps this isolated.
+      - name: Test and generate coverage report
+        run: |
+          go test -race -coverprofile=coverage.out ./...
+          gocov convert coverage.out > coverage.json
+          # Annoyingly, the coverage.xml file needs to be in a .coverage folder.
+          mkdir .coverage
+          gocov-xml < coverage.json > .coverage/coverage.xml
+
+      - name: TICS GitHub Action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          project: pebble
+          installTics: true


### PR DESCRIPTION
Once a month, send the latest code quality (including coverage) data to TIOBE for central storage.