### PR TITLE
feat(daemon): add `ExternalMode` reboot

### DIFF
--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -794,7 +794,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 	oldRebootWaitTimeout := rebootWaitTimeout
 	defer func() {
 		rebootHandler = systemdModeReboot
-		fallbackRebootHandler = systemdModeReboot
+		rebootMode = SystemdMode
 		rebootNoticeWait = oldRebootNoticeWait
 		rebootWaitTimeout = oldRebootWaitTimeout
 	}()
@@ -806,7 +806,6 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 		delays = append(delays, d)
 		return nil
 	}
-	fallbackRebootHandler = rebootHandler
 
 	st.Lock()
 	restart.Request(st, restart.RestartSystem)

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -17,6 +17,7 @@ package daemon
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -793,6 +794,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 	oldRebootWaitTimeout := rebootWaitTimeout
 	defer func() {
 		rebootHandler = systemdModeReboot
+		fallbackRebootHandler = systemdModeReboot
 		rebootNoticeWait = oldRebootNoticeWait
 		rebootWaitTimeout = oldRebootWaitTimeout
 	}()
@@ -804,6 +806,7 @@ func (s *daemonSuite) TestRestartSystemWiring(c *C) {
 		delays = append(delays, d)
 		return nil
 	}
+	fallbackRebootHandler = rebootHandler
 
 	st.Lock()
 	restart.Request(st, restart.RestartSystem)
@@ -1170,6 +1173,58 @@ services:
 	// Ensure it returned a service-failure error.
 	err = d.Stop(nil)
 	c.Assert(err, Equals, ErrRestartServiceFailure)
+}
+
+func (s *daemonSuite) TestRebootExternal(c *C) {
+	oldRebootWaitTimeout := rebootWaitTimeout
+	defer func() {
+		rebootWaitTimeout = oldRebootWaitTimeout
+	}()
+	rebootWaitTimeout = 0
+
+	didFallbackReboot := false
+	defer FakeSyscallSync(func() {})()
+	defer FakeSyscallReboot(func(cmd int) error {
+		if cmd == syscall.LINUX_REBOOT_CMD_RESTART {
+			didFallbackReboot = true
+		}
+		return nil
+	})()
+	SetRebootMode(ExternalMode)
+	defer SetRebootMode(SystemdMode)
+
+	d := s.newDaemon(c)
+	makeDaemonListeners(c, d)
+	c.Assert(d.Start(), IsNil)
+
+	st := d.overlord.State()
+	st.Lock()
+	restart.Request(st, restart.RestartSystem)
+	st.Unlock()
+
+	select {
+	case <-d.Dying():
+	case <-time.After(2 * time.Second):
+		c.Fatal("RequestRestart -> overlord -> Kill chain didn't work")
+	}
+
+	d.mu.Lock()
+	restartType := d.requestedRestart
+	d.mu.Unlock()
+
+	c.Assert(restartType, Equals, restart.RestartSystem)
+
+	err := d.Stop(nil)
+	c.Assert(errors.Is(err, ErrRestartExternal), Equals, true)
+
+	d.mu.Lock()
+	d.requestedRestart = restart.RestartUnset
+	d.mu.Unlock()
+
+	c.Assert(didFallbackReboot, Equals, true)
+	st.Lock()
+	restart.ClearReboot(st)
+	st.Unlock()
 }
 
 func (s *daemonSuite) TestConnTrackerCanShutdown(c *C) {


### PR DESCRIPTION
This patch adds a new `daemon.ExternalMode` reboot mode that does nothing, so that code in charge of starting and stopping the Pebble daemon can run custom logic after the daemon has stopped.

When `ExternalMode` is set and the Pebble daemon stops after a system restart has been requested, `daemon.Stop()` returns the special `daemon.ErrRestartExternal` error that can be detected by the caller in order to execute custom reboot logic.

Furthermore, the fallback reboot handler is set to `syscallModeReboot()`, so that a system reboot is forced after `rebootWaitTimeout` is reached. In other words, the code responsible for handling the reboot with custom logic has a time span given by `rebootWaitTimeout` to perform a system reboot, or it will be forced.

```go
func exampleUsage() error {
    /* ... */
    daemon.SetRebootMode(daemon.ExternalMode)
    d, err := daemon.New(...)
    if err != nil {
        return err
    }
    /* ... */

    sigs := make(chan os.Signal, 1)
    signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
    select {
    case <-sigs:
        // Exiting due to signal
    case <-d.Dying():
        // Exiting due to daemon error/requested reboot
    }

    err := d.Stop()
    if errors.Is(err, daemon.ErrRestartExternal) {
        // Custom reboot logic (~10min window before reboot(2) is called)
        /* ... */
        return nil
    }
    return err
}
```