### PR TITLE
docs: add release info to homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,11 +40,9 @@ Pebble is useful for developers who are building [Juju charms on Kubernetes](htt
 
 ## Releases
 
-Pebble releases are tracked in GitHub.
-
 [Read the release notes](https://github.com/canonical/pebble/releases)
 
-To get notified when there's a new release, watch the [Pebble repository](https://github.com/canonical/pebble).
+Pebble releases are tracked in GitHub. To get notified when there's a new release, watch the [Pebble repository](https://github.com/canonical/pebble).
 
 ## Project and community
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,9 +44,9 @@ Pebble is free software and released under [GPL-3.0](https://www.gnu.org/license
 
 The Pebble project is sponsored by [Canonical Ltd](https://www.canonical.com).
 
-- [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct).
+- [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
 - [Contribute to the project](https://github.com/canonical/pebble?tab=readme-ov-file#contributing)
-- [Development](https://github.com/canonical/pebble/blob/master/HACKING.md): information on how to run and hack on the Pebble codebase during development.
+- [Development](https://github.com/canonical/pebble/blob/master/HACKING.md): information on how to run and hack on the Pebble codebase during development
 
 ```{filtered-toctree}
 :hidden:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,14 @@ Pebble is useful for developers who are building [Juju charms on Kubernetes](htt
 ```
 ````
 
+## Releases
+
+Pebble releases are tracked in GitHub.
+
+[Read the release notes](https://github.com/canonical/pebble/releases)
+
+To get notified when there's a new release, watch the [Pebble repository](https://github.com/canonical/pebble).
+
 ## Project and community
 
 Pebble is free software and released under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).


### PR DESCRIPTION
This PR adds a new section called "Releases" to the docs homepage. The purpose is to help newcomers find the Pebble release notes.

Preview build: https://canonical-pebble--533.com.readthedocs.build/en/533/

(While making this change, I also removed a couple of trailing periods in the "Project and community" bullets, for consistency)