### PR TITLE
docs: add API reference sections to the TOC

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -175,5 +175,47 @@ window.onload = function() {
   // End Swagger UI call region
 
   window.ui = ui
+
+  function addSwaggerTagsToTOC(tags) {
+    // Find the last H2 entry in the TOC and insert a 'ul' element for the tag list
+    const tocContainer = document.querySelector(
+      ".toc-tree > ul > li > ul > li:last-child"
+    );
+    const tocList = document.createElement("ul");
+    tocContainer.appendChild(tocList);
+    // Add a link for each tag inside the 'ul' element
+    for (const tag of tags) {
+      // Create an 'a' element for the tag link
+      const tocLink = document.createElement("a");
+      tocLink.classList.add("reference", "internal");
+      tocLink.href= `#/${tag}`;
+      tocLink.innerText = tag;
+      tocLink.addEventListener("click", event => {
+        if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+          return;
+        }
+        // When the tag link is clicked with no modifier keys:
+        // - Scroll the tag section into view
+        // - If the tag section is closed, open it (by simulating a click)
+        const swaggerHeading = document.getElementById(`operations-tag-${tag}`);
+        swaggerHeading.scrollIntoView({
+          behavior: "smooth"
+        });
+        if (swaggerHeading.getAttribute("data-is-open") == "false") {
+          swaggerHeading.click();
+        }
+      });
+      // Wrap the tag link in a 'li' element and add it to the tag list
+      const tocItem = document.createElement("li");
+      tocItem.appendChild(tocLink);
+      tocList.appendChild(tocItem);
+    }
+  }
+
+  // Make sure to match the tags defined in openapi.yaml
+  addSwaggerTagsToTOC([
+    "changes",
+    "services"
+  ]);
 }
 </script>


### PR DESCRIPTION
This PR adds JavaScript code to create TOC entries for the sections (tags) in the API reference.

**[Preview build](https://canonical-pebble--542.com.readthedocs.build/en/542/reference/api/)**

**The tags need to be hardcoded in _api.md_.** It would be possible for JavaScript to determine the tags from the rendered Swagger UI elements, but there's no event to tell us when the Swagger UI has rendered. So I think it's not worth the effort - simpler to hard code the tags.

**Behavior**
- Adds a link for each tag inside the last top-level entry in the TOC.
- When a tag link is clicked (with no modifier keys), the tag section scrolls into view. The tag section opens if it's not open.

**Why do this in JavaScript?** We already run some JavaScript, because Swagger UI requires JavaScript. And even if we inserted the tag links at build-time in Sphinx, we'd still need JavaScript to automatically open the tag sections.