### PR TITLE
chore: replace interface{} with any

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,10 @@ jobs:
         go fmt ./...
         git diff --exit-code
 
+    - name: Ensure no use of empty interface (should be any)
+      run: |
+        ! egrep -R --exclude-dir .git 'interface\{\}'
+
   docs:
     runs-on: ubuntu-latest
 

--- a/client/changes.go
+++ b/client/changes.go
@@ -44,7 +44,7 @@ type Change struct {
 var ErrNoData = fmt.Errorf("data entry not found")
 
 // Get unmarshals into value the kind-specific data with the provided key.
-func (c *Change) Get(key string, value interface{}) error {
+func (c *Change) Get(key string, value any) error {
 	raw := c.data[key]
 	if raw == nil {
 		return ErrNoData
@@ -68,7 +68,7 @@ type Task struct {
 }
 
 // Get unmarshals into value the kind-specific data with the provided key.
-func (t *Task) Get(key string, value interface{}) error {
+func (t *Task) Get(key string, value any) error {
 	raw := t.Data[key]
 	if raw == nil {
 		return ErrNoData

--- a/client/checks_test.go
+++ b/client/checks_test.go
@@ -78,7 +78,7 @@ func (cs *clientSuite) TestStartChecks(c *check.C) {
 	c.Assert(cs.req.Method, check.Equals, "POST")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v1/checks")
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "start")
@@ -103,7 +103,7 @@ func (cs *clientSuite) TestStopChecks(c *check.C) {
 	c.Assert(cs.req.Method, check.Equals, "POST")
 	c.Assert(cs.req.URL.Path, check.Equals, "/v1/checks")
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "stop")

--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,7 @@ type RequestResponse struct {
 // DecodeResult decodes the endpoint-specific result payload that is included as part of
 // sync and async request responses. The decoding is performed with the standard JSON
 // package, so the usual field tags should be used to prepare the type for decoding.
-func (resp *RequestResponse) DecodeResult(result interface{}) error {
+func (resp *RequestResponse) DecodeResult(result any) error {
 	reader := bytes.NewReader(resp.Result)
 	dec := json.NewDecoder(reader)
 	dec.UseNumber()
@@ -165,7 +165,7 @@ type clientWebsocket interface {
 }
 
 type jsonWriter interface {
-	WriteJSON(v interface{}) error
+	WriteJSON(v any) error
 }
 
 func New(config *Config) (*Client, error) {
@@ -386,7 +386,7 @@ func (rq *defaultRequester) Do(ctx context.Context, opts *RequestOptions) (*Requ
 	}, nil
 }
 
-func decodeInto(reader io.Reader, v interface{}) error {
+func decodeInto(reader io.Reader, v any) error {
 	dec := json.NewDecoder(reader)
 	if err := dec.Decode(v); err != nil {
 		r := dec.Buffered()
@@ -413,9 +413,9 @@ type response struct {
 
 // Error is the real value of response.Result when an error occurs.
 type Error struct {
-	Kind    string      `json:"kind"`
-	Value   interface{} `json:"value"`
-	Message string      `json:"message"`
+	Kind    string `json:"kind"`
+	Value   any    `json:"value"`
+	Message string `json:"message"`
 
 	StatusCode int
 }
@@ -497,12 +497,12 @@ func (client *Client) SysInfo() (*SysInfo, error) {
 }
 
 type debugAction struct {
-	Action string      `json:"action"`
-	Params interface{} `json:"params,omitempty"`
+	Action string `json:"action"`
+	Params any    `json:"params,omitempty"`
 }
 
 // DebugPost sends a POST debug action to the server with the provided parameters.
-func (client *Client) DebugPost(action string, params interface{}, result interface{}) error {
+func (client *Client) DebugPost(action string, params any, result any) error {
 	body, err := json.Marshal(debugAction{
 		Action: action,
 		Params: params,
@@ -528,7 +528,7 @@ func (client *Client) DebugPost(action string, params interface{}, result interf
 }
 
 // DebugGet sends a GET debug action to the server with the provided parameters.
-func (client *Client) DebugGet(action string, result interface{}, params map[string]string) error {
+func (client *Client) DebugGet(action string, result any, params map[string]string) error {
 	urlParams := url.Values{"action": []string{action}}
 	for k, v := range params {
 		urlParams.Set(k, v)

--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,7 @@ type RequestResponse struct {
 // DecodeResult decodes the endpoint-specific result payload that is included as part of
 // sync and async request responses. The decoding is performed with the standard JSON
 // package, so the usual field tags should be used to prepare the type for decoding.
-func (resp *RequestResponse) DecodeResult(result any) error {
+func (resp *RequestResponse) DecodeResult(result interface{}) error {
 	reader := bytes.NewReader(resp.Result)
 	dec := json.NewDecoder(reader)
 	dec.UseNumber()

--- a/client/client.go
+++ b/client/client.go
@@ -74,7 +74,7 @@ type RequestResponse struct {
 // DecodeResult decodes the endpoint-specific result payload that is included as part of
 // sync and async request responses. The decoding is performed with the standard JSON
 // package, so the usual field tags should be used to prepare the type for decoding.
-func (resp *RequestResponse) DecodeResult(result interface{}) error {
+func (resp *RequestResponse) DecodeResult(result any) error {
 	reader := bytes.NewReader(resp.Result)
 	dec := json.NewDecoder(reader)
 	dec.UseNumber()

--- a/client/exec_test.go
+++ b/client/exec_test.go
@@ -73,8 +73,8 @@ func (s *execSuite) TestExitZero(c *C) {
 		Command: []string{"true"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"true"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"true"},
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)
@@ -85,8 +85,8 @@ func (s *execSuite) TestExitNonZero(c *C) {
 		Command: []string{"false"},
 	}
 	process, reqBody := s.exec(c, opts, 1)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"false"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"false"},
 	})
 	err := s.wait(c, process)
 	exitError, ok := err.(*client.ExitError)
@@ -100,8 +100,8 @@ func (s *execSuite) TestTimeout(c *C) {
 		Timeout: time.Second,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"sleep", "3"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"sleep", "3"},
 		"timeout": "1s",
 	})
 	err := s.wait(c, process)
@@ -126,9 +126,9 @@ func (s *execSuite) TestOtherOptions(c *C) {
 		Stderr:      io.Discard,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command":      []interface{}{"echo", "foo"},
-		"environment":  map[string]interface{}{"K1": "V1", "K2": "V2"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command":      []any{"echo", "foo"},
+		"environment":  map[string]any{"K1": "V1", "K2": "V2"},
 		"working-dir":  "WD",
 		"user-id":      1000.0,
 		"user":         "bob",
@@ -148,8 +148,8 @@ func (s *execSuite) TestWaitChangeError(c *C) {
 		Command: []string{"foo"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"foo"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"foo"},
 	})
 
 	// Make /v1/changes/{id}/wait return a "change error"
@@ -173,8 +173,8 @@ func (s *execSuite) TestWaitTasksError(c *C) {
 		Command: []string{"foo"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"foo"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"foo"},
 	})
 
 	// Make /v1/changes/{id}/wait return no tasks
@@ -197,8 +197,8 @@ func (s *execSuite) TestWaitExitCodeError(c *C) {
 		Command: []string{"foo"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"foo"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"foo"},
 	})
 
 	// Make /v1/changes/{id}/wait return no exit code
@@ -225,8 +225,8 @@ func (s *execSuite) TestSendSignal(c *C) {
 		Command: []string{"server"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"server"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"server"},
 	})
 	err := process.SendSignal("SIGHUP")
 	c.Assert(err, IsNil)
@@ -243,8 +243,8 @@ func (s *execSuite) TestSendResize(c *C) {
 		Command: []string{"server"},
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"server"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"server"},
 	})
 	err := process.SendResize(150, 50)
 	c.Assert(err, IsNil)
@@ -268,8 +268,8 @@ func (s *execSuite) TestOutputCombined(c *C) {
 		Stdout:  &stdout,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)
@@ -293,8 +293,8 @@ func (s *execSuite) TestOutputSplit(c *C) {
 		Stderr:  &stderr,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command":      []interface{}{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command":      []any{"/bin/sh", "-c", "echo OUT; echo ERR >err"},
 		"split-stderr": true,
 	})
 	err := s.wait(c, process)
@@ -315,8 +315,8 @@ func (s *execSuite) TestStdinAndStdout(c *C) {
 		Stdout:  &stdout,
 	}
 	process, reqBody := s.exec(c, opts, 0)
-	c.Assert(reqBody, DeepEquals, map[string]interface{}{
-		"command": []interface{}{"awk", "{ print toupper($0) }"},
+	c.Assert(reqBody, DeepEquals, map[string]any{
+		"command": []any{"awk", "{ print toupper($0) }"},
 	})
 	err := s.wait(c, process)
 	c.Assert(err, IsNil)
@@ -360,7 +360,7 @@ func (w *testWebsocket) Close() error {
 	return nil
 }
 
-func (w *testWebsocket) WriteJSON(v interface{}) error {
+func (w *testWebsocket) WriteJSON(v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -369,7 +369,7 @@ func (w *testWebsocket) WriteJSON(v interface{}) error {
 	return nil
 }
 
-func (s *execSuite) exec(c *C, opts *client.ExecOptions, exitCode int) (process *client.ExecProcess, requestBody map[string]interface{}) {
+func (s *execSuite) exec(c *C, opts *client.ExecOptions, exitCode int) (process *client.ExecProcess, requestBody map[string]any) {
 	s.addResponses("123", exitCode)
 	process, err := s.cli.Exec(opts)
 	c.Assert(err, IsNil)

--- a/client/files.go
+++ b/client/files.go
@@ -85,7 +85,7 @@ func (fi *FileInfo) IsDir() bool {
 }
 
 // Sys returns the underlying data source (always nil for client.FileInfo).
-func (fi *FileInfo) Sys() interface{} {
+func (fi *FileInfo) Sys() any {
 	return nil
 }
 

--- a/client/plan_test.go
+++ b/client/plan_test.go
@@ -61,9 +61,9 @@ services:
 		c.Check(cs.req.Method, check.Equals, "POST")
 		c.Check(cs.req.URL.Path, check.Equals, "/v1/layers")
 		c.Check(cs.req.URL.Query(), check.HasLen, 0)
-		var body map[string]interface{}
+		var body map[string]any
 		c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
-		c.Assert(body, check.DeepEquals, map[string]interface{}{
+		c.Assert(body, check.DeepEquals, map[string]any{
 			"action":  "add",
 			"combine": option.combine,
 			"label":   "foo",

--- a/client/services_test.go
+++ b/client/services_test.go
@@ -53,11 +53,11 @@ func (cs *clientSuite) TestStartStop(c *check.C) {
 		c.Check(cs.req.Method, check.Equals, "POST")
 		c.Check(cs.req.URL.Path, check.Equals, "/v1/services")
 
-		var body map[string]interface{}
+		var body map[string]any
 		c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 		c.Check(body, check.HasLen, 2)
 		c.Check(body["action"], check.Equals, action)
-		c.Check(body["services"], check.DeepEquals, []interface{}{"one", "two"})
+		c.Check(body["services"], check.DeepEquals, []any{"one", "two"})
 	}
 }
 
@@ -78,7 +78,7 @@ func (cs *clientSuite) TestAutostart(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/services")
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "autostart")
@@ -130,11 +130,11 @@ func (cs *clientSuite) TestRestart(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/services")
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "restart")
-	c.Check(body["services"], check.DeepEquals, []interface{}{"one", "two"})
+	c.Check(body["services"], check.DeepEquals, []any{"one", "two"})
 }
 
 func (cs *clientSuite) TestReplan(c *check.C) {
@@ -154,7 +154,7 @@ func (cs *clientSuite) TestReplan(c *check.C) {
 	c.Check(cs.req.Method, check.Equals, "POST")
 	c.Check(cs.req.URL.Path, check.Equals, "/v1/services")
 
-	var body map[string]interface{}
+	var body map[string]any
 	c.Assert(json.NewDecoder(cs.req.Body).Decode(&body), check.IsNil)
 	c.Check(body, check.HasLen, 2)
 	c.Check(body["action"], check.Equals, "replan")

--- a/client/signals_test.go
+++ b/client/signals_test.go
@@ -37,11 +37,11 @@ func (cs *clientSuite) TestSignals(c *C) {
 	c.Check(cs.req.Method, Equals, "POST")
 	c.Check(cs.req.URL.Path, Equals, "/v1/signals")
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.NewDecoder(cs.req.Body).Decode(&body)
 	c.Assert(err, IsNil)
-	c.Assert(body, DeepEquals, map[string]interface{}{
+	c.Assert(body, DeepEquals, map[string]any{
 		"signal":   "SIGHUP",
-		"services": []interface{}{"s1", "s2"},
+		"services": []any{"s1", "s2"},
 	})
 }

--- a/internals/cli/cli_test.go
+++ b/internals/cli/cli_test.go
@@ -98,8 +98,8 @@ func (s *BasePebbleSuite) RedirectClientToTestServer(handler func(http.ResponseW
 }
 
 // DecodedRequestBody returns the JSON-decoded body of the request.
-func DecodedRequestBody(c *C, r *http.Request) map[string]interface{} {
-	var body map[string]interface{}
+func DecodedRequestBody(c *C, r *http.Request) map[string]any {
+	var body map[string]any
 	decoder := json.NewDecoder(r.Body)
 	decoder.UseNumber()
 	err := decoder.Decode(&body)
@@ -108,7 +108,7 @@ func DecodedRequestBody(c *C, r *http.Request) map[string]interface{} {
 }
 
 // EncodeResponseBody writes JSON-serialized body to the response writer.
-func EncodeResponseBody(c *C, w http.ResponseWriter, body interface{}) {
+func EncodeResponseBody(c *C, w http.ResponseWriter, body any) {
 	encoder := json.NewEncoder(w)
 	err := encoder.Encode(body)
 	c.Assert(err, IsNil)

--- a/internals/cli/cmd_add_test.go
+++ b/internals/cli/cmd_add_test.go
@@ -52,7 +52,7 @@ services:
 	}
 }`)
 			} else {
-				c.Check(body, check.DeepEquals, map[string]interface{}{
+				c.Check(body, check.DeepEquals, map[string]any{
 					"action":  "add",
 					"combine": combine,
 					"label":   "foo",

--- a/internals/cli/cmd_autostart_test.go
+++ b/internals/cli/cmd_autostart_test.go
@@ -55,7 +55,7 @@ func (s *PebbleSuite) TestAutostart(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "autostart",
 			"services": nil,
 		})
@@ -79,7 +79,7 @@ func (s *PebbleSuite) TestAutostartFailsNoDefaultServices(c *check.C) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "autostart",
 			"services": nil,
 		})
@@ -105,7 +105,7 @@ func (s *PebbleSuite) TestAutostartNoWait(c *check.C) {
 		c.Check(r.URL.Path, check.Not(check.Equals), "/v1/changes/42")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "autostart",
 			"services": nil,
 		})
@@ -136,7 +136,7 @@ func (s *PebbleSuite) TestAutostartFailsGetChange(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "autostart",
 			"services": nil,
 		})

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -193,7 +193,7 @@ func (cmd *cmdEnter) Execute(args []string) error {
 	}
 
 	runReadyCh := make(chan func(), 1)
-	runResultCh := make(chan interface{})
+	runResultCh := make(chan any)
 	var runStop func()
 
 	go func() {

--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -33,7 +33,7 @@ func dumbDedent(s string) string {
 	return s
 }
 
-func writeTemplate(filename string, templateString string, templateData interface{}) {
+func writeTemplate(filename string, templateString string, templateData any) {
 	os.MkdirAll(filepath.Dir(filename), 0755)
 
 	t, err := template.New(filename).Parse(templateString)

--- a/internals/cli/cmd_mkdir_test.go
+++ b/internals/cli/cmd_mkdir_test.go
@@ -39,10 +39,10 @@ func (s *PebbleSuite) TestMkdir(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foo",
 					"make-parents": false,
 					"permissions":  "",
@@ -78,10 +78,10 @@ func (s *PebbleSuite) TestMkdirMakeParents(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foo/bar",
 					"make-parents": true,
 					"permissions":  "",
@@ -109,10 +109,10 @@ func (s *PebbleSuite) TestMkdirPermissions(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foo/bar",
 					"make-parents": false,
 					"permissions":  "755",
@@ -140,10 +140,10 @@ func (s *PebbleSuite) TestMkdirOwnerIDs(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foo/bar",
 					"make-parents": false,
 					"permissions":  "",
@@ -171,10 +171,10 @@ func (s *PebbleSuite) TestMkdirOwnerNames(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foo/bar",
 					"make-parents": false,
 					"permissions":  "",
@@ -202,10 +202,10 @@ func (s *PebbleSuite) TestMkdirFails(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foo",
 					"make-parents": false,
 					"permissions":  "",
@@ -233,10 +233,10 @@ func (s *PebbleSuite) TestMkdirFailsOnDirectory(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "make-dirs",
-			"dirs": []interface{}{
-				map[string]interface{}{
+			"dirs": []any{
+				map[string]any{
 					"path":         "/foobar",
 					"make-parents": false,
 					"permissions":  "",

--- a/internals/cli/cmd_replan_test.go
+++ b/internals/cli/cmd_replan_test.go
@@ -55,7 +55,7 @@ func (s *PebbleSuite) TestReplan(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "replan",
 			"services": nil,
 		})
@@ -79,7 +79,7 @@ func (s *PebbleSuite) TestReplanFailsNoDefaultServices(c *check.C) {
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "replan",
 			"services": nil,
 		})
@@ -105,7 +105,7 @@ func (s *PebbleSuite) TestReplanNoWait(c *check.C) {
 		c.Check(r.URL.Path, check.Not(check.Equals), "/v1/changes/43")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "replan",
 			"services": nil,
 		})
@@ -136,7 +136,7 @@ func (s *PebbleSuite) TestReplanFailsGetChange(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "replan",
 			"services": nil,
 		})

--- a/internals/cli/cmd_restart_test.go
+++ b/internals/cli/cmd_restart_test.go
@@ -47,9 +47,9 @@ func (s *PebbleSuite) TestRestart(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "restart",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -72,9 +72,9 @@ func (s *PebbleSuite) TestRestartFails(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "restart",
-			"services": []interface{}{"srv1", "srv3"},
+			"services": []any{"srv1", "srv3"},
 		})
 
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)
@@ -94,9 +94,9 @@ func (s *PebbleSuite) TestRestartNoWait(c *check.C) {
 		c.Check(r.URL.Path, check.Not(check.Equals), "/v1/changes/44")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "restart",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -125,9 +125,9 @@ func (s *PebbleSuite) TestRestartFailsGetChange(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "restart",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{

--- a/internals/cli/cmd_rm_test.go
+++ b/internals/cli/cmd_rm_test.go
@@ -38,10 +38,10 @@ func (s *PebbleSuite) TestRm(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "remove",
-			"paths": []interface{}{
-				map[string]interface{}{
+			"paths": []any{
+				map[string]any{
 					"path":      "/foo/bar.baz",
 					"recursive": false,
 				},
@@ -64,10 +64,10 @@ func (s *PebbleSuite) TestRmRecursive(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "remove",
-			"paths": []interface{}{
-				map[string]interface{}{
+			"paths": []any{
+				map[string]any{
 					"path":      "/foo/bar",
 					"recursive": true,
 				},
@@ -90,10 +90,10 @@ func (s *PebbleSuite) TestRmFails(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "remove",
-			"paths": []interface{}{
-				map[string]interface{}{
+			"paths": []any{
+				map[string]any{
 					"path":      "/foo/bar.baz",
 					"recursive": false,
 				},
@@ -116,10 +116,10 @@ func (s *PebbleSuite) TestRmFailsOnPath(c *C) {
 		c.Check(r.URL.Path, Equals, "/v1/files")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, DeepEquals, map[string]interface{}{
+		c.Check(body, DeepEquals, map[string]any{
 			"action": "remove",
-			"paths": []interface{}{
-				map[string]interface{}{
+			"paths": []any{
+				map[string]any{
 					"path":      "/foo/bar",
 					"recursive": true,
 				},

--- a/internals/cli/cmd_signal_test.go
+++ b/internals/cli/cmd_signal_test.go
@@ -28,9 +28,9 @@ func (s *PebbleSuite) TestSignalShortName(c *check.C) {
 		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"signal":   "SIGHUP",
-			"services": []interface{}{"s1"},
+			"services": []any{"s1"},
 		})
 		fmt.Fprint(w, `{
     "type": "sync",
@@ -49,9 +49,9 @@ func (s *PebbleSuite) TestSignalFullName(c *check.C) {
 		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"signal":   "SIGHUP",
-			"services": []interface{}{"s2"},
+			"services": []any{"s2"},
 		})
 		fmt.Fprint(w, `{
     "type": "sync",
@@ -70,9 +70,9 @@ func (s *PebbleSuite) TestSignalMultipleServices(c *check.C) {
 		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"signal":   "SIGHUP",
-			"services": []interface{}{"s1", "s2"},
+			"services": []any{"s1", "s2"},
 		})
 		fmt.Fprint(w, `{
     "type": "sync",
@@ -96,9 +96,9 @@ func (s *PebbleSuite) TestSignalServerError(c *check.C) {
 		body := DecodedRequestBody(c, r)
 		c.Check(r.Method, check.Equals, "POST")
 		c.Check(r.URL.Path, check.Equals, "/v1/signals")
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"signal":   "SIGHUP",
-			"services": []interface{}{"s1"},
+			"services": []any{"s1"},
 		})
 		fmt.Fprint(w, `{
 			"type": "error",

--- a/internals/cli/cmd_start-checks_test.go
+++ b/internals/cli/cmd_start-checks_test.go
@@ -29,9 +29,9 @@ func (s *PebbleSuite) TestStartChecks(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/checks")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action": "start",
-			"checks": []interface{}{"chk1", "chk2", "chk3"},
+			"checks": []any{"chk1", "chk2", "chk3"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -54,9 +54,9 @@ func (s *PebbleSuite) TestStartChecksFails(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/checks")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action": "start",
-			"checks": []interface{}{"chk1", "chk3"},
+			"checks": []any{"chk1", "chk3"},
 		})
 
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)

--- a/internals/cli/cmd_start_test.go
+++ b/internals/cli/cmd_start_test.go
@@ -47,9 +47,9 @@ func (s *PebbleSuite) TestStart(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "start",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -72,9 +72,9 @@ func (s *PebbleSuite) TestStartFails(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "start",
-			"services": []interface{}{"srv1", "srv3"},
+			"services": []any{"srv1", "srv3"},
 		})
 
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)
@@ -94,9 +94,9 @@ func (s *PebbleSuite) TestStartNoWait(c *check.C) {
 		c.Check(r.URL.Path, check.Not(check.Equals), "/v1/changes/45")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "start",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -125,9 +125,9 @@ func (s *PebbleSuite) TestStartFailsGetChange(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "start",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{

--- a/internals/cli/cmd_stop-checks_test.go
+++ b/internals/cli/cmd_stop-checks_test.go
@@ -29,9 +29,9 @@ func (s *PebbleSuite) TestStopChecks(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/checks")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action": "stop",
-			"checks": []interface{}{"chk1", "chk2", "chk3"},
+			"checks": []any{"chk1", "chk2", "chk3"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -54,9 +54,9 @@ func (s *PebbleSuite) TestStopChecksFails(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/checks")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action": "stop",
-			"checks": []interface{}{"chk1", "chk3"},
+			"checks": []any{"chk1", "chk3"},
 		})
 
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)

--- a/internals/cli/cmd_stop_test.go
+++ b/internals/cli/cmd_stop_test.go
@@ -47,9 +47,9 @@ func (s *PebbleSuite) TestStop(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "stop",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -72,9 +72,9 @@ func (s *PebbleSuite) TestStopFails(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "stop",
-			"services": []interface{}{"srv1", "srv3"},
+			"services": []any{"srv1", "srv3"},
 		})
 
 		fmt.Fprintf(w, `{"type": "error", "result": {"message": "could not foo"}}`)
@@ -94,9 +94,9 @@ func (s *PebbleSuite) TestStopNoWait(c *check.C) {
 		c.Check(r.URL.Path, check.Not(check.Equals), "/v1/changes/46")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "stop",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{
@@ -125,9 +125,9 @@ func (s *PebbleSuite) TestStopFailsGetChange(c *check.C) {
 		c.Check(r.URL.Path, check.Equals, "/v1/services")
 
 		body := DecodedRequestBody(c, r)
-		c.Check(body, check.DeepEquals, map[string]interface{}{
+		c.Check(body, check.DeepEquals, map[string]any{
 			"action":   "stop",
-			"services": []interface{}{"srv1", "srv2"},
+			"services": []any{"srv1", "srv2"},
 		})
 
 		fmt.Fprintf(w, `{

--- a/internals/cli/format_test.go
+++ b/internals/cli/format_test.go
@@ -91,7 +91,7 @@ func (s *PebbleSuite) TestColorTable(c *check.C) {
 	type T struct {
 		isTTY         bool
 		noColor, term string
-		expected      interface{}
+		expected      any
 		desc          string
 	}
 

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -123,7 +123,7 @@ func v1SystemInfo(c *Command, r *http.Request, _ *UserState) Response {
 	state := c.d.overlord.State()
 	state.Lock()
 	defer state.Unlock()
-	result := map[string]interface{}{
+	result := map[string]any{
 		"version": c.d.Version,
 		"boot-id": restart.BootID(state),
 	}

--- a/internals/daemon/api_changes_test.go
+++ b/internals/daemon/api_changes_test.go
@@ -222,39 +222,39 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "install",
 		"summary":    "install...",
 		"status":     "Do",
 		"ready":      false,
 		"spawn-time": "2016-04-21T01:02:03Z",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "download",
 				"summary":    "1...",
 				"status":     "Do",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
-				"data": map[string]interface{}{
+				"data": map[string]any{
 					"foo": "bar",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "activate",
 				"summary":    "2...",
 				"status":     "Do",
-				"progress":   map[string]interface{}{"label": "", "done": 0., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 0., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 			},
 		},
-		"data": map[string]interface{}{
+		"data": map[string]any{
 			"n": float64(42),
 		},
 	})
@@ -298,10 +298,10 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"id":         ids[0],
 		"kind":       "install",
 		"summary":    "install...",
@@ -309,23 +309,23 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 		"ready":      true,
 		"spawn-time": "2016-04-21T01:02:03Z",
 		"ready-time": "2016-04-21T01:02:03Z",
-		"tasks": []interface{}{
-			map[string]interface{}{
+		"tasks": []any{
+			map[string]any{
 				"id":         ids[2],
 				"kind":       "download",
 				"summary":    "1...",
 				"status":     "Hold",
-				"log":        []interface{}{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"log":        []any{"2016-04-21T01:02:03Z INFO l11", "2016-04-21T01:02:03Z INFO l12"},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":         ids[3],
 				"kind":       "activate",
 				"summary":    "2...",
 				"status":     "Hold",
-				"progress":   map[string]interface{}{"label": "", "done": 1., "total": 1.},
+				"progress":   map[string]any{"label": "", "done": 1., "total": 1.},
 				"spawn-time": "2016-04-21T01:02:03Z",
 				"ready-time": "2016-04-21T01:02:03Z",
 			},
@@ -363,10 +363,10 @@ func (s *apiSuite) TestStateChangeAbortIsReady(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeError)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	c.Check(body["result"], check.DeepEquals, map[string]interface{}{
+	c.Check(body["result"], check.DeepEquals, map[string]any{
 		"message": fmt.Sprintf("cannot abort change %s with nothing pending", ids[0]),
 	})
 }
@@ -402,10 +402,10 @@ func (s *apiSuite) TestWaitChangeSuccess(c *check.C) {
 	c.Check(rsp.Type, check.Equals, ResponseTypeSync)
 	c.Check(rsp.Result, check.NotNil)
 
-	var body map[string]interface{}
+	var body map[string]any
 	err := json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, check.IsNil)
-	result := body["result"].(map[string]interface{})
+	result := body["result"].(map[string]any)
 	c.Check(result["id"].(string), check.Equals, changeID)
 	c.Check(result["kind"].(string), check.Equals, "exec")
 	c.Check(result["ready"].(bool), check.Equals, true)

--- a/internals/daemon/api_checks_test.go
+++ b/internals/daemon/api_checks_test.go
@@ -56,10 +56,10 @@ checks:
 		rsp, body := s.getChecks(c, "")
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
-		expected := []interface{}{
-			map[string]interface{}{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-			map[string]interface{}{"name": "chk2", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C1"},
-			map[string]interface{}{"name": "chk3", "status": "up", "threshold": 3.0, "change-id": "C2"},
+		expected := []any{
+			map[string]any{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk2", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C1"},
+			map[string]any{"name": "chk3", "status": "up", "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -75,34 +75,34 @@ checks:
 	rsp, body := s.getChecks(c, "?names=chk1&names=chk3")
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
-	c.Check(body["result"], DeepEquals, []interface{}{
-		map[string]interface{}{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]interface{}{"name": "chk3", "status": "up", "threshold": 3.0, "change-id": "C1"},
+	c.Check(body["result"], DeepEquals, []any{
+		map[string]any{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "status": "up", "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with names filter (comma-separated values)
 	rsp, body = s.getChecks(c, "?names=chk1,chk3")
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
-	c.Check(body["result"], DeepEquals, []interface{}{
-		map[string]interface{}{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]interface{}{"name": "chk3", "status": "up", "threshold": 3.0, "change-id": "C1"},
+	c.Check(body["result"], DeepEquals, []any{
+		map[string]any{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "status": "up", "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with level filter
 	rsp, body = s.getChecks(c, "?level=alive")
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
-	c.Check(body["result"], DeepEquals, []interface{}{
-		map[string]interface{}{"name": "chk2", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C0"},
+	c.Check(body["result"], DeepEquals, []any{
+		map[string]any{"name": "chk2", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C0"},
 	})
 
 	// Request with names and level filters
 	rsp, body = s.getChecks(c, "?level=ready&names=chk1")
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
-	c.Check(body["result"], DeepEquals, []interface{}{
-		map[string]interface{}{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+	c.Check(body["result"], DeepEquals, []any{
+		map[string]any{"name": "chk1", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 	})
 }
 
@@ -114,7 +114,7 @@ func (s *apiSuite) TestChecksGetInvalidLevel(c *C) {
 	c.Check(rsp.Status, Equals, 400)
 	c.Check(rsp.Type, Equals, ResponseTypeError)
 	c.Check(rsp.Result, NotNil)
-	c.Check(body["result"], DeepEquals, map[string]interface{}{
+	c.Check(body["result"], DeepEquals, map[string]any{
 		"message": `level must be "alive" or "ready"`,
 	})
 }
@@ -126,24 +126,24 @@ func (s *apiSuite) TestChecksEmpty(c *C) {
 	rsp, body := s.getChecks(c, "")
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
-	c.Check(body["result"], DeepEquals, []interface{}{}) // should be [] rather than null
+	c.Check(body["result"], DeepEquals, []any{}) // should be [] rather than null
 }
 
-func (s *apiSuite) getChecks(c *C, query string) (*resp, map[string]interface{}) {
+func (s *apiSuite) getChecks(c *C, query string) (*resp, map[string]any) {
 	req, err := http.NewRequest("GET", "/v1/checks"+query, nil)
 	c.Assert(err, IsNil)
 	rsp := v1GetChecks(apiCmd("/v1/checks"), req, nil).(*resp)
 	rec := httptest.NewRecorder()
 	rsp.ServeHTTP(rec, req)
 	c.Check(rec.Code, Equals, rsp.Status)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, IsNil)
 
 	// Standardise the change-id fields before comparison as these can vary.
-	if results, ok := body["result"].([]interface{}); ok {
+	if results, ok := body["result"].([]any); ok {
 		for i, result := range results {
-			resultMap := result.(map[string]interface{})
+			resultMap := result.(map[string]any)
 			c.Check(resultMap["change-id"].(string), Not(Equals), "")
 			resultMap["change-id"] = fmt.Sprintf("C%d", i)
 		}

--- a/internals/daemon/api_exec.go
+++ b/internals/daemon/api_exec.go
@@ -112,7 +112,7 @@ func v1PostExec(c *Command, req *http.Request, _ *UserState) Response {
 
 	stateEnsureBefore(st, 0) // start it right away
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"environment": metadata.Environment,
 		"task-id":     metadata.TaskID,
 		"working-dir": metadata.WorkingDir,

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -437,10 +437,10 @@ func (s *execSuite) TestUserGroupError(c *C) {
 }
 
 type execResponse struct {
-	StatusCode int                    `json:"status-code"`
-	Type       string                 `json:"type"`
-	Change     string                 `json:"change"`
-	Result     map[string]interface{} `json:"result"`
+	StatusCode int            `json:"status-code"`
+	Type       string         `json:"type"`
+	Change     string         `json:"change"`
+	Result     map[string]any `json:"result"`
 }
 
 // execRequest directly calls exec via the ServeHTTP endpoint, rather than

--- a/internals/daemon/api_files_test.go
+++ b/internals/daemon/api_files_test.go
@@ -1210,7 +1210,7 @@ func assertFile(c *C, path string, perm os.FileMode, content string) {
 
 // Read a multipart HTTP response body, parse JSON in "response" field to result,
 // and return map of file field to file content.
-func readMultipart(c *C, response *http.Response, body io.Reader, result interface{}) map[string]string {
+func readMultipart(c *C, response *http.Response, body io.Reader, result any) map[string]string {
 	contentType := response.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	c.Assert(err, IsNil)
@@ -1271,7 +1271,7 @@ func assertError(c *C, body io.Reader, status int, kind, message string) {
 	c.Assert(r.Status, Equals, status)
 	c.Assert(r.StatusText, Equals, http.StatusText(status))
 	c.Assert(r.Type, Equals, ResponseTypeError)
-	result := r.Result.(map[string]interface{})
+	result := r.Result.(map[string]any)
 	if kind != "" {
 		c.Assert(result["kind"], Equals, kind)
 	}
@@ -1292,8 +1292,8 @@ func writeTempFile(c *C, dir, filename, content string, perm os.FileMode) {
 	c.Assert(err, IsNil)
 }
 
-func assertListResult(c *C, result interface{}, index int, typ, dir, name, perms string, size int) {
-	x := result.([]interface{})[index].(map[string]interface{})
+func assertListResult(c *C, result any, index int, typ, dir, name, perms string, size int) {
+	x := result.([]any)[index].(map[string]any)
 	c.Assert(x["type"], Equals, typ)
 	c.Assert(x["name"], Equals, name)
 	c.Assert(x["path"], Equals, filepath.Join(dir, name))

--- a/internals/daemon/api_health_test.go
+++ b/internals/daemon/api_health_test.go
@@ -186,21 +186,21 @@ func (s *healthSuite) TestNames(c *C) {
 	// With only an inactive check, this is the same as no checks, so healthy.
 	status, response = serveHealth(c, "GET", "/v1/health?names=chk4", nil)
 	c.Assert(status, Equals, 200)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": true,
 	})
 
 	// One healthy check, one that should be ignored.
 	status, response = serveHealth(c, "GET", "/v1/health?names=chk2,chk4", nil)
 	c.Assert(status, Equals, 200)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": true,
 	})
 
 	// One unhealthy check, one that should be ignored.
 	status, response = serveHealth(c, "GET", "/v1/health?names=chk1,chk4", nil)
 	c.Assert(status, Equals, 502)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": false,
 	})
 }

--- a/internals/daemon/api_health_test.go
+++ b/internals/daemon/api_health_test.go
@@ -44,7 +44,7 @@ func (s *healthSuite) TestNoChecks(c *C) {
 	status, response := serveHealth(c, "GET", "/v1/health", nil)
 
 	c.Assert(status, Equals, 200)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": true,
 	})
 }
@@ -61,7 +61,7 @@ func (s *healthSuite) TestHealthy(c *C) {
 	status, response := serveHealth(c, "GET", "/v1/health", nil)
 
 	c.Assert(status, Equals, 200)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": true,
 	})
 }
@@ -79,7 +79,7 @@ func (s *healthSuite) TestUnhealthy(c *C) {
 	status, response := serveHealth(c, "GET", "/v1/health", nil)
 
 	c.Assert(status, Equals, 502)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": false,
 	})
 }
@@ -128,19 +128,19 @@ func (s *healthSuite) TestLevel(c *C) {
 			status, response := serveHealth(c, "GET", "/v1/health?level=alive", nil)
 			if test.aliveHealthy {
 				c.Check(status, Equals, 200)
-				c.Check(response, DeepEquals, map[string]interface{}{"healthy": true})
+				c.Check(response, DeepEquals, map[string]any{"healthy": true})
 			} else {
 				c.Check(status, Equals, 502)
-				c.Check(response, DeepEquals, map[string]interface{}{"healthy": false})
+				c.Check(response, DeepEquals, map[string]any{"healthy": false})
 			}
 
 			status, response = serveHealth(c, "GET", "/v1/health?level=ready", nil)
 			if test.readyHealthy {
 				c.Check(status, Equals, 200)
-				c.Check(response, DeepEquals, map[string]interface{}{"healthy": true})
+				c.Check(response, DeepEquals, map[string]any{"healthy": true})
 			} else {
 				c.Check(status, Equals, 502)
-				c.Check(response, DeepEquals, map[string]interface{}{"healthy": false})
+				c.Check(response, DeepEquals, map[string]any{"healthy": false})
 			}
 		}()
 	}
@@ -158,25 +158,25 @@ func (s *healthSuite) TestNames(c *C) {
 
 	status, response := serveHealth(c, "GET", "/v1/health?names=chk1&names=chk3", nil)
 	c.Assert(status, Equals, 502)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": false,
 	})
 
 	status, response = serveHealth(c, "GET", "/v1/health?names=chk1,chk3", nil)
 	c.Assert(status, Equals, 502)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": false,
 	})
 
 	status, response = serveHealth(c, "GET", "/v1/health?names=chk2", nil)
 	c.Assert(status, Equals, 200)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": true,
 	})
 
 	status, response = serveHealth(c, "GET", "/v1/health?names=chk3", nil)
 	c.Assert(status, Equals, 200)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"healthy": true,
 	})
 }
@@ -190,7 +190,7 @@ func (s *healthSuite) TestBadLevel(c *C) {
 	status, response := serveHealth(c, "GET", "/v1/health?level=foo", nil)
 
 	c.Assert(status, Equals, 400)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"message": `level must be "alive" or "ready"`,
 	})
 }
@@ -204,7 +204,7 @@ func (s *healthSuite) TestChecksError(c *C) {
 	status, response := serveHealth(c, "GET", "/v1/health", nil)
 
 	c.Assert(status, Equals, 500)
-	c.Assert(response, DeepEquals, map[string]interface{}{
+	c.Assert(response, DeepEquals, map[string]any{
 		"message": "internal server error",
 	})
 }
@@ -276,7 +276,7 @@ func (s *apiSuite) testHealthStateLockNotHeld(c *C, level string, expectErr bool
 	}
 }
 
-func serveHealth(c *C, method, url string, body io.Reader) (int, map[string]interface{}) {
+func serveHealth(c *C, method, url string, body io.Reader) (int, map[string]any) {
 	recorder := httptest.NewRecorder()
 	request, err := http.NewRequest(method, url, body)
 	c.Assert(err, IsNil)
@@ -285,8 +285,8 @@ func serveHealth(c *C, method, url string, body io.Reader) (int, map[string]inte
 	server.ServeHTTP(recorder, request)
 
 	c.Assert(recorder.Result().Header.Get("Content-Type"), Equals, "application/json")
-	var response map[string]interface{}
+	var response map[string]any
 	err = json.NewDecoder(recorder.Result().Body).Decode(&response)
 	c.Assert(err, IsNil)
-	return recorder.Result().StatusCode, response["result"].(map[string]interface{})
+	return recorder.Result().StatusCode, response["result"].(map[string]any)
 }

--- a/internals/daemon/api_services_test.go
+++ b/internals/daemon/api_services_test.go
@@ -222,14 +222,14 @@ func (s *apiSuite) TestServicesGet(c *C) {
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(rsp.Result, NotNil)
-	var body map[string]interface{}
+	var body map[string]any
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, IsNil)
-	c.Check(body["result"], DeepEquals, []interface{}{
-		map[string]interface{}{"startup": "enabled", "name": "test1", "current": "inactive"},
-		map[string]interface{}{"startup": "disabled", "name": "test2", "current": "inactive"},
-		map[string]interface{}{"startup": "disabled", "name": "test3", "current": "inactive"},
-		map[string]interface{}{"startup": "disabled", "name": "test4", "current": "inactive"},
+	c.Check(body["result"], DeepEquals, []any{
+		map[string]any{"startup": "enabled", "name": "test1", "current": "inactive"},
+		map[string]any{"startup": "disabled", "name": "test2", "current": "inactive"},
+		map[string]any{"startup": "disabled", "name": "test3", "current": "inactive"},
+		map[string]any{"startup": "disabled", "name": "test4", "current": "inactive"},
 	})
 }
 

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -116,7 +116,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(rec.Result().Header.Get("Content-Type"), check.Equals, "application/json")
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"version": "42b1",
 		"boot-id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
 	}

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -1017,7 +1017,7 @@ func (s *daemonSuite) TestRestartExpectedRebootOK(c *C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	var v interface{}
+	var v any
 	// these were cleared
 	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
 	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
@@ -1041,7 +1041,7 @@ func (s *daemonSuite) TestRestartExpectedRebootGiveUp(c *C) {
 	st := d.overlord.State()
 	st.Lock()
 	defer st.Unlock()
-	var v interface{}
+	var v any
 	// these were cleared
 	c.Check(st.Get("daemon-system-restart-at", &v), testutil.ErrorIs, state.ErrNoState)
 	c.Check(st.Get("system-restart-from-boot-id", &v), testutil.ErrorIs, state.ErrNoState)
@@ -1289,14 +1289,14 @@ func (s *daemonSuite) TestHTTPAPI(c *C) {
 	response, err := http.DefaultClient.Do(request)
 	c.Assert(err, IsNil)
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
-	var m map[string]interface{}
+	var m map[string]any
 	err = json.NewDecoder(response.Body).Decode(&m)
 	c.Assert(err, IsNil)
-	c.Assert(m, DeepEquals, map[string]interface{}{
+	c.Assert(m, DeepEquals, map[string]any{
 		"type":        "sync",
 		"status-code": float64(http.StatusOK),
 		"status":      "OK",
-		"result": map[string]interface{}{
+		"result": map[string]any{
 			"healthy": true,
 		},
 	})

--- a/internals/daemon/response_test.go
+++ b/internals/daemon/response_test.go
@@ -34,7 +34,7 @@ func (s *responseSuite) TestRespSetsLocationIfAccepted(c *check.C) {
 
 	rsp := &resp{
 		Status: http.StatusAccepted,
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}
@@ -49,7 +49,7 @@ func (s *responseSuite) TestRespSetsLocationIfCreated(c *check.C) {
 
 	rsp := &resp{
 		Status: http.StatusCreated,
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}
@@ -64,7 +64,7 @@ func (s *responseSuite) TestRespDoesNotSetLocationIfOther(c *check.C) {
 
 	rsp := &resp{
 		Status: http.StatusTeapot, // I'm a teapot
-		Result: map[string]interface{}{
+		Result: map[string]any{
 			"resource": "foo/bar",
 		},
 	}

--- a/internals/logger/logger.go
+++ b/internals/logger/logger.go
@@ -49,7 +49,7 @@ var (
 )
 
 // Panicf notifies the user and then panics
-func Panicf(format string, v ...interface{}) {
+func Panicf(format string, v ...any) {
 	loggerLock.Lock()
 	defer loggerLock.Unlock()
 	msg := fmt.Sprintf(format, v...)
@@ -58,7 +58,7 @@ func Panicf(format string, v ...interface{}) {
 }
 
 // Noticef notifies the user of something
-func Noticef(format string, v ...interface{}) {
+func Noticef(format string, v ...any) {
 	loggerLock.Lock()
 	defer loggerLock.Unlock()
 	msg := fmt.Sprintf(format, v...)
@@ -66,7 +66,7 @@ func Noticef(format string, v ...interface{}) {
 }
 
 // Debugf records something in the debug log
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	loggerLock.Lock()
 	defer loggerLock.Unlock()
 	msg := fmt.Sprintf(format, v...)

--- a/internals/overlord/checkstate/manager.go
+++ b/internals/overlord/checkstate/manager.go
@@ -113,7 +113,7 @@ func (m *CheckManager) PlanChanged(newPlan *plan.Plan) {
 				continue
 			}
 			details := mustGetCheckDetails(change)
-			var configKey interface{}
+			var configKey any
 			if change.Kind() == performCheckKind {
 				configKey = performConfigKey{change.ID()}
 			} else {

--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -425,7 +425,7 @@ func setExitCode(task *state.Task, exitCode int) {
 	st := task.State()
 	st.Lock()
 	defer st.Unlock()
-	task.Set("api-data", map[string]interface{}{
+	task.Set("api-data", map[string]any{
 		"exit-code": exitCode,
 	})
 }

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -123,13 +123,13 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	d, err := state.MarshalJSON()
 	c.Assert(err, IsNil)
 
-	var got, expected map[string]interface{}
+	var got, expected map[string]any
 	err = json.Unmarshal(d, &got)
 	c.Assert(err, IsNil)
 	err = json.Unmarshal(fakeState, &expected)
 	c.Assert(err, IsNil)
 
-	data, _ := got["data"].(map[string]interface{})
+	data, _ := got["data"].(map[string]any)
 	c.Assert(data, NotNil)
 
 	c.Check(got, DeepEquals, expected)

--- a/internals/overlord/state/change.go
+++ b/internals/overlord/state/change.go
@@ -260,14 +260,14 @@ func (c *Change) Summary() string {
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (c *Change) Set(key string, value interface{}) {
+func (c *Change) Set(key string, value any) {
 	c.state.writing()
 	c.data.set(key, value)
 }
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
-func (c *Change) Get(key string, value interface{}) error {
+func (c *Change) Get(key string, value any) error {
 	c.state.reading()
 	return c.data.get(key, value)
 }

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -287,7 +287,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 // Warnf records a warning: if it's the first Warning with this message it'll
 // be added (with its firstOccurred and lastOccurred set to the current time),
 // otherwise the existing one will have its lastOccurred updated.
-func (s *State) Warnf(template string, args ...interface{}) {
+func (s *State) Warnf(template string, args ...any) {
 	var message string
 	if len(args) > 0 {
 		message = fmt.Sprintf(template, args...)

--- a/internals/overlord/state/task.go
+++ b/internals/overlord/state/task.go
@@ -415,7 +415,7 @@ func FakeTime(now time.Time) (restore func()) {
 	return func() { timeNow = time.Now }
 }
 
-func (t *Task) addLog(kind, format string, args []interface{}) {
+func (t *Task) addLog(kind, format string, args []any) {
 	if len(t.log) > 9 {
 		copy(t.log, t.log[len(t.log)-9:])
 		t.log = t.log[:9]
@@ -444,27 +444,27 @@ func (t *Task) Log() []string {
 }
 
 // Logf logs information about the progress of the task.
-func (t *Task) Logf(format string, args ...interface{}) {
+func (t *Task) Logf(format string, args ...any) {
 	t.state.writing()
 	t.addLog(LogInfo, format, args)
 }
 
 // Errorf logs error information about the progress of the task.
-func (t *Task) Errorf(format string, args ...interface{}) {
+func (t *Task) Errorf(format string, args ...any) {
 	t.state.writing()
 	t.addLog(LogError, format, args)
 }
 
 // Set associates value with key for future consulting by managers.
 // The provided value must properly marshal and unmarshal with encoding/json.
-func (t *Task) Set(key string, value interface{}) {
+func (t *Task) Set(key string, value any) {
 	t.state.writing()
 	t.data.set(key, value)
 }
 
 // Get unmarshals the stored value associated with the provided key
 // into the value parameter.
-func (t *Task) Get(key string, value interface{}) error {
+func (t *Task) Get(key string, value any) error {
 	t.state.reading()
 	return t.data.get(key, value)
 }

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -117,7 +117,7 @@ type Plan struct {
 // MarshalYAML implements an override for top level omitempty tags handling.
 // This is required since Sections are based on an inlined map, for which
 // omitempty and inline together is not currently supported.
-func (p *Plan) MarshalYAML() (interface{}, error) {
+func (p *Plan) MarshalYAML() (any, error) {
 	// Define the content inside a structure so we can control the ordering
 	// of top level sections.
 	ordered := []reflect.StructField{{
@@ -1258,7 +1258,7 @@ func ParseLayer(order int, label string, data []byte) (*Layer, error) {
 	// 2. We honor KnownFields = true behaviour for non extended schema
 	// sections, and at the top field level, which includes Section field
 	// names.
-	builtins := map[string]interface{}{
+	builtins := map[string]any{
 		"summary":     &layer.Summary,
 		"description": &layer.Description,
 		"services":    &layer.Services,

--- a/internals/plan/types.go
+++ b/internals/plan/types.go
@@ -17,7 +17,7 @@ func (o OptionalDuration) IsZero() bool {
 	return !o.IsSet
 }
 
-func (o OptionalDuration) MarshalYAML() (interface{}, error) {
+func (o OptionalDuration) MarshalYAML() (any, error) {
 	if !o.IsSet {
 		return nil, nil
 	}
@@ -46,7 +46,7 @@ func (o OptionalFloat) IsZero() bool {
 	return !o.IsSet
 }
 
-func (o OptionalFloat) MarshalYAML() (interface{}, error) {
+func (o OptionalFloat) MarshalYAML() (any, error) {
 	if !o.IsSet {
 		return nil, nil
 	}

--- a/internals/testutil/containschecker.go
+++ b/internals/testutil/containschecker.go
@@ -32,7 +32,7 @@ var Contains check.Checker = &containsChecker{
 	&check.CheckerInfo{Name: "Contains", Params: []string{"container", "elem"}},
 }
 
-func commonEquals(container, elem interface{}, result *bool, error *string) bool {
+func commonEquals(container, elem any, result *bool, error *string) bool {
 	containerV := reflect.ValueOf(container)
 	elemV := reflect.ValueOf(elem)
 	switch containerV.Kind() {
@@ -71,15 +71,15 @@ func commonEquals(container, elem interface{}, result *bool, error *string) bool
 	return false
 }
 
-func (c *containsChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *containsChecker) Check(params []any, names []string) (result bool, error string) {
 	defer func() {
 		if v := recover(); v != nil {
 			result = false
 			error = fmt.Sprint(v)
 		}
 	}()
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+	var container any = params[0]
+	var elem any = params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return
 	}
@@ -117,9 +117,9 @@ var DeepContains check.Checker = &deepContainsChecker{
 	&check.CheckerInfo{Name: "DeepContains", Params: []string{"container", "elem"}},
 }
 
-func (c *deepContainsChecker) Check(params []interface{}, names []string) (result bool, error string) {
-	var container interface{} = params[0]
-	var elem interface{} = params[1]
+func (c *deepContainsChecker) Check(params []any, names []string) (result bool, error string) {
+	var container any = params[0]
+	var elem any = params[1]
 	if commonEquals(container, elem, &result, &error) {
 		return
 	}
@@ -157,7 +157,7 @@ var DeepUnsortedMatches check.Checker = &deepUnsortedMatchChecker{
 	&check.CheckerInfo{Name: "DeepUnsortedMatches", Params: []string{"container1", "container2"}},
 }
 
-func (c *deepUnsortedMatchChecker) Check(params []interface{}, _ []string) (bool, string) {
+func (c *deepUnsortedMatchChecker) Check(params []any, _ []string) (bool, string) {
 	container1 := reflect.ValueOf(params[0])
 	container2 := reflect.ValueOf(params[1])
 

--- a/internals/testutil/errorischecker.go
+++ b/internals/testutil/errorischecker.go
@@ -29,7 +29,7 @@ type errorIsChecker struct {
 	*check.CheckerInfo
 }
 
-func (*errorIsChecker) Check(params []interface{}, names []string) (result bool, errMsg string) {
+func (*errorIsChecker) Check(params []any, names []string) (result bool, errMsg string) {
 	if params[0] == nil {
 		return params[1] == nil, ""
 	}

--- a/internals/testutil/errorischecker_test.go
+++ b/internals/testutil/errorischecker_test.go
@@ -57,11 +57,11 @@ func (*errorIsCheckerSuite) TestErrorIsCheckFails(c *C) {
 }
 
 func (*errorIsCheckerSuite) TestErrorIsWithInvalidArguments(c *C) {
-	res, errMsg := ErrorIs.Check([]interface{}{"", errors.New("")}, []string{"error", "target"})
+	res, errMsg := ErrorIs.Check([]any{"", errors.New("")}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "first argument must be an error")
 
-	res, errMsg = ErrorIs.Check([]interface{}{errors.New(""), ""}, []string{"error", "target"})
+	res, errMsg = ErrorIs.Check([]any{errors.New(""), ""}, []string{"error", "target"})
 	c.Assert(res, Equals, false)
 	c.Assert(errMsg, Equals, "second argument must be an error")
 

--- a/internals/testutil/filecontentchecker.go
+++ b/internals/testutil/filecontentchecker.go
@@ -48,7 +48,7 @@ var FileMatches check.Checker = &fileContentChecker{
 	CheckerInfo: &check.CheckerInfo{Name: "FileMatches", Params: []string{"filename", "regex"}},
 }
 
-func (c *fileContentChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *fileContentChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "Filename must be a string"
@@ -67,7 +67,7 @@ func (c *fileContentChecker) Check(params []interface{}, names []string) (result
 	return fileContentCheck(filename, params[1], c.exact)
 }
 
-func fileContentCheck(filename string, content interface{}, exact bool) (result bool, error string) {
+func fileContentCheck(filename string, content any, exact bool) (result bool, error string) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Sprintf("Cannot read file %q: %v", filename, err)

--- a/internals/testutil/filepresencechecker.go
+++ b/internals/testutil/filepresencechecker.go
@@ -38,7 +38,7 @@ var FileAbsent check.Checker = &filePresenceChecker{
 	present:     false,
 }
 
-func (c *filePresenceChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (c *filePresenceChecker) Check(params []any, names []string) (result bool, error string) {
 	filename, ok := params[0].(string)
 	if !ok {
 		return false, "filename must be a string"

--- a/internals/testutil/intcheckers.go
+++ b/internals/testutil/intcheckers.go
@@ -25,7 +25,7 @@ type intChecker struct {
 	rel string
 }
 
-func (checker *intChecker) Check(params []interface{}, names []string) (result bool, error string) {
+func (checker *intChecker) Check(params []any, names []string) (result bool, error string) {
 	a, ok := params[0].(int)
 	if !ok {
 		return false, "left-hand-side argument must be an int"

--- a/internals/testutil/testutil_test.go
+++ b/internals/testutil/testutil_test.go
@@ -35,7 +35,7 @@ func testInfo(c *check.C, checker check.Checker, name string, paramNames []strin
 	}
 }
 
-func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...interface{}) ([]interface{}, []string) {
+func testCheck(c *check.C, checker check.Checker, result bool, error string, params ...any) ([]any, []string) {
 	info := checker.Info()
 	if len(params) != len(info.Params) {
 		c.Fatalf("unexpected param count in test; expected %d got %d", len(info.Params), len(params))

--- a/internals/timing/span_test.go
+++ b/internals/timing/span_test.go
@@ -82,12 +82,12 @@ func (s *spanSuite) fakeMinNestedSpan(threshold time.Duration) {
 	s.AddCleanup(restore)
 }
 
-func encodeDecode(span *timing.Span) interface{} {
+func encodeDecode(span *timing.Span) any {
 	data, err := json.Marshal(span)
 	if err != nil {
 		panic(err)
 	}
-	var decoded interface{}
+	var decoded any
 	decoder := json.NewDecoder(bytes.NewBuffer(data))
 	decoder.UseNumber()
 	err = decoder.Decode(&decoded)
@@ -118,22 +118,22 @@ func (s *spanSuite) TestSave(c *C) {
 	decoded0 := encodeDecode(spans[0])
 	decoded1 := encodeDecode(spans[1])
 
-	c.Assert(decoded0, DeepEquals, map[string]interface{}{
-		"tags": map[string]interface{}{
+	c.Assert(decoded0, DeepEquals, map[string]any{
+		"tags": map[string]any{
 			"change": "12",
 			"task":   "0",
 		},
 		"base": json.Number("1577840460"),
 		"b":    json.Number("6000000"),
-		"spans": []interface{}{
-			map[string]interface{}{
+		"spans": []any{
+			map[string]any{
 				"label":   "First level",
 				"summary": "...",
 				"depth":   json.Number("1"),
 				"a":       json.Number("2000000"),
 				"b":       json.Number("5000000"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"label":   "Second level",
 				"summary": "...",
 				"depth":   json.Number("2"),
@@ -142,22 +142,22 @@ func (s *spanSuite) TestSave(c *C) {
 			},
 		},
 	})
-	c.Assert(decoded1, DeepEquals, map[string]interface{}{
-		"tags": map[string]interface{}{
+	c.Assert(decoded1, DeepEquals, map[string]any{
+		"tags": map[string]any{
 			"change": "12",
 			"task":   "1",
 		},
 		"base": json.Number("1577840460"),
 		"b":    json.Number("12000000"),
-		"spans": []interface{}{
-			map[string]interface{}{
+		"spans": []any{
+			map[string]any{
 				"label":   "First level",
 				"summary": "...",
 				"depth":   json.Number("1"),
 				"a":       json.Number("8000000"),
 				"b":       json.Number("11000000"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"label":   "Second level",
 				"summary": "...",
 				"depth":   json.Number("2"),
@@ -168,7 +168,7 @@ func (s *spanSuite) TestSave(c *C) {
 	})
 }
 
-func (s *spanSuite) testDurationThreshold(c *C, threshold time.Duration, expected interface{}) {
+func (s *spanSuite) testDurationThreshold(c *C, threshold time.Duration, expected any) {
 	s.fakeMinNestedSpan(threshold)
 
 	span1 := timing.Start("", "", nil)
@@ -184,25 +184,25 @@ func (s *spanSuite) testDurationThreshold(c *C, threshold time.Duration, expecte
 }
 
 func (s *spanSuite) TestDurationThresholdAll(c *C) {
-	s.testDurationThreshold(c, 0, map[string]interface{}{
+	s.testDurationThreshold(c, 0, map[string]any{
 		"base": json.Number("1577840460"),
 		"b":    json.Number("8000000"),
-		"spans": []interface{}{
-			map[string]interface{}{
+		"spans": []any{
+			map[string]any{
 				"label":   "main",
 				"summary": "...",
 				"depth":   json.Number("1"),
 				"a":       json.Number("2000000"),
 				"b":       json.Number("7000000"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"label":   "nested",
 				"summary": "...",
 				"depth":   json.Number("2"),
 				"a":       json.Number("3000000"),
 				"b":       json.Number("6000000"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"label":   "nested more",
 				"summary": "...",
 				"depth":   json.Number("3"),
@@ -214,18 +214,18 @@ func (s *spanSuite) TestDurationThresholdAll(c *C) {
 }
 
 func (s *spanSuite) TestDurationThreshold(c *C) {
-	s.testDurationThreshold(c, 3000000, map[string]interface{}{
+	s.testDurationThreshold(c, 3000000, map[string]any{
 		"base": json.Number("1577840460"),
 		"b":    json.Number("8000000"),
-		"spans": []interface{}{
-			map[string]interface{}{
+		"spans": []any{
+			map[string]any{
 				"label":   "main",
 				"summary": "...",
 				"depth":   json.Number("1"),
 				"a":       json.Number("2000000"),
 				"b":       json.Number("7000000"),
 			},
-			map[string]interface{}{
+			map[string]any{
 				"label":   "nested",
 				"summary": "...",
 				"depth":   json.Number("2"),
@@ -237,11 +237,11 @@ func (s *spanSuite) TestDurationThreshold(c *C) {
 }
 
 func (s *spanSuite) TestDurationThresholdRootOnly(c *C) {
-	s.testDurationThreshold(c, 4000000, map[string]interface{}{
+	s.testDurationThreshold(c, 4000000, map[string]any{
 		"base": json.Number("1577840460"),
 		"b":    json.Number("8000000"),
-		"spans": []interface{}{
-			map[string]interface{}{
+		"spans": []any{
+			map[string]any{
 				"label":   "main",
 				"summary": "...",
 				"depth":   json.Number("1"),


### PR DESCRIPTION
`any` is (as of Go 1.18) a builtin alias for `interface{}`, equivalent in every respect. It was introduced in Go 1.18+, and our go.mod says we're on 1.22. A similar thing was done to the Go project and stdlib a while back, see for example https://pkg.go.dev/encoding/json#Marshal

Commands used to generate this PR (based on the [same thing done](https://go-review.googlesource.com/c/protobuf/+/585735) to the Go project):

```
$ sed -i 's,interface{},any,g' **/*.go
$ sed -i 's,interface{},any,g' **/**/*.go
$ sed -i 's,interface{},any,g' **/**/**/*.go
# I'm not actually sure why the last two were needed here and not for Go,
# but the first one only did the client package

go fmt ./...
```

This also adds a GitHub Action (part of the format checks) that runs grep to ensure we don't have any remaining `interface{}`, for example from in-flight PRs. See [failing example run](https://github.com/canonical/pebble/actions/runs/13263762684/job/37026049090?pr=568).