### PR TITLE
docs: clarify different types of API access

### DIFF
--- a/docs/explanation/api-and-clients.md
+++ b/docs/explanation/api-and-clients.md
@@ -19,8 +19,8 @@ In addition to the Go client, there's also a [Python client](https://github.com/
 API endpoints fall into one of three access levels, from least restricted to most restricted:
 
 * **Open-access** - Allowed from any user, even unauthenticated users using the HTTP-over-TCP listener.
-    * `GET /v1/system-info`, which returns the Pebble version and an identifier for the daemon
-    * `GET /v1/health`, which returns a boolean to indicate the state of Pebble's health checks
+    * `GET /v1/system-info`, which returns the Pebble version and other information
+    * `GET /v1/health`, which returns a boolean to indicate whether Pebble's health checks are all healthy
 
 * **Read-access** - Allowed from any authenticated user. For example, listing services or viewing notices.
     * All `GET` endpoints except the admin-access `GET` endpoints

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -833,7 +833,7 @@ pebble run --args myservice --port 8080 \; --hold
           --create-dirs  Create Pebble directory on startup if it doesn't exist
           --hold         Do not start default services automatically
           --http=        Start HTTP API listening on this address (e.g.,
-                         ":4000")
+                         ":4000") and expose open-access endpoints
       -v, --verbose      Log all output from services to stdout
           --args=        Provide additional arguments to a service
           --identities=  Seed identities from file (like update-identities

--- a/docs/reference/identities.md
+++ b/docs/reference/identities.md
@@ -11,8 +11,8 @@ identities:
     <name>:
         # (Required) Access level of this identity. Possible values are:
         #
-        # - untrusted: has access only to untrusted or "open" endpoints
-        # - read: has access to read or "user" endpoints
+        # - untrusted: has access to open-access endpoints only
+        # - read: has access to read-access endpoints
         # - admin: has access to all endpoints
         access: untrusted | read | admin
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -57,7 +57,7 @@ type sharedRunEnterOpts struct {
 var sharedRunEnterArgsHelp = map[string]string{
 	"--create-dirs": "Create {{.DisplayName}} directory on startup if it doesn't exist",
 	"--hold":        "Do not start default services automatically",
-	"--http":        `Start HTTP API listening on this address (e.g., ":4000")`,
+	"--http":        `Start HTTP API listening on this address (e.g., ":4000") and expose open-access endpoints`,
 	"--verbose":     "Log all output from services to stdout",
 	"--args":        "Provide additional arguments to a service",
 	"--identities":  "Seed identities from file (like update-identities --replace)",


### PR DESCRIPTION
The purpose of this PR is make it easier to understand details about API security. (I'll create a separate PR to add a general security overview doc)

Summary of changes:
* Specify which API endpoints have which access level
* Use terms more consistently:
    * "Authenticated" to mean a user with `read` or `admin` access level
    * "Unauthenticated" to mean a user with `untrusted` access level
    * "Open-access" to mean an API endpoint that doesn't require authentication (instead of calling them "untrusted")

Preview build: https://canonical-pebble--535.com.readthedocs.build/en/535/