### PR TITLE
refactor: update client code+tests to use Requester interface

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -100,7 +101,15 @@ func (client *Client) Change(id string) (*Change, error) {
 	}
 
 	var chgd changeAndData
-	_, err := client.doSync("GET", "/v1/changes/"+id, nil, nil, nil, &chgd)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/changes/" + id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&chgd)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +135,17 @@ func (client *Client) Abort(id string) (*Change, error) {
 	}
 
 	var chg Change
-	if _, err := client.doSync("POST", "/v1/changes/"+id, nil, nil, &body, &chg); err != nil {
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "/v1/changes/" + id,
+		Body:   &body,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&chg)
+	if err != nil {
 		return nil, err
 	}
 
@@ -173,7 +192,16 @@ func (client *Client) Changes(opts *ChangesOptions) ([]*Change, error) {
 	}
 
 	var chgds []changeAndData
-	_, err := client.doSync("GET", "/v1/changes", query, nil, nil, &chgds)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/changes",
+		Query:  query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&chgds)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +237,16 @@ func (client *Client) WaitChange(id string, opts *WaitChangeOptions) (*Change, e
 		query.Set("timeout", opts.Timeout.String())
 	}
 
-	_, err := client.doSync("GET", "/v1/changes/"+id+"/wait", query, nil, nil, &chgd)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/changes/" + id + "/wait",
+		Query:  query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&chgd)
 	if err != nil {
 		return nil, err
 	}

--- a/client/checks.go
+++ b/client/checks.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"net/url"
 )
 
@@ -84,7 +85,16 @@ func (client *Client) Checks(opts *ChecksOptions) ([]*CheckInfo, error) {
 		query["names"] = opts.Names
 	}
 	var checks []*CheckInfo
-	_, err := client.doSync("GET", "/v1/checks", query, nil, nil, &checks)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/checks",
+		Query:  query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&checks)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -131,7 +131,7 @@ func (cs *clientSuite) TestContextCancellation(c *C) {
 
 func (cs *clientSuite) TestClientWorks(c *C) {
 	var v []int
-	cs.rsp = `[1, 2]`
+	cs.rsp = `[1,2]`
 	reqBody := io.NopCloser(strings.NewReader(""))
 	resp, err := cs.cli.Requester().Do(context.Background(), &client.RequestOptions{
 		Type:   client.RawRequest,

--- a/client/exec.go
+++ b/client/exec.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -152,7 +153,17 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 		"Content-Type": "application/json",
 	}
 	var result execResult
-	resp, err := client.doAsync("POST", "/v1/exec", nil, headers, &body, &result)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:    AsyncRequest,
+		Method:  "POST",
+		Path:    "/v1/exec",
+		Headers: headers,
+		Body:    &body,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&result)
 	if err != nil {
 		return nil, err
 	}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -28,7 +29,11 @@ func (client *Client) SetDoer(d doer) {
 }
 
 func (client *Client) FakeAsyncRequest() (changeId string, err error) {
-	resp, err := client.doAsync("GET", "/v1/async-test", nil, nil, nil, nil)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   AsyncRequest,
+		Method: "GET",
+		Path:   "/v1/async-test",
+	})
 	if err != nil {
 		return "", fmt.Errorf("cannot do async test: %v", err)
 	}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -15,10 +15,7 @@
 package client
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net/url"
 )
 
 var (
@@ -28,28 +25,6 @@ var (
 
 func (client *Client) SetDoer(d doer) {
 	client.Requester().(*defaultRequester).doer = d
-}
-
-// TODO: Clean up tests to use the new Requester API. Tests do not generate a client.response type
-// reply in the body while SyncRequest or AsyncRequest responses assume the JSON body can be
-// unmarshalled into client.response.
-func (client *Client) Do(method, path string, query url.Values, body io.Reader, v interface{}) error {
-	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
-		Type:    RawRequest,
-		Method:  method,
-		Path:    path,
-		Query:   query,
-		Headers: nil,
-		Body:    body,
-	})
-	if err != nil {
-		return err
-	}
-	err = decodeInto(resp.Body, v)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (client *Client) FakeAsyncRequest() (changeId string, err error) {

--- a/client/files.go
+++ b/client/files.go
@@ -127,7 +127,16 @@ func (client *Client) ListFiles(opts *ListFilesOptions) ([]*FileInfo, error) {
 	}
 
 	var results []fileInfoResult
-	_, err := client.doSync("GET", "/v1/files", q, nil, nil, &results)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/files",
+		Query:  q,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&results)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +295,18 @@ func (client *Client) MakeDir(opts *MakeDirOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.doSync("POST", "/v1/files", nil, headers, &body, &result); err != nil {
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:    SyncRequest,
+		Method:  "POST",
+		Path:    "/v1/files",
+		Headers: headers,
+		Body:    &body,
+	})
+	if err != nil {
+		return err
+	}
+	err = resp.DecodeResult(&result)
+	if err != nil {
 		return err
 	}
 
@@ -353,7 +373,18 @@ func (client *Client) RemovePath(opts *RemovePathOptions) error {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
-	if _, err := client.doSync("POST", "/v1/files", nil, headers, &body, &result); err != nil {
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:    SyncRequest,
+		Method:  "POST",
+		Path:    "/v1/files",
+		Headers: headers,
+		Body:    &body,
+	})
+	if err != nil {
+		return err
+	}
+	err = resp.DecodeResult(&result)
+	if err != nil {
 		return err
 	}
 

--- a/client/health.go
+++ b/client/health.go
@@ -14,7 +14,10 @@
 
 package client
 
-import "net/url"
+import (
+	"context"
+	"net/url"
+)
 
 // HealthOptions holds query options to pass to a Health call.
 type HealthOptions struct {
@@ -42,7 +45,16 @@ func (client *Client) Health(opts *HealthOptions) (health bool, err error) {
 	}
 
 	var info healthInfo
-	_, err = client.doSync("GET", "/v1/health", query, nil, nil, &info)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/health",
+		Query:  query,
+	})
+	if err != nil {
+		return false, err
+	}
+	err = resp.DecodeResult(&info)
 	if err != nil {
 		return false, err
 	}

--- a/client/notices.go
+++ b/client/notices.go
@@ -69,7 +69,16 @@ func (client *Client) Notify(opts *NotifyOptions) (string, error) {
 	result := struct {
 		ID string `json:"id"`
 	}{}
-	_, err := client.doSync("POST", "/v1/notices", nil, nil, &body, &result)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "/v1/notices",
+		Body:   &body,
+	})
+	if err != nil {
+		return "", err
+	}
+	err = resp.DecodeResult(&result)
 	if err != nil {
 		return "", err
 	}
@@ -154,7 +163,15 @@ func (client *Client) Notice(id string) (*Notice, error) {
 		return nil, fmt.Errorf("invalid notice ID %q", id)
 	}
 	var jn *jsonNotice
-	_, err := client.doSync("GET", "/v1/notices/"+id, nil, nil, nil, &jn)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/notices/" + id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&jn)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +183,19 @@ func (client *Client) Notice(id string) (*Notice, error) {
 func (client *Client) Notices(opts *NoticesOptions) ([]*Notice, error) {
 	query := makeNoticesQuery(opts)
 	var jns []*jsonNotice
-	_, err := client.doSync("GET", "/v1/notices", query, nil, nil, &jns)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/notices",
+		Query:  query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&jns)
+	if err != nil {
+		return nil, err
+	}
 	return jsonNoticesToNotices(jns), err
 }
 

--- a/client/plan.go
+++ b/client/plan.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/url"
 )
@@ -67,7 +68,12 @@ func (client *Client) AddLayer(opts *AddLayerOptions) error {
 	if err := json.NewEncoder(&body).Encode(&payload); err != nil {
 		return err
 	}
-	_, err := client.doSync("POST", "/v1/layers", nil, nil, &body, nil)
+	_, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "/v1/layers",
+		Body:   &body,
+	})
 	return err
 }
 
@@ -79,7 +85,16 @@ func (client *Client) PlanBytes(_ *PlanOptions) (data []byte, err error) {
 		"format": []string{"yaml"},
 	}
 	var dataStr string
-	_, err = client.doSync("GET", "/v1/plan", query, nil, nil, &dataStr)
+	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "GET",
+		Path:   "/v1/plan",
+		Query:  query,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = resp.DecodeResult(&dataStr)
 	if err != nil {
 		return nil, err
 	}

--- a/client/signals.go
+++ b/client/signals.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -36,7 +37,12 @@ func (client *Client) SendSignal(opts *SendSignalOptions) error {
 	if err != nil {
 		return fmt.Errorf("cannot encode JSON payload: %w", err)
 	}
-	_, err = client.doSync("POST", "/v1/signals", nil, nil, &body, nil)
+	_, err = client.Requester().Do(context.Background(), &RequestOptions{
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "/v1/signals",
+		Body:   &body,
+	})
 	return err
 }
 


### PR DESCRIPTION
Refactor client test framework to use the requester interface.

Closes https://github.com/canonical/pebble/issues/315.

See more information here in https://github.com/canonical/pebble/pull/310.