### PR TITLE
poc: add run-check to execute a check immediately

### DIFF
--- a/client/checks.go
+++ b/client/checks.go
@@ -104,15 +104,15 @@ func (client *Client) Checks(opts *ChecksOptions) ([]*CheckInfo, error) {
 	return checks, nil
 }
 
-type RunCheckPayload struct {
+type RunCheckOptions struct {
 	Check string
 }
 
-// RunCheck runs a specific health check immediately and return the status.
-func (client *Client) RunCheck(opts *RunCheckPayload) (string, error) {
+// RunCheck runs a specific health check immediately and returns the error.
+func (client *Client) RunCheck(opts *RunCheckOptions) error {
 	body, err := json.Marshal(opts)
 	if err != nil {
-		return "", fmt.Errorf("cannot marshal checks payload: %w", err)
+		return fmt.Errorf("cannot marshal checks payload: %w", err)
 	}
 
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
@@ -122,9 +122,8 @@ func (client *Client) RunCheck(opts *RunCheckPayload) (string, error) {
 		Body:   bytes.NewBuffer(body),
 	})
 	if err != nil {
-		return "", err
+		return err
 	}
 	var status string
-	err = resp.DecodeResult(&status)
-	return status, err
+	return resp.DecodeResult(&status)
 }

--- a/client/checks.go
+++ b/client/checks.go
@@ -104,13 +104,12 @@ func (client *Client) Checks(opts *ChecksOptions) ([]*CheckInfo, error) {
 	return checks, nil
 }
 
-type CheckPayload struct {
-	Action string
-	Check  string
+type RunCheckPayload struct {
+	Check string
 }
 
 // RunCheck runs a specific health check immediately and return the status.
-func (client *Client) RunCheck(opts *CheckPayload) (string, error) {
+func (client *Client) RunCheck(opts *RunCheckPayload) (string, error) {
 	body, err := json.Marshal(opts)
 	if err != nil {
 		return "", fmt.Errorf("cannot marshal checks payload: %w", err)
@@ -119,7 +118,7 @@ func (client *Client) RunCheck(opts *CheckPayload) (string, error) {
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
 		Type:   SyncRequest,
 		Method: "POST",
-		Path:   "/v1/checks",
+		Path:   "/v1/checks/run",
 		Body:   bytes.NewBuffer(body),
 	})
 	if err != nil {

--- a/internals/cli/cmd_run-check.go
+++ b/internals/cli/cmd_run-check.go
@@ -51,13 +51,13 @@ func (cmd *cmdRunCheck) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	opts := client.RunCheckPayload{
+	opts := client.RunCheckOptions{
 		Check: cmd.Positional.Check,
 	}
-	status, err := cmd.client.RunCheck(&opts)
+	err := cmd.client.RunCheck(&opts)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(Stdout, status)
+	fmt.Fprintf(Stderr, "Check %q succeeded.\n", cmd.Positional.Check)
 	return nil
 }

--- a/internals/cli/cmd_run-check.go
+++ b/internals/cli/cmd_run-check.go
@@ -22,12 +22,12 @@ import (
 	"github.com/canonical/pebble/client"
 )
 
-const cmdCheckSummary = "Run check immediately and get the status"
-const cmdCheckDescription = `
+const cmdRunCheckSummary = "Run check immediately and get the status"
+const cmdRunCheckDescription = `
 The check command runs a check immediately and return the status.
 `
 
-type cmdCheck struct {
+type cmdRunCheck struct {
 	client *client.Client
 
 	Positional struct {
@@ -38,15 +38,15 @@ type cmdCheck struct {
 func init() {
 	AddCommand(&CmdInfo{
 		Name:        "run-check",
-		Summary:     cmdCheckSummary,
-		Description: cmdCheckDescription,
+		Summary:     cmdRunCheckSummary,
+		Description: cmdRunCheckDescription,
 		New: func(opts *CmdOptions) flags.Commander {
-			return &cmdCheck{client: opts.Client}
+			return &cmdRunCheck{client: opts.Client}
 		},
 	})
 }
 
-func (cmd *cmdCheck) Execute(args []string) error {
+func (cmd *cmdRunCheck) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}

--- a/internals/cli/cmd_run-check.go
+++ b/internals/cli/cmd_run-check.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/canonical/go-flags"
+
+	"github.com/canonical/pebble/client"
+)
+
+const cmdCheckSummary = "Run check immediately and get the status"
+const cmdCheckDescription = `
+The check command runs a check immediately and return the status.
+`
+
+type cmdCheck struct {
+	client *client.Client
+
+	Positional struct {
+		Check string `positional-arg-name:"<check>" required:"1"`
+	} `positional-args:"yes"`
+}
+
+func init() {
+	AddCommand(&CmdInfo{
+		Name:        "run-check",
+		Summary:     cmdCheckSummary,
+		Description: cmdCheckDescription,
+		New: func(opts *CmdOptions) flags.Commander {
+			return &cmdCheck{client: opts.Client}
+		},
+	})
+}
+
+func (cmd *cmdCheck) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	opts := client.CheckPayload{
+		Action: "run",
+		Check:  cmd.Positional.Check,
+	}
+	status, err := cmd.client.RunCheck(&opts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(Stdout, status)
+	return nil
+}

--- a/internals/cli/cmd_run-check.go
+++ b/internals/cli/cmd_run-check.go
@@ -51,9 +51,8 @@ func (cmd *cmdRunCheck) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
-	opts := client.CheckPayload{
-		Action: "run",
-		Check:  cmd.Positional.Check,
+	opts := client.RunCheckPayload{
+		Check: cmd.Positional.Check,
 	}
 	status, err := cmd.client.RunCheck(&opts)
 	if err != nil {

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -94,7 +94,7 @@ var API = []*Command{{
 	GET:        v1GetChecks,
 }, {
 	Path:        "/v1/checks/run",
-	WriteAccess: UserAccess{},
+	WriteAccess: AdminAccess{},
 	POST:        v1PostChecksRun,
 }, {
 	Path:        "/v1/notices",

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -89,9 +89,11 @@ var API = []*Command{{
 	WriteAccess: AdminAccess{},
 	POST:        v1PostSignals,
 }, {
-	Path:       "/v1/checks",
-	ReadAccess: UserAccess{},
-	GET:        v1GetChecks,
+	Path:        "/v1/checks",
+	ReadAccess:  UserAccess{},
+	WriteAccess: UserAccess{},
+	GET:         v1GetChecks,
+	POST:        v1PostChecks,
 }, {
 	Path:        "/v1/notices",
 	ReadAccess:  UserAccess{},

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -89,11 +89,13 @@ var API = []*Command{{
 	WriteAccess: AdminAccess{},
 	POST:        v1PostSignals,
 }, {
-	Path:        "/v1/checks",
-	ReadAccess:  UserAccess{},
+	Path:       "/v1/checks",
+	ReadAccess: UserAccess{},
+	GET:        v1GetChecks,
+}, {
+	Path:        "/v1/checks/run",
 	WriteAccess: UserAccess{},
-	GET:         v1GetChecks,
-	POST:        v1PostChecks,
+	POST:        v1PostChecksRun,
 }, {
 	Path:        "/v1/notices",
 	ReadAccess:  UserAccess{},

--- a/internals/daemon/api_changes.go
+++ b/internals/daemon/api_changes.go
@@ -243,7 +243,7 @@ func v1PostChange(c *Command, r *http.Request, _ *UserState) Response {
 	}
 
 	if reqData.Action != "abort" {
-		return BadRequest("change action %q is unsupported", reqData.Action)
+		return BadRequest("invalid action %q", reqData.Action)
 	}
 
 	if chg.Status().Ready() {

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -16,6 +16,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/canonical/x-go/strutil"
@@ -83,12 +84,12 @@ func v1PostChecksRun(c *Command, r *http.Request, _ *UserState) Response {
 
 	check, ok := c.d.overlord.PlanManager().Plan().Checks[payload.Check]
 	if !ok {
-		return SyncResponse("check not found")
+		return NotFound("cannot find check with name %q", payload.Check)
 	}
 
 	err := c.d.overlord.CheckManager().RunCheck(r.Context(), check)
 	if err != nil {
 		return SyncResponse(err)
 	}
-	return SyncResponse("check passed")
+	return SyncResponse(fmt.Sprintf("Check %q succeeded.", payload.Check))
 }

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -91,7 +91,7 @@ func v1PostChecksRun(c *Command, r *http.Request, _ *UserState) Response {
 	checkMgr := c.d.overlord.CheckManager()
 	err := checkMgr.RunCheck(r.Context(), check)
 	if err != nil {
-		return InternalError("%v", err)
+		return BadGateway("%v", err)
 	}
 
 	return SyncResponse(fmt.Sprintf("Check %q succeeded.", payload.Check))

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -79,17 +79,20 @@ func v1PostChecksRun(c *Command, r *http.Request, _ *UserState) Response {
 	}
 
 	if payload.Check == "" {
-		return BadRequest("no check provided")
+		return BadRequest("must specify check name")
 	}
 
-	check, ok := c.d.overlord.PlanManager().Plan().Checks[payload.Check]
+	plan := c.d.overlord.PlanManager().Plan()
+	check, ok := plan.Checks[payload.Check]
 	if !ok {
 		return NotFound("cannot find check with name %q", payload.Check)
 	}
 
-	err := c.d.overlord.CheckManager().RunCheck(r.Context(), check)
+	checkMgr := c.d.overlord.CheckManager()
+	err := checkMgr.RunCheck(r.Context(), check)
 	if err != nil {
-		return SyncResponse(err)
+		return InternalError("%v", err)
 	}
+
 	return SyncResponse(fmt.Sprintf("Check %q succeeded.", payload.Check))
 }

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -15,6 +15,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/canonical/x-go/strutil"
@@ -65,4 +66,35 @@ func v1GetChecks(c *Command, r *http.Request, _ *UserState) Response {
 		}
 	}
 	return SyncResponse(infos)
+}
+
+func v1PostChecks(c *Command, r *http.Request, _ *UserState) Response {
+	var payload struct {
+		Action string `json:"action"`
+		Check  string `json:"check"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&payload); err != nil {
+		return BadRequest("cannot decode data from request body: %v", err)
+	}
+	switch payload.Action {
+	case "run":
+		if payload.Check == "" {
+			return BadRequest("no check to %s provided", payload.Action)
+		}
+
+		check, ok := c.d.overlord.PlanManager().Plan().Checks[payload.Check]
+		if !ok {
+			return SyncResponse("check not found")
+		}
+
+		err := c.d.overlord.CheckManager().RunCheck(r.Context(), check)
+		if err != nil {
+			return SyncResponse(err)
+		}
+		return SyncResponse("check passed")
+
+	default:
+		return BadRequest("action %s not supported", payload.Action)
+	}
 }

--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -182,7 +182,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 		sort.Strings(services)
 		payload.Services = services
 	default:
-		return BadRequest("action %q is unsupported", payload.Action)
+		return BadRequest("invalid action %q", payload.Action)
 	}
 	if err != nil {
 		return BadRequest("cannot %s services: %v", payload.Action, err)

--- a/internals/daemon/response.go
+++ b/internals/daemon/response.go
@@ -204,4 +204,5 @@ var (
 	MethodNotAllowed = makeErrorResponder(http.StatusMethodNotAllowed)
 	InternalError    = makeErrorResponder(http.StatusInternalServerError)
 	GatewayTimeout   = makeErrorResponder(http.StatusGatewayTimeout)
+	BadGateway       = makeErrorResponder(http.StatusBadGateway)
 )

--- a/internals/overlord/checkstate/handlers.go
+++ b/internals/overlord/checkstate/handlers.go
@@ -186,7 +186,6 @@ func pluralise(n int, singular, plural string) string {
 }
 
 func (m *CheckManager) RunCheck(ctx context.Context, check *plan.Check) error {
-	logger.Debugf("Performing check %q", check.Name)
 	chk := newChecker(check)
 	return runCheck(ctx, chk, check.Timeout.Value)
 }

--- a/internals/overlord/checkstate/handlers.go
+++ b/internals/overlord/checkstate/handlers.go
@@ -184,3 +184,9 @@ func pluralise(n int, singular, plural string) string {
 	}
 	return fmt.Sprintf("%d %s", n, plural)
 }
+
+func (m *CheckManager) RunCheck(ctx context.Context, check *plan.Check) error {
+	logger.Debugf("Performing check %q", check.Name)
+	chk := newChecker(check)
+	return runCheck(ctx, chk, check.Timeout.Value)
+}


### PR DESCRIPTION
Some notes (will delete later):

- [x] use req.Context()
- [x] something on the check manager
- [x] RunCheck(ctx context.Context, checkName string) error
- [x] get the config from plan.checks
- [x] POST /v1/checks {"action": "run", "check": "chk1"}
- [x] subcommand run-check (stop-checks/start-checks)
- [x] parse plan manager to check manager `PlanManager.Plan() *Plan`