### PR TITLE
fix: change "20x" in HTTP health check error messages to "2xx"

### DIFF
--- a/docs/reference/layer-specification.md
+++ b/docs/reference/layer-specification.md
@@ -164,7 +164,7 @@ checks:
         threshold: <failure threshold>
 
         # Configures an HTTP check, which is successful if a GET to the
-        # specified URL returns a 20x status code.
+        # specified URL returns a 2xx status code.
         #
         # Only one of "http", "tcp", or "exec" may be specified.
         http:

--- a/internals/overlord/checkstate/checkers.go
+++ b/internals/overlord/checkstate/checkers.go
@@ -41,7 +41,7 @@ const (
 	execWaitDelay = time.Second
 )
 
-// httpChecker is a checker that ensures an HTTP GET at a specified URL returns 20x.
+// httpChecker is a checker that ensures an HTTP GET at a specified URL returns 2xx.
 type httpChecker struct {
 	name    string
 	url     string
@@ -77,7 +77,7 @@ func (c *httpChecker) check(ctx context.Context) error {
 			details = strings.Join(lines, "\n")
 		}
 		return &detailsError{
-			error:   fmt.Errorf("non-20x status code %d", response.StatusCode),
+			error:   fmt.Errorf("non-2xx status code %d", response.StatusCode),
 			details: details,
 		}
 	}

--- a/internals/overlord/checkstate/checkers_test.go
+++ b/internals/overlord/checkstate/checkers_test.go
@@ -72,17 +72,17 @@ func (s *CheckersSuite) TestHTTP(c *C) {
 	c.Assert(headers.Get("X-Name"), Equals, "Bob Smith")
 	c.Assert(headers.Get("User-Agent"), Equals, "pebble-test")
 
-	// Non-20x status code returns error
+	// Non-2xx status code returns error
 	chk = &httpChecker{url: server.URL + "/404"}
 	err = chk.check(context.Background())
-	c.Assert(err, ErrorMatches, "non-20x status code 404")
+	c.Assert(err, ErrorMatches, "non-2xx status code 404")
 	c.Assert(path, Equals, "/404")
 
-	// In case of non-20x status, short response body is fully included in error details
+	// In case of non-2xx status, short response body is fully included in error details
 	response = "error details"
 	chk = &httpChecker{url: server.URL + "/500"}
 	err = chk.check(context.Background())
-	c.Assert(err, ErrorMatches, "non-20x status code 500")
+	c.Assert(err, ErrorMatches, "non-2xx status code 500")
 	detailsErr, ok := err.(*detailsError)
 	c.Assert(ok, Equals, true)
 	c.Assert(detailsErr.Details(), Equals, "error details")
@@ -95,7 +95,7 @@ func (s *CheckersSuite) TestHTTP(c *C) {
 	response = output.String()
 	chk = &httpChecker{url: server.URL + "/500"}
 	err = chk.check(context.Background())
-	c.Assert(err, ErrorMatches, "non-20x status code 500")
+	c.Assert(err, ErrorMatches, "non-2xx status code 500")
 	detailsErr, ok = err.(*detailsError)
 	c.Assert(ok, Equals, true)
 	c.Assert(detailsErr.Details(), Matches, `(?s)line 1\n.*line 5\n\(\.\.\.\)`)


### PR DESCRIPTION
This was a bug. The code looks for any non-2xx HTTP status code, not just non-20x.

Also fix it in the layer reference doc and code comments.