### PR TITLE
chore: vuln scan failure workaround

### DIFF
--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -22,3 +22,5 @@ jobs:
           trivy-config: .github/trivy.yaml
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          # known issue: aquasecurity/trivy-action#389
+          # workaround: https://github.com/orgs/community/discussions/139074#discussioncomment-10808081

--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -22,5 +22,6 @@ jobs:
           trivy-config: .github/trivy.yaml
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-          # known issue: aquasecurity/trivy-action#389
-          # workaround: https://github.com/orgs/community/discussions/139074#discussioncomment-10808081
+          # TODO: Remove the whole "env" section when the issue below is resolved.
+          # Known issue: aquasecurity/trivy-action#389.
+          # Workaround: https://github.com/orgs/community/discussions/139074#discussioncomment-10808081.

--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -20,3 +20,5 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           trivy-config: .github/trivy.yaml
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db


### PR DESCRIPTION
Known issue: https://github.com/aquasecurity/trivy-action/issues/389
Workaround: https://github.com/orgs/community/discussions/139074#discussioncomment-10808081