### PR TITLE
docs: update okay delay related docs

### DIFF
--- a/docs/explanation/service-start-order.md
+++ b/docs/explanation/service-start-order.md
@@ -2,14 +2,13 @@
 
 When multiple services need to be started together, they're started in order according to the `before` and `after` in the [layer configuration](../reference/layer-specification.md). Pebble waits 1 second after starting each service to ensure the command doesn't exit too quickly.
 
-```{include} /reuse/service-auto-restart.md
-   :start-after: Start: Service auto-restart note
-   :end-before: End: Service auto-restart note
-```
-
 The `before` option is a list of services that this service must start before (it may or may not `requires` them, see [Service dependencies](./service-dependencies.md)). Or if it's easier to specify this ordering the other way around, `after` is a list of services that this service must start after.
 
 ```{include} /reuse/service-start-order.md
    :start-after: Start: Service start order note
    :end-before: End: Service start order note
 ```
+
+## Service auto-restart
+
+By default, if a service exits, Pebble will restart it after the backoff delay, which defaults to half a second. For more information, see [start command](/reference/cli-commands/start.md).

--- a/docs/explanation/service-start-order.md
+++ b/docs/explanation/service-start-order.md
@@ -2,6 +2,11 @@
 
 When multiple services need to be started together, they're started in order according to the `before` and `after` in the [layer configuration](../reference/layer-specification.md). Pebble waits 1 second after starting each service to ensure the command doesn't exit too quickly.
 
+```{include} /reuse/service-auto-restart.md
+   :start-after: Start: Service auto-restart note
+   :end-before: End: Service auto-restart note
+```
+
 The `before` option is a list of services that this service must start before (it may or may not `requires` them, see [Service dependencies](./service-dependencies.md)). Or if it's easier to specify this ordering the other way around, `after` is a list of services that this service must start after.
 
 ```{include} /reuse/service-start-order.md

--- a/docs/explanation/service-start-order.md
+++ b/docs/explanation/service-start-order.md
@@ -1,6 +1,6 @@
 # Service start order
 
-When multiple services need to be started together, they're started in order according to the `before` and `after` in the [layer configuration](../reference/layer-specification.md). Pebble waits 1 second after starting each service to ensure the command doesn't exit too quickly.
+When multiple services need to be started together, they're started in order according to the `before` and `after` in the [layer configuration](../reference/layer-specification.md). Pebble [waits 1 second](/reference/cli-commands/start.md) after starting each service to ensure the command doesn't exit too quickly.
 
 The `before` option is a list of services that this service must start before (it may or may not `requires` them, see [Service dependencies](./service-dependencies.md)). Or if it's easier to specify this ordering the other way around, `after` is a list of services that this service must start after.
 
@@ -8,7 +8,3 @@ The `before` option is a list of services that this service must start before (i
    :start-after: Start: Service start order note
    :end-before: End: Service start order note
 ```
-
-## Service auto-restart
-
-By default, if a service exits, Pebble will restart it after the backoff delay, which defaults to half a second. For more information, see [start command](/reference/cli-commands/start.md).

--- a/docs/reference/cli-commands/start.md
+++ b/docs/reference/cli-commands/start.md
@@ -24,10 +24,8 @@ any other services it depends on, in the correct order.
 
 When starting a service, Pebble executes the service's `command`, and waits 1 second to ensure the command doesn't exit too quickly.
 
-- If the command doesn't exit within the 1 second window, the start is considered successful.
-- If the command exits within the 1 second window, Pebble retries the command after a backoff delay of half a second (default value). Within the 1 second window, Pebble applies the restart logic described in [Service auto-restart](/reference/service-auto-restart.md). You can configure the backoff delay and the auto-restart behaviour according to the service's exit code. For more information, see [Layer specification](/reference/layer-specification.md).
-
-If the service exits after each start attempt within the 1 second window, pebble start exits with an error, regardless of the on-failure value.
+- If the command is still running at the end of the 1 second window, the start is considered successful.
+- If the command exits within the 1 second window, Pebble retries the command after a configurable backoff, using the restart logic described in [Service auto-restart](/reference/service-auto-restart.md). If one of the started services exits within the 1 second window, `pebble start` prints an appropriate error message and exits with an error.
 
 ## Examples
 

--- a/docs/reference/cli-commands/start.md
+++ b/docs/reference/cli-commands/start.md
@@ -22,12 +22,12 @@ any other services it depends on, in the correct order.
 
 ## How it works
 
-When starting a service, Pebble executes the service's `command`, and waits 1 second to ensure the command doesn't exit too quickly. Assuming the command doesn't exit within that time window, the start is considered successful, otherwise `pebble start` will exit with an error, regardless of the `on-failure` value.
+When starting a service, Pebble executes the service's `command`, and waits 1 second to ensure the command doesn't exit too quickly.
 
-```{include} /reuse/service-auto-restart.md
-   :start-after: Start: Service auto-restart note
-   :end-before: End: Service auto-restart note
-```
+- If the command doesn't exit within the 1 second window, the start is considered successful.
+- If the command exits within the 1 second window, Pebble retries the command after a backoff delay of half a second (default value). Within the 1 second window, Pebble applies the restart logic described in [Service auto-restart](/reference/service-auto-restart.md). You can configure the backoff delay and the auto-restart behaviour according to the service's exit code. For more information, see [Layer specification](/reference/layer-specification.md).
+
+If the service exits after each start attempt within the 1 second window, pebble start exits with an error, regardless of the on-failure value.
 
 ## Examples
 

--- a/docs/reference/cli-commands/start.md
+++ b/docs/reference/cli-commands/start.md
@@ -24,6 +24,11 @@ any other services it depends on, in the correct order.
 
 When starting a service, Pebble executes the service's `command`, and waits 1 second to ensure the command doesn't exit too quickly. Assuming the command doesn't exit within that time window, the start is considered successful, otherwise `pebble start` will exit with an error, regardless of the `on-failure` value.
 
+```{include} /reuse/service-auto-restart.md
+   :start-after: Start: Service auto-restart note
+   :end-before: End: Service auto-restart note
+```
+
 ## Examples
 
 To start specific services, run `pebble start` followed by one or more service names. For example, to start two services named "srv1" and "srv2" (and any dependencies), run:

--- a/docs/reuse/service-auto-restart.md
+++ b/docs/reuse/service-auto-restart.md
@@ -1,0 +1,7 @@
+Start: Service auto-restart note
+
+```{note}
+By default, if a service exits, Pebble will restart it after the backoff delay, which defaults to half a second. The backoff delay can be configured, refer to [Layer specification](/reference/layer-specification.md) for more details. The default auto-restart behaviour can also be configured according to the service's exit code, refer to [Service auto-restart](/reference/service-auto-restart.md) and [Layer specification](/reference/layer-specification.md) for more information.
+```
+
+End: Service auto-restart note

--- a/docs/reuse/service-auto-restart.md
+++ b/docs/reuse/service-auto-restart.md
@@ -1,7 +1,7 @@
 Start: Service auto-restart note
 
 ```{note}
-By default, if a service exits, Pebble will restart it after the backoff delay, which defaults to half a second. The backoff delay can be configured, refer to [Layer specification](/reference/layer-specification.md) for more details. The default auto-restart behaviour can also be configured according to the service's exit code, refer to [Service auto-restart](/reference/service-auto-restart.md) and [Layer specification](/reference/layer-specification.md) for more information.
+By default, if a service exits, Pebble will restart it after the backoff delay, which defaults to half a second. The backoff delay can be configured, and the default auto-restart behaviour can also be configured according to the service's exit code. Refer to [Service auto-restart](/reference/service-auto-restart.md) and [Layer specification](/reference/layer-specification.md) for more details.
 ```
 
 End: Service auto-restart note

--- a/docs/reuse/service-auto-restart.md
+++ b/docs/reuse/service-auto-restart.md
@@ -1,7 +1,0 @@
-Start: Service auto-restart note
-
-```{note}
-By default, if a service exits, Pebble will restart it after the backoff delay, which defaults to half a second. The backoff delay can be configured, and the default auto-restart behaviour can also be configured according to the service's exit code. Refer to [Service auto-restart](/reference/service-auto-restart.md) and [Layer specification](/reference/layer-specification.md) for more details.
-```
-
-End: Service auto-restart note


### PR DESCRIPTION
Since [the PR for auto-restarting services that fail within okay delay](https://github.com/canonical/pebble/pull/520) is merged, we are updating docs that are related to the 1-second okay delay.

Note that the original [Service auto-restart](https://canonical-pebble--531.com.readthedocs.build/en/531/reference/service-auto-restart/) reference doc is not updated because the description in it is still valid, so I didn't update it.

[Here](https://canonical-pebble--531.com.readthedocs.build/en/531/) is a preview, please:
- Help check if I missed anything;
- and see if we can better organize the content in the [Service auto-restart](https://canonical-pebble--531.com.readthedocs.build/en/531/reference/service-auto-restart/) reference doc to address this change.