### PR TITLE
chore: bump the snapcore/action-build action version

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build ${{ env.SNAP_NAME }} Snap
         id: build-snap
-        uses: snapcore/action-build@v1.1.3
+        uses: snapcore/action-build@v1.3.0
 
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build ${{ env.SNAP_NAME }} Snap for ${{ matrix.arch }}
         id: build-snap
-        uses: snapcore/action-build@v1.1.3
+        uses: snapcore/action-build@v1.3.0
         with:
           snapcraft-args: remote-build --build-for=${{ matrix.arch }} --launchpad-accept-public-upload
 


### PR DESCRIPTION
It [seems like there's only 1.3.0] available now, although I'm not sure what the story is behind that. This blocks other PRs from merging.

In any case, it seems reasonable to bump this to the latest available 1.x version. I couldn't find a changelog or release notes, but the commits seem straightforward and unlikely to cause issues, and it is a Canonical project.