### PR TITLE
docs: make landing pages more informative

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -4,8 +4,8 @@
 :titlesonly:
 :maxdepth: 1
 
-API and clients <api-and-clients>
 General model <general-model>
+API and clients <api-and-clients>
 Service dependencies <service-dependencies>
 Service start order <service-start-order>
 ```

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -5,7 +5,7 @@ These guides explain how Pebble works.
 
 ## Fundamentals
 
-Pebble works as a daemon, with state and configuration stored in the `$PEBBLE` directory.
+Pebble works as a daemon and a client, with state and configuration stored in the `$PEBBLE` directory.
 
 ```{toctree}
 :titlesonly:
@@ -15,9 +15,9 @@ General model <general-model>
 ```
 
 
-## Access to the daemon
+## Access to the API
 
-The daemon exposes an API that remote clients can connect to. By default, Pebble restricts access to some API endpoints based on the user that is connecting. You can set up named identities to grant specific access levels to users.
+The daemon exposes an API that clients can connect to. By default, Pebble restricts access to some API endpoints based on the user that is connecting. You can set up named "identities" to grant specific access levels to users.
 
 ```{toctree}
 :titlesonly:
@@ -29,7 +29,7 @@ API and clients <api-and-clients>
 
 ## Service orchestration
 
-Pebble can automatically start and stop services according to dependencies in your service definition.
+Pebble automatically starts and stops services if you specify dependencies between services.
 
 ```{toctree}
 :titlesonly:

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,11 +1,40 @@
 # Explanation
 
+These guides explain how Pebble works.
+
+
+## Fundamentals
+
+Pebble works as a daemon, with state and configuration stored in the `$PEBBLE` directory.
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
 General model <general-model>
+```
+
+
+## Access to the daemon
+
+The daemon exposes an API that remote clients can connect to. By default, Pebble restricts access to some API endpoints based on the user that is connecting. You can set up named identities to grant specific access levels to users.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 API and clients <api-and-clients>
+```
+
+
+## Service orchestration
+
+Pebble can automatically start and stop services according to dependencies in your service definition.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Service dependencies <service-dependencies>
 Service start order <service-start-order>
 ```

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,11 +1,11 @@
 # How-to guides
 
-These guides walk you through the operations lifecycle of Pebble.
+These guides walk you through key operations you can perform with Pebble.
 
 
 ## Installation
 
-Installation follows a broadly similar pattern on all architectures. You can choose to install the pre-built binary or build it from the source by yourself.
+Installation follows a similar pattern on all architectures. You can choose to install the pre-built binary or build it from the source by yourself.
 
 ```{toctree}
 :titlesonly:

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -29,7 +29,7 @@ Manage service dependencies <service-dependencies>
 
 ## Identities
 
-Use named identities to allow additional users to access the API.
+Use named "identities" to allow additional users to access the API.
 
 ```{toctree}
 :titlesonly:

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,11 +1,11 @@
 # How-to guides
 
-These guides will walk you through every step of using Pebble through its complete operations lifecycle.
+These guides walk you through the operations lifecycle of Pebble.
 
 
 ## Installation
 
-Installation follows a broadly similar pattern on all architectures, and you can choose to install the pre-built binary or build it from the source by yourself.
+Installation follows a broadly similar pattern on all architectures. You can choose to install the pre-built binary or build it from the source by yourself.
 
 ```{toctree}
 :titlesonly:

--- a/docs/reference/cli-commands/cli-commands.md
+++ b/docs/reference/cli-commands/cli-commands.md
@@ -1,4 +1,4 @@
-# CLI Commands
+# CLI commands
 
 Pebble uses subcommands, like some other command-line tools such as go tool or git.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -30,7 +30,7 @@ CLI Commands <cli-commands/cli-commands>
 
 ## Pebble in containers
 
-When Pebble is configured as a client connected to a remote system (for example, a separate container), you can use subcommands on the client to manage the remote system.
+When the Pebble daemon is running inside a remote system (for example, a separate container), you can manage the remote system using subcommands on the Pebble client.
 
 ```{toctree}
 :titlesonly:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,17 +1,101 @@
 # Reference
 
+These guides provide technical information about Pebble.
+
+
+## Layers
+
+Your service configuration is defined as a stack of "layers".
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
 
 Layers <layers>
 Layer specification <layer-specification>
+```
+
+
+## Pebble commands
+
+The `pebble` command has several subcommands.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 CLI Commands <cli-commands/cli-commands>
+```
+
+
+## Pebble in containers
+
+When Pebble is configured as a client connected to a remote system (e.g., a separate container), you can use subcommands on the client to manage the remote system.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Use Pebble in containers <pebble-in-containers>
+```
+
+
+## Access to the API
+
+You can set up named "identities" to control access to the API.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Identities <identities>
+```
+
+
+## Service failures
+
+Pebble provides two ways to automatically restart services when they fail. Auto-restart is based on exit codes from services. Health checks are a more sophisticated way to test and report the availability of services.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Service auto-restart <service-auto-restart>
 Health checks <health-checks>
+```
+
+
+## Changes and tasks
+
+Pebble tracks system changes as "tasks" grouped into "change" objects.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Changes and tasks <changes-and-tasks>
+```
+
+
+## Notices
+
+Pebble records events as "notices". In addition to the built-in notices, clients can report custom notices.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Notices <notices>
+```
+
+
+## Log forwarding
+
+Pebble can send service logs to a Loki server.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
 Log forwarding <log-forwarding>
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,14 +4,14 @@
 :titlesonly:
 :maxdepth: 1
 
-Changes and tasks <changes-and-tasks>
-CLI Commands <cli-commands/cli-commands>
-Health checks <health-checks>
-Identities <identities>
 Layers <layers>
 Layer specification <layer-specification>
-Log forwarding <log-forwarding>
-Notices <notices>
-Service auto-restart <service-auto-restart>
+CLI Commands <cli-commands/cli-commands>
 Use Pebble in containers <pebble-in-containers>
+Identities <identities>
+Service auto-restart <service-auto-restart>
+Health checks <health-checks>
+Changes and tasks <changes-and-tasks>
+Notices <notices>
+Log forwarding <log-forwarding>
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,100 +2,87 @@
 
 These guides provide technical information about Pebble.
 
+% COMMENT: This toctree is for the navigation sidebar only
+%          Use an alphabetical listing of pages in the toctree
+%          For each page, make sure there's also a link in a section below
+
+```{toctree}
+:hidden:
+:titlesonly:
+:maxdepth: 1
+
+Changes and tasks <changes-and-tasks>
+CLI commands <cli-commands/cli-commands>
+Health checks <health-checks>
+Identities <identities>
+Layers <layers>
+Layer specification <layer-specification>
+Log forwarding <log-forwarding>
+Notices <notices>
+Pebble in containers <pebble-in-containers>
+Service auto-restart <service-auto-restart>
+```
+
+
+% COMMENT: The first few pages are presented in a more logical reading order
+
 
 ## Layers
 
 Pebble configuration is defined as a stack of "layers".
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
-Layers <layers>
-Layer specification <layer-specification>
-```
+* [Layers](layer-specification)
+* [Layer specification](layer-specification)
 
 
 ## Pebble commands
 
 The `pebble` command has several subcommands.
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
-CLI Commands <cli-commands/cli-commands>
-```
+* [CLI commands](cli-commands/cli-commands)
 
 
 ## Pebble in containers
 
 When the Pebble daemon is running inside a remote system (for example, a separate container), you can manage the remote system using subcommands on the Pebble client.
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
-Use Pebble in containers <pebble-in-containers>
-```
-
-
-## Access to the API
-
-You can set up named "identities" to control access to the API.
-
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
-Identities <identities>
-```
+* [Pebble in containers](pebble-in-containers)
 
 
 ## Service failures
 
 Pebble provides two ways to automatically restart services when they fail. Auto-restart is based on exit codes from services. Health checks are a more sophisticated way to test and report the availability of services.
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
+* [Service auto-restart](service-auto-restart)
+* [Health checks](health-checks)
 
-Service auto-restart <service-auto-restart>
-Health checks <health-checks>
-```
+
+% COMMENT: After this point, match the alphabetical listing of pages
 
 
 ## Changes and tasks
 
 Pebble tracks system changes as "tasks" grouped into "change" objects.
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
-Changes and tasks <changes-and-tasks>
-```
+* [Changes and tasks](changes-and-tasks)
 
 
-## Notices
+## Identities
 
-Pebble records events as "notices". In addition to the built-in notices, clients can report custom notices.
+You can set up named "identities" to control access to the API.
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
-
-Notices <notices>
-```
+* [Identities](identities)
 
 
 ## Log forwarding
 
 Pebble can send service logs to a Loki server.
 
-```{toctree}
-:titlesonly:
-:maxdepth: 1
+* [Log forwarding](log-forwarding)
 
-Log forwarding <log-forwarding>
-```
+
+## Notices
+
+Pebble records events as "notices". In addition to the built-in notices, clients can report custom notices.
+
+* [Notices](notices)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,7 +5,7 @@ These guides provide technical information about Pebble.
 
 ## Layers
 
-Your service configuration is defined as a stack of "layers".
+Pebble configuration is defined as a stack of "layers".
 
 ```{toctree}
 :titlesonly:
@@ -30,7 +30,7 @@ CLI Commands <cli-commands/cli-commands>
 
 ## Pebble in containers
 
-When Pebble is configured as a client connected to a remote system (e.g., a separate container), you can use subcommands on the client to manage the remote system.
+When Pebble is configured as a client connected to a remote system (for example, a separate container), you can use subcommands on the client to manage the remote system.
 
 ```{toctree}
 :titlesonly:

--- a/docs/reference/pebble-in-containers.md
+++ b/docs/reference/pebble-in-containers.md
@@ -1,4 +1,4 @@
-# Use Pebble in containers
+# Pebble in containers
 
 Pebble works well as a local service manager, but if running Pebble in a separate container, you can use the exec and file management APIs to coordinate with the remote system over the shared unix socket.
 


### PR DESCRIPTION
The purpose of this PR is to use a consistent style for the three landing pages [How-to guides](https://canonical-pebble.readthedocs-hosted.com/en/latest/how-to/), [Explanation](https://canonical-pebble.readthedocs-hosted.com/en/latest/explanation/), and [Reference](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/). How-to guides already has the style we want, so I'm using the same style for Explanation and Reference.

Summary of changes:
- **How-to guides** - Adjusted some wording for readability and consistency of language
- **Explanation** - Moved [General model](https://canonical-pebble.readthedocs-hosted.com/en/latest/explanation/general-model/) to the top of the TOC; split the landing page into sections with brief summaries
- **Reference** - Applied a logical order to the TOC; split the landing page into sections with brief summaries