### PR TITLE
docs: add an overview of security

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -38,3 +38,15 @@ Pebble automatically starts and stops services if you specify dependencies betwe
 Service dependencies <service-dependencies>
 Service start order <service-start-order>
 ```
+
+
+## Security
+
+To use Pebble in a secure way, pay attention to API access levels, the Pebble directory, and how you install Pebble.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Security <security>
+```

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -12,7 +12,7 @@ For more information, see [](api-and-clients.md) and [](../how-to/manage-identit
 
 ## The Pebble directory
 
-Pebble stores its configuration, internal state, and Unix socket in the `$PEBBLE` directory. If `$PEBBLE` is not set, Pebble uses the directory `/var/lib/pebble/default`.
+Pebble stores its configuration, internal state, and Unix socket in the directory specified by the `PEBBLE` environment variable. If `$PEBBLE` is not set, Pebble uses the directory `/var/lib/pebble/default`.
 
 The `$PEBBLE` directory must be readable and writable by the UID of the pebble process. Make sure that no other UIDs can read or write to the $PEBBLE directory.
 
@@ -21,4 +21,4 @@ The file `$PEBBLE/.pebble.state` contains the internal state of the Pebble daemo
 
 ## Security updates
 
-There are several ways to install Pebble. The easiest way to ensure that you get security updates is to install the snap. See [](#install_pebble_snap).
+There are several ways to install Pebble. The easiest way to ensure that you get security updates is to [install the snap](#install_pebble_snap).

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -1,0 +1,24 @@
+# Security
+
+
+## Access to the API
+
+The Pebble daemon exposes an API that enables remote clients to interact with the daemon. The API uses HTTP over a Unix socket, with access to the API controlled by user ID (UID). If you want to grant a specific access level to a user, you can define an "identity" for the user.
+
+If you use the `--http` option when starting the daemon, Pebble exposes a limited set of open-access API endpoints over TCP. No authentication is required to connect to the open-access endpoints.
+
+For more information, see [](api-and-clients.md) and [](../how-to/manage-identities.md).
+
+
+## The Pebble directory
+
+Pebble stores its configuration, internal state, and Unix socket in the `$PEBBLE` directory. If `$PEBBLE` is not set, Pebble uses the directory `/var/lib/pebble/default`.
+
+The `$PEBBLE` directory must be readable and writable by the UID of the pebble process. Make sure that no other UIDs can read or write to the $PEBBLE directory.
+
+The file `$PEBBLE/.pebble.state` contains the internal state of the Pebble daemon. You shouldn't try to edit this file or change its permissions.
+
+
+## Security updates
+
+There are several ways to install Pebble. The easiest way to ensure that you get security updates is to install the snap. See [](#install_pebble_snap).


### PR DESCRIPTION
This PR adds a new page to summarize security considerations for Pebble. Preview: https://canonical-pebble--536.com.readthedocs.build/en/536/explanation/security/