### PR TITLE
chore: bump documentation dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,32 +4,32 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras .sphinx/requirements.txt
 #
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
-anyio==4.4.0
+anyio==4.8.0
     # via
     #   starlette
     #   watchfiles
-attrs==24.2.0
+attrs==25.1.0
     # via
     #   jsonschema
     #   referencing
-babel==2.15.0
+babel==2.17.0
     # via sphinx
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.1
     # via
     #   canonical-sphinx-extensions
     #   furo
     #   pyspelling
-bracex==2.4
+bracex==2.5.post1
     # via wcmatch
-canonical-sphinx-extensions==0.0.21
+canonical-sphinx-extensions==0.0.23
     # via -r .sphinx/requirements.txt
-certifi==2024.2.2
+certifi==2025.1.31
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via uvicorn
 colorama==0.4.6
     # via sphinx-autobuild
@@ -42,23 +42,25 @@ docutils==0.21.2
     #   sphinx
     #   sphinx-mdinclude
     #   sphinx-tabs
-furo==2024.5.6
+furo==2024.8.6
     # via -r .sphinx/requirements.txt
-gitdb==4.0.11
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.43
-    # via -r .sphinx/requirements.txt
+gitpython==3.1.44
+    # via
+    #   -r .sphinx/requirements.txt
+    #   canonical-sphinx-extensions
 h11==0.14.0
     # via uvicorn
 html5lib==1.1
     # via pyspelling
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   myst-parser
     #   sphinx
@@ -68,29 +70,29 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 linkify-it-py==2.0.3
     # via -r .sphinx/requirements.txt
-lxml==5.2.2
+lxml==5.3.0
     # via pyspelling
-markdown==3.6
+markdown==3.7
     # via pyspelling
 markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
     #   myst-parser
-markupsafe==2.1.5
+markupsafe==3.0.2
     # via jinja2
-mdit-py-plugins==0.4.1
+mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.0.2
+mistune==3.1.1
     # via sphinx-mdinclude
-myst-parser==3.0.1
+myst-parser==4.0.0
     # via -r .sphinx/requirements.txt
-packaging==24.0
+packaging==24.2
     # via sphinx
 picobox==4.0.0
     # via sphinxcontrib-openapi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   furo
     #   sphinx
@@ -98,16 +100,16 @@ pygments==2.18.0
     #   sphinx-tabs
 pyspelling==2.10
     # via -r .sphinx/requirements.txt
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   myst-parser
     #   pyspelling
     #   sphinxcontrib-openapi
-referencing==0.35.1
+referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.2
+requests==2.32.3
     # via
     #   canonical-sphinx-extensions
     #   sphinx
@@ -115,21 +117,21 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-six==1.16.0
+six==1.17.0
     # via
     #   html5lib
     #   sphinxcontrib-httpdomain
-smmap==5.0.1
+smmap==5.0.2
     # via gitdb
 sniffio==1.3.1
     # via anyio
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via
     #   beautifulsoup4
     #   pyspelling
-sphinx==7.3.7
+sphinx==8.1.3
     # via
     #   -r .sphinx/requirements.txt
     #   canonical-sphinx-extensions
@@ -146,25 +148,25 @@ sphinx==7.3.7
     #   sphinxcontrib-jquery
     #   sphinxcontrib-openapi
     #   sphinxext-opengraph
-sphinx-autobuild==2024.4.16
+sphinx-autobuild==2024.10.3
     # via -r .sphinx/requirements.txt
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
     # via -r .sphinx/requirements.txt
-sphinx-design==0.6.0
+sphinx-design==0.6.1
     # via -r .sphinx/requirements.txt
 sphinx-mdinclude==0.6.2
     # via sphinxcontrib-openapi
-sphinx-notfound-page==1.0.2
+sphinx-notfound-page==1.1.0
     # via -r .sphinx/requirements.txt
-sphinx-tabs==3.4.5
+sphinx-tabs==3.4.7
     # via -r .sphinx/requirements.txt
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-httpdomain==1.8.1
     # via sphinxcontrib-openapi
@@ -174,27 +176,32 @@ sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-openapi==0.8.4
     # via -r .sphinx/requirements.txt
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxext-opengraph==0.9.1
     # via -r .sphinx/requirements.txt
-starlette==0.37.2
+starlette==0.45.3
     # via sphinx-autobuild
+typing-extensions==4.12.2
+    # via
+    #   anyio
+    #   beautifulsoup4
+    #   referencing
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.2.1
+urllib3==2.3.0
     # via requests
-uvicorn==0.29.0
+uvicorn==0.34.0
     # via sphinx-autobuild
-watchfiles==0.22.0
+watchfiles==1.0.4
     # via
     #   -r .sphinx/requirements.txt
     #   sphinx-autobuild
-wcmatch==8.5.2
+wcmatch==10.0
     # via pyspelling
 webencodings==0.5.1
     # via html5lib
-websockets==12.0
+websockets==14.2
     # via sphinx-autobuild


### PR DESCRIPTION
Primarily this pulls in security fixes for starlette, jinja, urllib3, and certifi, but it updates all the dependencies while we're doing this. The docs build with no errors and look ok with a cursory review.