### PR TITLE
chore: temporarily disable TIOBE reporting

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -2,8 +2,10 @@ name: TIOBE Quality Checks
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 7 1 * *'
+# Temporarily disabled during an upgrade, see:
+# https://discourse.canonical.com/t/end-of-the-year-update-for-tiobe-tics-required-action-to-disable-tics-cicd-pipelines/4890
+#  schedule:
+#    - cron:  '0 7 1 * *'
 
 jobs:
   TICS:


### PR DESCRIPTION
Per [instruction](https://discourse.canonical.com/t/end-of-the-year-update-for-tiobe-tics-required-action-to-disable-tics-cicd-pipelines/4890) (internal link only, sorry), we need to temporarily disable reporting to TIOBE.