### PR TITLE
docs: fix missing styles on doc error pages

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -115,7 +115,7 @@ html_context = {
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ""
+slug = "pebble"
 
 ############################################################
 ### Redirects


### PR DESCRIPTION
This PR attempts to fix unstyled error pages ([example](https://documentation.ubuntu.com/pebble/asdf)) by setting the Sphinx project slug. I can't test this locally, so we'll need to merge and see what happens.