### PR TITLE
docs: clarify the replan behaviour with regards to stopped services

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -721,7 +721,7 @@ current plan.
 When you update service configuration (by adding a layer), the services changed won't be automatically restarted. `pebble replan ` restarts them and brings the service state in sync with the new configuration.
 
 - The "replan" operation restarts `startup: enabled` services whose configuration have changed between when they started and now; if the configuration hasn't changed, replan does nothing.
-- Replan also starts `startup: enabled` services that have not yet been started.
+- Replan also starts `startup: enabled` services that have not yet been started, or that have been manually stopped.
 
 ### Examples
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -720,7 +720,12 @@ current plan.
 
 When you update service configuration (by adding a layer), the services changed won't be automatically restarted. `pebble replan ` restarts them and brings the service state in sync with the new configuration.
 
-- The "replan" operation restarts `startup: enabled` services whose configuration have changed between when they started and now; if the configuration hasn't changed, replan does nothing.
+For `startup: enabled` services that are running:
+
+- If the service hasn't changed configuration since it started, replan does nothing to the service.
+- If the service has changed configuration since it started, replan restarts the service.
+
+Replan also starts any `startup: enabled` services that have not yet been started, or that have been manually stopped.
 - Replan also starts `startup: enabled` services that have not yet been started, or that have been manually stopped.
 
 ### Examples

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -726,7 +726,6 @@ For `startup: enabled` services that are running:
 - If the service has changed configuration since it started, replan restarts the service.
 
 Replan also starts any `startup: enabled` services that have not yet been started, or that have been manually stopped.
-- Replan also starts `startup: enabled` services that have not yet been started, or that have been manually stopped.
 
 ### Examples
 

--- a/docs/reference/layer-specification.md
+++ b/docs/reference/layer-specification.md
@@ -37,7 +37,7 @@ services:
             <description>
 
         # (Optional) Control whether the service is started automatically when
-        # Pebble starts. Default is "disabled".
+        # Pebble starts or performs a 'replan' operation. Default is "disabled".
         startup: enabled | disabled
 
         # (Optional) A list of other services in the plan that this service


### PR DESCRIPTION
A `replan` command will start any services that have been stopped (with a `stop` command), if the service has `startup: enabled` set. Clarify that in the documentation.