### PR TITLE
chore: update doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ _Take control of your internal daemons!_
 
 Pebble's key features:
 
-- [Layer](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/layer-specification/)-based configuration
-- Service [dependencies](https://canonical-pebble.readthedocs-hosted.com/en/latest/explanation/service-dependencies/)
-- Service [logs](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/cli-commands/#logs) and [log forwarding](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/log-forwarding/)
-- [Health checks](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/health-checks/)
-- [Notices](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/notices/) (aggregated events)
-- [Identities](https://canonical-pebble.readthedocs-hosted.com/en/latest/how-to/manage-identities/)
-- Can be used in [virtual machines and containers](https://canonical-pebble.readthedocs-hosted.com/en/latest/how-to/manage-a-remote-system/)
-- [CLI commands](https://canonical-pebble.readthedocs-hosted.com/en/latest/reference/cli-commands/)
-- [HTTP API](https://canonical-pebble.readthedocs-hosted.com/en/latest/explanation/api-and-clients/) with a [Go client](https://pkg.go.dev/github.com/canonical/pebble/client) and a [Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py)
+- [Layer](https://documentation.ubuntu.com/pebble/reference/layer-specification/)-based configuration
+- Service [dependencies](https://documentation.ubuntu.com/pebble/explanation/service-dependencies/)
+- Service [logs](https://documentation.ubuntu.com/pebble/reference/cli-commands/#logs) and [log forwarding](https://documentation.ubuntu.com/pebble/reference/log-forwarding/)
+- [Health checks](https://documentation.ubuntu.com/pebble/reference/health-checks/)
+- [Notices](https://documentation.ubuntu.com/pebble/reference/notices/) (aggregated events)
+- [Identities](https://documentation.ubuntu.com/pebble/how-to/manage-identities/)
+- Can be used in [virtual machines and containers](https://documentation.ubuntu.com/pebble/how-to/manage-a-remote-system/)
+- [CLI commands](https://documentation.ubuntu.com/pebble/reference/cli-commands/)
+- [HTTP API](https://documentation.ubuntu.com/pebble/explanation/api-and-clients/) with a [Go client](https://pkg.go.dev/github.com/canonical/pebble/client) and a [Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py)
 
 ## Quick start
 
@@ -41,13 +41,13 @@ services:
 pebble run
 ```
 
-Read more about Pebble's general model [here](https://canonical-pebble.readthedocs-hosted.com/en/latest/explanation/general-model/).
+Read more about Pebble's general model [here](https://documentation.ubuntu.com/pebble/explanation/general-model/).
 
-For a hands-on introduction to Pebble, we recommend going through the [tutorial](https://canonical-pebble.readthedocs-hosted.com/en/latest/tutorial/getting-started/).
+For a hands-on introduction to Pebble, we recommend going through the [tutorial](https://documentation.ubuntu.com/pebble/tutorial/getting-started/).
 
 ## Getting help
 
-To get the most out of Pebble, we recommend starting with the [documentation](https://canonical-pebble.readthedocs-hosted.com/en/latest/).
+To get the most out of Pebble, we recommend starting with the [documentation](https://documentation.ubuntu.com/pebble/).
 
 You can [create an issue](https://github.com/canonical/pebble/issues/new) and we will help!
 


### PR DESCRIPTION
A quick PR to update the README to use the new URLs of Pebble docs. We've already set up redirects, so this is just to keep things tidy.

@benhoyt / @IronCore864 are you able to update the link in the **About** section of the repo? I don't think I have access to do that.