### PR TITLE
docs: add snap as an installation method

### DIFF
--- a/docs/how-to/install-pebble.md
+++ b/docs/how-to/install-pebble.md
@@ -7,6 +7,7 @@ To install the latest version of Pebble, choose any of the following methods:
 - {ref}`install_pebble_snap`
 - {ref}`install_pebble_from_source`
 
+
 (install_pebble_binary)=
 ## Install the binary
 
@@ -16,6 +17,7 @@ To install the binary for the latest version of Pebble:
    :start-after: Start: Install Pebble binary
    :end-before: End: Install Pebble binary
 ```
+
 
 (install_pebble_snap)=
 ## Install the snap
@@ -34,9 +36,10 @@ For information about snaps, see the [snap documentation](https://snapcraft.io/d
 
 To install the latest version of Pebble from source:
 
-1. Follow the official Go documentation [here](https://go.dev/doc/install) to download and install Go.
-2. After installing, you will want to add the `$GOBIN` directory to your `$PATH` so you can use the installed tools. For more information, refer to the [official documentation](https://go.dev/doc/install/source#environment).
+1. Follow the [Go installation documentation](https://go.dev/doc/install) to download and install Go.
+2. After installing, add the `$GOBIN` directory to your `$PATH` so you can use the installed tools. For more information, see the [Go environment documentation](https://go.dev/doc/install/source#environment).
 3. Run `go install github.com/canonical/pebble/cmd/pebble@latest` to build and install Pebble.
+
 
 ## Verify the Pebble installation
 

--- a/docs/how-to/install-pebble.md
+++ b/docs/how-to/install-pebble.md
@@ -4,6 +4,7 @@
 To install the latest version of Pebble, choose any of the following methods:
 
 - {ref}`install_pebble_binary`
+- {ref}`install_pebble_snap`
 - {ref}`install_pebble_from_source`
 
 (install_pebble_binary)=
@@ -16,10 +17,22 @@ To install the binary for the latest version of Pebble:
    :end-before: End: Install Pebble binary
 ```
 
+(install_pebble_snap)=
+## Install the snap
+
+To install the latest version of Pebble from the Snap Store:
+
+```
+sudo snap install pebble --classic
+```
+
+For information about snaps, see the [snap documentation](https://snapcraft.io/docs).
+
+
 (install_pebble_from_source)=
 ## Install from source
 
-Alternatively, you can install the latest version of Pebble from source:
+To install the latest version of Pebble from source:
 
 1. Follow the official Go documentation [here](https://go.dev/doc/install) to download and install Go.
 2. After installing, you will want to add the `$GOBIN` directory to your `$PATH` so you can use the installed tools. For more information, refer to the [official documentation](https://go.dev/doc/install/source#environment).

--- a/docs/how-to/install-pebble.md
+++ b/docs/how-to/install-pebble.md
@@ -1,7 +1,7 @@
 (how_to_install_pebble)=
 # How to install Pebble
 
-To install the latest version of Pebble, you can choose any of the following methods:
+To install the latest version of Pebble, choose any of the following methods:
 
 - {ref}`install_pebble_binary`
 - {ref}`install_pebble_from_source`


### PR DESCRIPTION
The purpose of this PR is to list the `pebble` snap as an option in [How to install Pebble](https://canonical-pebble.readthedocs-hosted.com/en/latest/how-to/install-pebble/).

Changes:

- Added a new section called "Install the snap" after "Install the binary". I put the new section immediately after "Install the binary" because these two sections are more user focused, whereas "Install from source" is more developer focused
- Adjusted some language within the page for readability and consistency
- Changed the link titles in "Install from source" to make it more obvious what we're linking to