### PR TITLE
feat: set home when user is set

### DIFF
--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -382,19 +382,19 @@ func (s *serviceData) startInternal() error {
 				Gid: uint32(*gid),
 			})
 		}
+	}
 
-		// Also set HOME and USER if not explicitly specified in config.
-		if environment["HOME"] == "" || environment["USER"] == "" {
-			u, err := user.LookupId(strconv.Itoa(*uid))
-			if err != nil {
-				logger.Noticef("Cannot look up user %d: %v", *uid, err)
-			} else {
-				if environment["HOME"] == "" {
-					environment["HOME"] = u.HomeDir
-				}
-				if environment["USER"] == "" {
-					environment["USER"] = u.Username
-				}
+	// Also set HOME and USER if not explicitly specified in config.
+	if uid != nil && (environment["HOME"] == "" || environment["USER"] == "") {
+		u, err := user.LookupId(strconv.Itoa(*uid))
+		if err != nil {
+			logger.Noticef("Cannot look up user %d: %v", *uid, err)
+		} else {
+			if environment["HOME"] == "" {
+				environment["HOME"] = u.HomeDir
+			}
+			if environment["USER"] == "" {
+				environment["USER"] = u.Username
 			}
 		}
 	}


### PR DESCRIPTION
Set the `HOME` environment variable when only uid is set.

Closes https://github.com/canonical/pebble/issues/183.

The above issue could not be reproduced, because even if only "user" is set without "group", [Pebble will find and use the user's primary group](https://github.com/canonical/pebble/blob/master/internals/osutil/user.go#L117), and [when setting home, both uid and gid are not empty](https://github.com/canonical/pebble/blob/master/internals/overlord/servstate/handlers.go#L374).

The code change still feels right after a discussion with Tony and Dima in the standup, though, because setting HOME should have nothing to do with gid, empty or not.

On a probably unrelated topic: There is an unrelated issue (or feature) where [if user-id is used (instead of user), group-id must be specified at the same time](https://github.com/canonical/pebble/blob/master/internals/osutil/user.go#L141); otherwise, the service start will fail. But I believe this isn't what the original issue is about.

After discussing the issue with the owner @axinojolais who didn't have time to try to reproduce, we decided it's OK to close this issue. If it happens again, they will reopen this.