### PR TITLE
fix: ring buffer deadlock

### DIFF
--- a/internals/servicelog/iterator.go
+++ b/internals/servicelog/iterator.go
@@ -69,6 +69,8 @@ func (it *iterator) Close() error {
 	if it.rb == nil {
 		return nil
 	}
+	it.rb.iteratorMutex.Lock()
+	defer it.rb.iteratorMutex.Unlock()
 	it.rb.removeIterator(it)
 	close(it.nextChan)
 	it.rb = nil


### PR DESCRIPTION
Fix an issue where the ring buffer might deadlock because rwlock and iterator mutex are acquired in a different order.

Fixes: https://github.com/canonical/pebble/issues/508

Notes:

1. As discussed with Harry and Ben, `rb.Write` isn't adjusted because the rwlock and iterator mutex are acquired at different times.
2. Besides an internal `close` function, an internal `positions` function is created for the same reason.
3. The [test case here](https://github.com/canonical/pebble/issues/508#issuecomment-2409839516) is not added because it was supposed to be an easy way to reproduce the deadlock. Adding an additional benchmark test is not useful, and the deadlock issue can be caught by the `TestDeadlock` test case anyway.
4. All three functions `signalIterators`, `releaseIterators` and `removeIterator` are adjusted (although technical only `releaseIterators` needed to be ) because they share a common naming pattern so it's nicer to share a common implementation pattern as well: all internal functions don't operate locks.

Benchmark test, manual test to reproduce the 3-way deadlock issue, and race test are all done and passed.