### PR TITLE
feat(plan): add plan sub-directory support

### DIFF
--- a/client/plan.go
+++ b/client/plan.go
@@ -26,7 +26,7 @@ type AddLayerOptions struct {
 	Combine bool
 
 	// Inner true means a new layer append may go into an existing
-	// subdirectory, even through it may not result in appending it
+	// subdirectory, even though it may not result in appending it
 	// to the end of the layers slice (it becomes an insert).
 	Inner bool
 

--- a/client/plan.go
+++ b/client/plan.go
@@ -55,6 +55,14 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 		Format:  "yaml",
 		Layer:   string(opts.LayerData),
 	}
+
+	// Add label validation here once layer persistence is supported over
+	// the API. We cannot do this in the plan library because JUJU already
+	// has labels in production systems that violates the layers file
+	// naming convention (which includes the label). Since JUJU uses its
+	// own client, we can enforce the label naming convention on all other
+	// systems using the Pebble supplied client by validating it here.
+
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(&payload); err != nil {
 		return err

--- a/client/plan.go
+++ b/client/plan.go
@@ -25,7 +25,7 @@ type AddLayerOptions struct {
 	// has the given label. False (the default) means append a new layer.
 	Combine bool
 
-	// Inner true means a new layer append may go into an existing
+	// Inner set to true means a new layer append may go into an existing
 	// subdirectory, even though it may not result in appending it
 	// to the end of the layers slice (it becomes an insert).
 	Inner bool

--- a/client/plan.go
+++ b/client/plan.go
@@ -25,6 +25,11 @@ type AddLayerOptions struct {
 	// has the given label. False (the default) means append a new layer.
 	Combine bool
 
+	// Inner true means a new layer append may go into an existing
+	// subdirectory, even through it may not result in appending it
+	// to the end of the layers slice (it becomes an insert).
+	Inner bool
+
 	// Label is the label for the new layer if appending, and the label of the
 	// layer to combine with if Combine is true.
 	Label string
@@ -38,12 +43,14 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	var payload = struct {
 		Action  string `json:"action"`
 		Combine bool   `json:"combine"`
+		Inner   bool   `json:"inner"`
 		Label   string `json:"label"`
 		Format  string `json:"format"`
 		Layer   string `json:"layer"`
 	}{
 		Action:  "add",
 		Combine: opts.Combine,
+		Inner:   opts.Inner,
 		Label:   opts.Label,
 		Format:  "yaml",
 		Layer:   string(opts.LayerData),

--- a/client/plan_test.go
+++ b/client/plan_test.go
@@ -24,7 +24,22 @@ import (
 )
 
 func (cs *clientSuite) TestAddLayer(c *check.C) {
-	for _, combine := range []bool{false, true} {
+	for _, option := range []struct {
+		combine bool
+		inner   bool
+	}{{
+		combine: false,
+		inner:   false,
+	}, {
+		combine: true,
+		inner:   false,
+	}, {
+		combine: false,
+		inner:   true,
+	}, {
+		combine: true,
+		inner:   true,
+	}} {
 		cs.rsp = `{
 		"type": "sync",
 		"status-code": 200,
@@ -37,7 +52,8 @@ services:
         command: cmd
 `[1:]
 		err := cs.cli.AddLayer(&client.AddLayerOptions{
-			Combine:   combine,
+			Combine:   option.combine,
+			Inner:     option.inner,
 			Label:     "foo",
 			LayerData: []byte(layerYAML),
 		})
@@ -49,11 +65,11 @@ services:
 		c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 		c.Assert(body, check.DeepEquals, map[string]interface{}{
 			"action":  "add",
-			"combine": combine,
+			"combine": option.combine,
 			"label":   "foo",
 			"format":  "yaml",
 			"layer":   layerYAML,
-			"inner":   false,
+			"inner":   option.inner,
 		})
 	}
 }

--- a/client/plan_test.go
+++ b/client/plan_test.go
@@ -53,6 +53,7 @@ services:
 			"label":   "foo",
 			"format":  "yaml",
 			"layer":   layerYAML,
+			"inner":   false,
 		})
 	}
 }

--- a/docs/reference/cli-commands/add.md
+++ b/docs/reference/cli-commands/add.md
@@ -19,5 +19,7 @@ label (or append if the label is not found).
 [add command options]
       --combine         Combine the new layer with an existing layer that has
                         the given label (default is to append)
+      --inner           Allow appending a new layer inside an existing
+                        subdirectory
 ```
 <!-- END AUTOMATED OUTPUT -->

--- a/internals/cli/cmd_add.go
+++ b/internals/cli/cmd_add.go
@@ -35,6 +35,7 @@ type cmdAdd struct {
 	client *client.Client
 
 	Combine    bool `long:"combine"`
+	Inner      bool `long:"inner"`
 	Positional struct {
 		Label     string `positional-arg-name:"<label>" required:"1"`
 		LayerPath string `positional-arg-name:"<layer-path>" required:"1"`
@@ -48,6 +49,7 @@ func init() {
 		Description: cmdAddDescription,
 		ArgsHelp: map[string]string{
 			"--combine": "Combine the new layer with an existing layer that has the given label (default is to append)",
+			"--inner":   "Allow appending a new layer inside an existing subdirectory",
 		},
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdAdd{client: opts.Client}
@@ -65,6 +67,7 @@ func (cmd *cmdAdd) Execute(args []string) error {
 	}
 	opts := client.AddLayerOptions{
 		Combine:   cmd.Combine,
+		Inner:     cmd.Inner,
 		Label:     cmd.Positional.Label,
 		LayerData: data,
 	}

--- a/internals/cli/cmd_add_test.go
+++ b/internals/cli/cmd_add_test.go
@@ -58,6 +58,7 @@ services:
 					"label":   "foo",
 					"format":  "yaml",
 					"layer":   layerYAML,
+					"inner":   false,
 				})
 				fmt.Fprint(w, `{
     "type": "sync",

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -206,7 +206,7 @@ func (s *execSuite) TestContextNoOverrides(c *C) {
 			Environment: map[string]string{"FOO": "foo", "BAR": "bar"},
 			WorkingDir:  dir,
 		}},
-	})
+	}, false)
 	c.Assert(err, IsNil)
 
 	stdout, stderr, err := s.exec(c, "", &client.ExecOptions{
@@ -228,7 +228,7 @@ func (s *execSuite) TestContextOverrides(c *C) {
 			Environment: map[string]string{"FOO": "foo", "BAR": "bar"},
 			WorkingDir:  c.MkDir(),
 		}},
-	})
+	}, false)
 	c.Assert(err, IsNil)
 
 	overrideDir := c.MkDir()

--- a/internals/daemon/api_plan.go
+++ b/internals/daemon/api_plan.go
@@ -69,9 +69,9 @@ func v1PostLayers(c *Command, r *http.Request, _ *UserState) Response {
 
 	planMgr := overlordPlanManager(c.d.overlord)
 	if payload.Combine {
-		err = planMgr.CombineLayer(layer)
+		err = planMgr.CombineLayer(layer, payload.Inner)
 	} else {
-		err = planMgr.AppendLayer(layer)
+		err = planMgr.AppendLayer(layer, payload.Inner)
 	}
 	if err != nil {
 		if _, ok := err.(*planstate.LabelExists); ok {

--- a/internals/daemon/api_plan.go
+++ b/internals/daemon/api_plan.go
@@ -43,6 +43,7 @@ func v1PostLayers(c *Command, r *http.Request, _ *UserState) Response {
 	var payload struct {
 		Action  string `json:"action"`
 		Combine bool   `json:"combine"`
+		Inner   bool   `json:"inner"`
 		Label   string `json:"label"`
 		Format  string `json:"format"`
 		Layer   string `json:"layer"`

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -176,7 +176,7 @@ func (m *PlanManager) appendLayer(newLayer *plan.Layer, inner bool) (*plan.Plan,
 		// an order?
 		newSubLabel, _, hasSub := strings.Cut(newLayer.Label, "/")
 		lastIndex := layersCount - 1
-		for i, _ := range m.plan.Layers {
+		for i := range m.plan.Layers {
 			layer := m.plan.Layers[lastIndex-i]
 			layerSubLabel, _, _ := strings.Cut(layer.Label, "/")
 			// If we have a sub-directory match we know it already exists.

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -222,7 +222,7 @@ func (m *PlanManager) appendLayer(newLayer *plan.Layer, inner bool) (*plan.Plan,
 			newIndex = layersCount
 			newOrder = ((m.plan.Layers[layersCount-1].Order / 1000) + 1) * 1000
 			if hasSub {
-				// The file in the sub-directory needs an order to "001".
+				// The first file in the sub-directory gets an order of "001".
 				newOrder += 1
 			}
 		}

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -211,6 +211,7 @@ func (m *PlanManager) appendLayer(newLayer *plan.Layer, inner bool) (*plan.Plan,
 			if layerSubLabel == newSubLabel {
 				newOrder = layer.Order + 1
 				newIndex = lastIndex - i + 1
+				break
 			}
 		}
 

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -383,7 +383,7 @@ test-field:
 	ps.planLayersHasLen(c, 3)
 
 	// Make sure that layer validation is happening.
-	layer, err = plan.ParseLayer(0, "label4", []byte(`
+	_, err = plan.ParseLayer(0, "label4", []byte(`
 checks:
     bad-check:
         override: replace
@@ -394,7 +394,7 @@ checks:
 	c.Check(err, ErrorMatches, `(?s).*plan check.*must be "alive" or "ready".*`)
 
 	// Make sure that layer validation is happening for extensions.
-	layer, err = plan.ParseLayer(0, "label4", []byte(`
+	_, err = plan.ParseLayer(0, "label4", []byte(`
 test-field:
     my1:
         override: replace
@@ -422,6 +422,7 @@ services:
         command: foo
 `)
 	err = ps.planMgr.AppendLayer(layer, false)
+	c.Assert(err, IsNil)
 
 	// Set arguments to services.
 	serviceArgs := map[string][]string{
@@ -455,8 +456,8 @@ func (ps *planSuite) TestChangeListenerAndLocking(c *C) {
 		// so we should be able to acquire it.
 		planLock := manager.PlanLock()
 		planLock.Lock()
+		calls++ // calls incremented here to satisfy staticcheck.
 		planLock.Unlock()
-		calls++
 	})
 
 	// Run operations in goroutine so we can time out the test if it fails.

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -116,9 +116,9 @@ test-field:
         override: replace
         a: something
 `)
-	err = ps.planMgr.AppendLayer(layer)
+	err = ps.planMgr.AppendLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 1)
+	c.Assert(layer.Order, Equals, 1000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -142,7 +142,7 @@ test-field:
         override: foobar
         a: something else
 `)
-	err = ps.planMgr.AppendLayer(layer)
+	err = ps.planMgr.AppendLayer(layer, false)
 	c.Assert(err.(*planstate.LabelExists).Label, Equals, "label1")
 	c.Assert(ps.planYAML(c), Equals, `
 services:
@@ -167,9 +167,9 @@ test-field:
         override: replace
         a: else
 `)
-	err = ps.planMgr.AppendLayer(layer)
+	err = ps.planMgr.AppendLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 2)
+	c.Assert(layer.Order, Equals, 2000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -193,9 +193,9 @@ test-field:
         override: replace
         a: something
 `)
-	err = ps.planMgr.AppendLayer(layer)
+	err = ps.planMgr.AppendLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 3)
+	c.Assert(layer.Order, Equals, 3000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -233,9 +233,9 @@ test-field:
         override: replace
         a: something
 `)
-	err = ps.planMgr.CombineLayer(layer)
+	err = ps.planMgr.CombineLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 1)
+	c.Assert(layer.Order, Equals, 1000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -259,9 +259,9 @@ test-field:
         override: replace
         a: else
 `)
-	err = ps.planMgr.CombineLayer(layer)
+	err = ps.planMgr.CombineLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 2)
+	c.Assert(layer.Order, Equals, 2000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -291,9 +291,9 @@ test-field:
         override: replace
         a: else
 `)
-	err = ps.planMgr.CombineLayer(layer)
+	err = ps.planMgr.CombineLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 1)
+	c.Assert(layer.Order, Equals, 1000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -323,9 +323,9 @@ test-field:
         override: replace
         a: something
 `)
-	err = ps.planMgr.CombineLayer(layer)
+	err = ps.planMgr.CombineLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 2)
+	c.Assert(layer.Order, Equals, 2000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -361,9 +361,9 @@ test-field:
         override: replace
         a: nothing
 `)
-	err = ps.planMgr.CombineLayer(layer)
+	err = ps.planMgr.CombineLayer(layer, false)
 	c.Assert(err, IsNil)
-	c.Assert(layer.Order, Equals, 3)
+	c.Assert(layer.Order, Equals, 3000)
 	c.Assert(ps.planYAML(c), Equals, `
 services:
     svc1:
@@ -421,7 +421,7 @@ services:
         override: replace
         command: foo
 `)
-	err = ps.planMgr.AppendLayer(layer)
+	err = ps.planMgr.AppendLayer(layer, false)
 
 	// Set arguments to services.
 	serviceArgs := map[string][]string{
@@ -477,10 +477,10 @@ services:
         override: replace
         command: /bin/sh
 `)
-		err = manager.AppendLayer(layer1)
+		err = manager.AppendLayer(layer1, false)
 		c.Assert(err, IsNil)
 
-		err = manager.CombineLayer(layer1)
+		err = manager.CombineLayer(layer1, false)
 		c.Assert(err, IsNil)
 
 		layer2 := ps.parseLayer(c, 0, "label2", `
@@ -489,7 +489,7 @@ services:
         override: replace
         command: /bin/sh
 `)
-		err = manager.CombineLayer(layer2)
+		err = manager.CombineLayer(layer2, false)
 		c.Assert(err, IsNil)
 
 		err = manager.SetServiceArgs(map[string][]string{

--- a/internals/overlord/planstate/manager_test.go
+++ b/internals/overlord/planstate/manager_test.go
@@ -510,7 +510,7 @@ services:
 	c.Assert(calls, Equals, 5)
 }
 
-func (ps *planSuite) TestAppendLayersNoInner(c *C) {
+func (ps *planSuite) TestAppendLayersWithoutInner(c *C) {
 	plan.RegisterSectionExtension(testField, testExtension{})
 	defer plan.UnregisterSectionExtension(testField)
 	var err error
@@ -528,7 +528,7 @@ func (ps *planSuite) TestAppendLayersNoInner(c *C) {
 	c.Assert(err, ErrorMatches, ".*cannot insert sub-directory.*")
 }
 
-func (ps *planSuite) TestAppendLayersOrderAllocation(c *C) {
+func (ps *planSuite) TestAppendLayersWithInner(c *C) {
 	plan.RegisterSectionExtension(testField, testExtension{})
 	defer plan.UnregisterSectionExtension(testField)
 	var err error

--- a/internals/overlord/planstate/package_test.go
+++ b/internals/overlord/planstate/package_test.go
@@ -147,7 +147,7 @@ type testSection struct {
 func (ts *testSection) Validate() error {
 	// Fictitious test requirement: fields must start with t
 	prefix := "t"
-	for field, _ := range ts.Entries {
+	for field := range ts.Entries {
 		if !strings.HasPrefix(field, prefix) {
 			return fmt.Errorf("%q entry names must start with %q", testField, prefix)
 		}

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -1707,7 +1707,7 @@ func (s *S) planChanged(c *C) {
 
 func (s *S) planAddLayer(c *C, layerYAML string) {
 	cnt := len(s.plan.Layers)
-	layer, err := plan.ParseLayer(cnt, fmt.Sprintf("testPlanLayer%v", cnt), []byte(layerYAML))
+	layer, err := plan.ParseLayer(cnt, fmt.Sprintf("test-plan-layer-%v", cnt), []byte(layerYAML))
 	c.Assert(err, IsNil)
 	// Resolve {{.NotifyDoneCheck}}
 	s.insertDoneChecks(c, layer)

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -16,7 +16,6 @@ package plan_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"slices"
@@ -402,8 +401,7 @@ nexttest:
 			return n.field == xField
 		}) {
 			// Verify "x-field" data.
-			var x *xSection
-			x = p.Sections[xField].(*xSection)
+			x := p.Sections[xField].(*xSection)
 			c.Assert(err, IsNil)
 			c.Assert(x.Entries, DeepEquals, testData.result.x.Entries)
 		}
@@ -412,8 +410,7 @@ nexttest:
 			return n.field == yField
 		}) {
 			// Verify "y-field" data.
-			var y *ySection
-			y = p.Sections[yField].(*ySection)
+			y := p.Sections[yField].(*ySection)
 			c.Assert(err, IsNil)
 			c.Assert(y.Entries, DeepEquals, testData.result.y.Entries)
 		}
@@ -474,6 +471,7 @@ func (s *S) TestSectionOrderExt(c *C) {
 		Sections:   combined.Sections,
 	}
 	data, err := yaml.Marshal(plan)
+	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, string(reindent(`
 		services:
 			srv1:
@@ -511,7 +509,7 @@ func (s *S) writeLayerFiles(c *C, layersDir string, inputs []*inputLayer) {
 	c.Assert(err, IsNil)
 
 	for _, input := range inputs {
-		err := ioutil.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%03d-%s.yaml", input.order, input.label)), reindent(input.yaml), 0644)
+		err := os.WriteFile(filepath.Join(layersDir, fmt.Sprintf("%03d-%s.yaml", input.order, input.label)), reindent(input.yaml), 0644)
 		c.Assert(err, IsNil)
 	}
 }
@@ -548,17 +546,15 @@ func (x xExtension) CombineSections(sections ...plan.Section) (plan.Section, err
 }
 
 func (x xExtension) ValidatePlan(p *plan.Plan) error {
-	var xs *xSection
-	xs = p.Sections[xField].(*xSection)
+	xs := p.Sections[xField].(*xSection)
 	if xs != nil {
-		var ys *ySection
-		ys = p.Sections[yField].(*ySection)
+		ys := p.Sections[yField].(*ySection)
 
 		// Test dependency: Make sure every Y field in X refer to an existing Y entry.
 		for xEntryField, xEntryValue := range xs.Entries {
 			for _, yReference := range xEntryValue.Y {
 				found := false
-				for yEntryField, _ := range ys.Entries {
+				for yEntryField := range ys.Entries {
 					if yReference == yEntryField {
 						found = true
 						break

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -823,7 +823,7 @@ func (layer *Layer) Validate() error {
 	for name, service := range layer.Services {
 		if name == "" {
 			return &FormatError{
-				Message: fmt.Sprintf("cannot use empty string as service name"),
+				Message: "cannot use empty string as service name",
 			}
 		}
 		if name == "pebble" {
@@ -880,7 +880,7 @@ func (layer *Layer) Validate() error {
 	for name, check := range layer.Checks {
 		if name == "" {
 			return &FormatError{
-				Message: fmt.Sprintf("cannot use empty string as check name"),
+				Message: "cannot use empty string as check name",
 			}
 		}
 		if check == nil {
@@ -890,7 +890,7 @@ func (layer *Layer) Validate() error {
 		}
 		if name == "" {
 			return &FormatError{
-				Message: fmt.Sprintf("cannot use empty string as log target name"),
+				Message: "cannot use empty string as log target name",
 			}
 		}
 		if check.Level != UnsetLevel && check.Level != AliveLevel && check.Level != ReadyLevel {
@@ -1281,7 +1281,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	// will at least have an empty node. This means we can consistently
 	// let the extension allocate and decode the yaml node for all sections,
 	// and in the case where it is zero, we get an empty backing type instance.
-	for field, _ := range sectionExtensions {
+	for field := range sectionExtensions {
 		sections[field] = yaml.Node{}
 	}
 	err := yaml.Unmarshal(data, &sections)

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -154,6 +154,28 @@ func (p *Plan) MarshalYAML() (interface{}, error) {
 	return plan, nil
 }
 
+// Layer represents an unmarshalled YAML layer configuration file. Layer files
+// are maintained as part of the Plan, ordered by their respective order
+// number. Each layer configuration also has a unique label, used for locating
+// and updating a specific layer configuration.
+//
+// Pebble supports a two level layer configuration directory structure. In the
+// root layers directory, both layer files and layer sub-directories are
+// allowed. Within a sub-directory, only layer files.
+//
+// ┌────────────────────────────┬─────────────────┬─────────┐
+// │ File (inside layersDir)    │ Order           │ Label   │
+// ├────────────────────────────┼─────────────────┼─────────┤
+// │                            │                 │         │
+// │ 001-foo.yaml               │ 001-000 => 1000 │ foo     │
+// │                            │                 │         │
+// │ 002-bar.d/001-aaa.yaml     │ 002-001 => 2001 │ bar/aaa │
+// │                            │                 │         │
+// │ 002-bar.d/002-bbb.yaml     │ 002-002 => 2002 │ bar/bbb │
+// │                            │                 │         │
+// │ 003-baz.yaml               │ 003-000 => 3000 │ baz     │
+// │                            │                 │         │
+// └────────────────────────────┴─────────────────┴─────────┘
 type Layer struct {
 	Order       int                   `yaml:"-"`
 	Label       string                `yaml:"-"`

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1237,24 +1237,7 @@ func (p *Plan) checkCycles() error {
 	return err
 }
 
-// labelRegexp represents a match of a valid layer label, which may include a
-// directory prefix (which excludes the '.d' ending, in the same way the
-// file suffix is omitted).
-//
-//	| Label    | Description                        |
-//	| -------- | ---------------------------------- |
-//	| abc      | Label of file in layers root       |
-//	| foo/bar  | Label of file inside sub-directory |
-var labelRegexp = regexp.MustCompile(`^(([a-z](?:-?[a-z0-9]){2,})/)?([a-z](?:-?[a-z0-9]){2,})$`)
-
 func ParseLayer(order int, label string, data []byte) (*Layer, error) {
-	// This function can be called directly over the daemon API. We
-	// must fail the API request if the label is not valid.
-	match := labelRegexp.FindStringSubmatch(label)
-	if match == nil {
-		return nil, fmt.Errorf("cannot parse layer: invalid label %q", label)
-	}
-
 	layer := &Layer{
 		Services:   make(map[string]*Service),
 		Checks:     make(map[string]*Check),

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -2138,6 +2138,7 @@ func (s *S) TestSectionOrder(c *C) {
 		LogTargets: combined.LogTargets,
 	}
 	data, err := yaml.Marshal(plan)
+	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, string(reindent(`
 	services:
 		srv1:

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -2308,38 +2308,3 @@ func (s *S) TestReadLayersDir(c *C) {
 		}
 	}
 }
-
-func (s *S) TestParseLayerLabelValidatorOK(c *C) {
-	for _, label := range []string{
-		"f12345",
-		"foo",
-		"f-1-2-3-4",
-		"foo-bar-baz-12345",
-		"f12345/f12345",
-		"foo/foo",
-		"f-1-2-3-4/f-1-2-3-4",
-		"foo-bar-baz-12345/foo-bar-baz-12345",
-	} {
-		_, err := plan.ParseLayer(0, label, []byte(""))
-		c.Assert(err, IsNil)
-	}
-}
-
-func (s *S) TestParseLayerLabelValidatorFail(c *C) {
-	for _, label := range []string{
-		"0foo",
-		"01234",
-		"f",
-		"foo--bar",
-		"fooBar",
-		"foo/0foo",
-		"foo/01234",
-		"foo/f",
-		"foo/foo--bar",
-		"foo/fooBar",
-		"foo/bar/baz",
-	} {
-		_, err := plan.ParseLayer(0, label, []byte(""))
-		c.Assert(err, ErrorMatches, ".*invalid label.*")
-	}
-}


### PR DESCRIPTION
Pebble currently only supports loading configuration layer files from the root of $PEBBLE/layers.

Add support for adding sub-directory support at the root level (2 levels in total only). [Spec KO071.](https://docs.google.com/document/d/1-9GLCJTx9o_hSd0JGvDp7o5xNQjkJMvLam6o1Ba_bYM/edit?tab=t.0)

This scheme has an impact on the meaning of ```label``` and ```order```. See the following examples to understand the new mapping:

- $PEBBLE/layers/001-foo.yaml
Order: 001-000 => 1000
Label: foo

- $PEBBLE/layers/005-bar.d/010-abc.yaml
Order: 005-010 => 5010
Label: bar/abc

- $PEBBLE/layers/005-bar.d/012-def.yaml
Order: 005-012 => 5012
Label: bar/def

- $PEBBLE/layers/006-baz.yaml
Order: 006-000 => 6000
Label: baz

Directory support allows other uses of Pebble using read-only file systems more flexibility by now giving the option to bind-mount a sub-directory to a writable disk location, for example.
