### PR TITLE
fix: mapping service to lanes when services are in random order

### DIFF
--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1134,6 +1134,7 @@ func createLanes(names []string, services map[string]*Service) ([][]string, erro
 
 	// Map all services into lanes.
 	var lane = -1
+	var maxLane = 0
 	for _, name := range names {
 		service, ok := services[name]
 		if !ok {
@@ -1143,10 +1144,13 @@ func createLanes(names []string, services map[string]*Service) ([][]string, erro
 		}
 
 		lane = getOrCreateLane(lane, service, serviceLaneMapping)
+		if lane > maxLane {
+			maxLane = lane
+		}
 	}
 
 	// Create lanes
-	lanes := make([][]string, lane+1)
+	lanes := make([][]string, maxLane+1)
 	for _, service := range names {
 		lane := serviceLaneMapping[service]
 		lanes[lane] = append(lanes[lane], service)

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -1133,8 +1133,8 @@ func createLanes(names []string, services map[string]*Service) ([][]string, erro
 	serviceLaneMapping := make(map[string]int)
 
 	// Map all services into lanes.
-	var lane = -1
-	var maxLane = 0
+	lane := -1
+	maxLane := 0
 	for _, name := range names {
 		service, ok := services[name]
 		if !ok {


### PR DESCRIPTION
If services are defined in random order in the layer config, for example, svc1, svc2, then svc3, but svc3 depends on svc1, when mapping these services into lanes, the maximum lane count is incorrectly calculated.

This PR fixes this issue and closes https://github.com/canonical/pebble/issues/525.

Manual test:

Layer config:

```yaml
summary: a simple layer
services:
  test1:
    override: replace
    command: bash -c "sleep 1000"
    startup: enabled
  test2:
    override: replace
    command: bash -c "sleep 1000"
    startup: enabled
  test3:
    override: replace
    command: bash -c "sleep 1000"
    startup: enabled
    requires:
      - test1
```

Result:

```bash
$ ./pebble run
2024-11-28T03:00:55.321Z [pebble] Started daemon.
2024-11-28T03:00:55.329Z [pebble] POST /v1/services 2.313041ms 202
2024-11-28T03:00:55.331Z [pebble] Service "test1" starting: bash -c "sleep 1000"
2024-11-28T03:00:55.332Z [pebble] Service "test2" starting: bash -c "sleep 1000"
2024-11-28T03:00:56.343Z [pebble] Service "test3" starting: bash -c "sleep 1000"
2024-11-28T03:00:57.351Z [pebble] GET /v1/changes/1/wait 2.022350876s 200
2024-11-28T03:00:57.352Z [pebble] Started default services with change 1.
^C2024-11-28T03:00:58.497Z [pebble] Exiting on interrupt signal.
2024-11-28T03:00:58.500Z [pebble] Stopping all running services.
2024-11-28T03:00:58.505Z [pebble] Service "test2" stopped
2024-11-28T03:00:58.505Z [pebble] Service "test1" stopped
2024-11-28T03:00:58.512Z [pebble] Service "test3" stopped
```

A [test case](https://github.com/canonical/pebble/pull/528/files#diff-f3aedc0e48287c8fa95ea71f4a1bd0a350d89ab1c5559ee7db3298d44207e93bR2076) is also added to cover this scenario.