### PR TITLE
feat(run): Add the --dry option to the run command

### DIFF
--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -84,6 +84,9 @@ type Options struct {
 	// OverlordExtension is an optional interface used to extend the capabilities
 	// of the Overlord.
 	OverlordExtension overlord.Extension
+
+	// If true, no state will be written to file.
+	DryRun bool
 }
 
 // A Daemon listens for requests and routes them to the right command
@@ -852,6 +855,7 @@ func New(opts *Options) (*Daemon, error) {
 		RestartHandler: d,
 		ServiceOutput:  opts.ServiceOutput,
 		Extension:      opts.OverlordExtension,
+		DryRun:         opts.DryRun,
 	}
 
 	ovld, err := overlord.New(&ovldOptions)

--- a/internals/overlord/backend.go
+++ b/internals/overlord/backend.go
@@ -25,18 +25,25 @@ type overlordStateBackend struct {
 	path           string
 	ensureBefore   func(d time.Duration)
 	requestRestart func(t restart.RestartType)
-
-	// If this is true, the backend will not actually save anything to file.
-	DryRun bool
 }
 
 func (osb *overlordStateBackend) Checkpoint(data []byte) error {
-	if osb.DryRun {
-		return nil
-	}
 	return osutil.AtomicWriteFile(osb.path, data, 0600, 0)
 }
 
 func (osb *overlordStateBackend) EnsureBefore(d time.Duration) {
 	osb.ensureBefore(d)
+}
+
+// dryRunStateBackend is a backend that does not actually write anything
+type dryRunStateBackend struct {
+	ensureBefore func(d time.Duration)
+}
+
+func (b *dryRunStateBackend) Checkpoint(data []byte) error {
+	return nil
+}
+
+func (b *dryRunStateBackend) EnsureBefore(d time.Duration) {
+	b.ensureBefore(d)
 }

--- a/internals/overlord/backend.go
+++ b/internals/overlord/backend.go
@@ -25,9 +25,15 @@ type overlordStateBackend struct {
 	path           string
 	ensureBefore   func(d time.Duration)
 	requestRestart func(t restart.RestartType)
+
+	// If this is true, the backend will not actually save anything to file.
+	DryRun bool
 }
 
 func (osb *overlordStateBackend) Checkpoint(data []byte) error {
+	if osb.DryRun {
+		return nil
+	}
 	return osutil.AtomicWriteFile(osb.path, data, 0600, 0)
 }
 

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -137,10 +137,16 @@ func New(opts *Options) (*Overlord, error) {
 
 	statePath := filepath.Join(o.pebbleDir, cmd.StateFile)
 
-	backend := &overlordStateBackend{
-		path:         statePath,
-		ensureBefore: o.ensureBefore,
-		DryRun:       opts.DryRun,
+	var backend state.Backend
+	if opts.DryRun {
+		backend = &dryRunStateBackend{
+			ensureBefore: o.ensureBefore,
+		}
+	} else {
+		backend = &overlordStateBackend{
+			path:         statePath,
+			ensureBefore: o.ensureBefore,
+		}
 	}
 	s, restartMgr, err := loadState(statePath, opts.RestartHandler, backend)
 	if err != nil {

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -76,6 +76,9 @@ type Options struct {
 	ServiceOutput io.Writer
 	// Extension allows extending the overlord with externally defined features.
 	Extension Extension
+	// DryRun must be true if state in storage is not meant to be altered.
+	// Otherwise, the Overlord will operate normally.
+	DryRun bool
 }
 
 // Overlord is the central manager of the system, keeping track
@@ -106,6 +109,9 @@ type Overlord struct {
 	logMgr     *logstate.LogManager
 
 	extension Extension
+
+	// If true, no state will be written to file.
+	DryRun bool
 }
 
 // New creates an Overlord with all its state managers.
@@ -116,6 +122,7 @@ func New(opts *Options) (*Overlord, error) {
 		loopTomb:  new(tomb.Tomb),
 		inited:    true,
 		extension: opts.Extension,
+		DryRun:    opts.DryRun,
 	}
 
 	if !filepath.IsAbs(o.pebbleDir) {
@@ -133,6 +140,7 @@ func New(opts *Options) (*Overlord, error) {
 	backend := &overlordStateBackend{
 		path:         statePath,
 		ensureBefore: o.ensureBefore,
+		DryRun:       opts.DryRun,
 	}
 	s, restartMgr, err := loadState(statePath, opts.RestartHandler, backend)
 	if err != nil {


### PR DESCRIPTION
The --dry option changes the behavior of the run command to only execute
the setting-up of the pebble daemon without actually starting it.
Side-effects of initialization on the state file are also disabled.

This allows checking the validity of a plan without launching pebble
proper.
For example, if you have a plan layer at `/tmp/layers/123-layer.yaml`, you
can check it using `PEBBLE=/tmp go run ./cmd/pebble run --dry` provided
this command is invoked from the root of this repository.