### PR TITLE
feat: verbose mode using environment variable

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -840,7 +840,8 @@ pebble run --args myservice --port 8080 \; --hold
           --hold         Do not start default services automatically
           --http=        Start HTTP API listening on this address (e.g.,
                          ":4000") and expose open-access endpoints
-      -v, --verbose      Log all output from services to stdout
+      -v, --verbose      Log all output from services to stdout (also
+                         PEBBLE_VERBOSE=1)
           --args=        Provide additional arguments to a service
           --identities=  Seed identities from file (like update-identities
                          --replace)

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -16,6 +16,8 @@ The `pebble` command has the following subcommands, organised into logical group
 * Notices: [warnings](#reference_pebble_warnings_command), [okay](#reference_pebble_okay_command), [notices](#reference_pebble_notices_command), [notice](#reference_pebble_notice_command), [notify](#reference_pebble_notify_command)
 * Identities: [identities](#reference_pebble_identities_command), [identity](#reference_pebble_identity_command), [add-identities](#reference_pebble_add-identities_command), [update-identities](#reference_pebble_update-identities_command), [remove-identities](#reference_pebble_remove-identities_command)
 
+You can use environment variables to configure Pebble's behavior. See [Environment variables](environment-variables).
+
 The subcommands are listed alphabetically below.
 
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,56 +1,33 @@
 # Pebble Environment Variables
 
-## NOTIFY_SOCKET
-
-If the `NOTIFY_SOCKET` environment variable is set, Pebble will send state string notifications to systemd. Specifically:
-
-- When Pebble daemon starts, it sends "READY=1", which tells systemd that Pebble startup is finished.
-- When Pebble daemon stops, it sends "STOPPING=1", which tells systemd that Pebble is beginning its shutdown. 
-
 ## PEBBLE
 
-Pebble's configuration directory. Defaults to "/var/lib/pebble/default" if not specified.
+Pebble's configuration directory. Defaults to `/var/lib/pebble/default` if not specified.
 
 The `$PEBBLE` directory must contain a `layers/` subdirectory that holds a stack of configuration files. See [general model](../explanation/general-model) for more information.
 
 ## PEBBLE_COPY_ONCE
 
-If specified, when Pebble daemon starts, Pebble copies the directory specified by `PEBBLE_COPY_ONCE` to the Pebble directory once.
+To initialise the `$PEBBLE` directory with the contents of another, in a one-time copy, set the `PEBBLE_COPY_ONCE` environment variable to the source directory.
+
+This will only copy the contents if the target directory, `$PEBBLE`, is empty.
 
 ## PEBBLE_DEBUG
 
-If set to "1", debug logs will be printed.
-
-## PEBBLE_REBOOT_DELAY
-
-A duration string for the delay of reboot. Used for tests.
-
-Reboot delay defaults to 1 minute if `PEBBLE_REBOOT_DELAY` is not set.
+If set to "1", debug logs will be printed to stderr.
 
 ## PEBBLE_SOCKET
 
-Pebble socket path. Defaults to `$PEBBLE/.pebble.socket` if not specified.
+Pebble socket path. Defaults to `$PEBBLE/.pebble.socket` if not specified, or `/var/lib/pebble/default/.pebble.socket` if `PEBBLE` is not set.
 
 ## PEBBLE_VERBOSE
 
-If set to "1", write service logs to Pebble's stdout.
+If set to "1", the Pebble daemon writes service logs to stdout.
 
-For `pebble run`, allow verbose logging mode (log all output from services to stdout) to be enabled when starting the daemon by setting the environment variable `PEBBLE_VERBOSE=1`.  This is in addition to the existing way of enabling verbose mode with a command line argument: `pebble run --verbose`.
+For `pebble run`, either `PEBBLE_VERBOSE=1` or the `--verbose` flag turns on verbose logging, with the command line flag overriding the environment variable.
 
-For pebble enter exec, the `--verbose flag` is currently disabled. However, `pebble enter` (including `pebble enter exec`) would still respect `PEBBLE_VERBOSE=1`: the user should know how their applications behave and it’s okay to use with verbose logging turned on.
-
-## SPREAD_SYSTEM
-
-If set, Pebble will think we are running tests, and the progress bar for commands `autorestart`, `replan`, `restart`, `start` and `stop` will be disabled.
-
-## UNSAFE_IO
-
-If set to "1," sync for testing is disabled. This brings massive improvements on certain filesystems (like btrfs) and noticeable improvements in all unit tests in general.
-
-## WATCHDOG_USEC
-
-If the `WATCHDOG_USEC` environment variable is set, systemd expects notifications from Pebble. Systemd will usually terminate a service when it does not get a notification message within the specified time after startup and after each previous message. It is recommended to send a keep-alive notification message every half of the time (in microseconds) specified by `WATCHDOG_USEC`. Notification messages are sent with `sd_notify` with a message string of "WATCHDOG=1".
+For `pebble enter exec`, the `--verbose` flag is currently disallowed. However, `pebble enter` (including `pebble enter exec`) still respects the `PEBBLE_VERBOSE=1` environment variable: the user should know how their applications behave, and that they're okay to use with verbose logging turned on.
 
 ## XDG_CONFIG_HOME
 
-Pebble CLI state path. Defaults to "$HOME/.config" if not specified.
+The [XDG configuration directory](https://specifications.freedesktop.org/basedir-spec/latest/#basics). Certain Pebble CLI commands create or use data files in `$XDG_CONFIG_HOME/pebble`. Defaults to `$HOME/.config` if not specified.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -4,7 +4,7 @@
 
 Pebble's configuration directory. Defaults to `/var/lib/pebble/default` if not specified.
 
-The `$PEBBLE` directory must contain a `layers/` subdirectory that holds a stack of configuration files. See [general model](../explanation/general-model) for more information.
+The `$PEBBLE` directory must contain a `layers/` subdirectory that holds a stack of configuration files. See [general model](../explanation/general-model) and [How to use layers](../how-to/use-layers) for more information.
 
 ## PEBBLE_COPY_ONCE
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,56 @@
+# Pebble Environment Variables
+
+## NOTIFY_SOCKET
+
+If the `NOTIFY_SOCKET` environment variable is set, Pebble will send state string notifications to systemd. Specifically:
+
+- When Pebble daemon starts, it sends "READY=1", which tells systemd that Pebble startup is finished.
+- When Pebble daemon stops, it sends "STOPPING=1", which tells systemd that Pebble is beginning its shutdown. 
+
+## PEBBLE
+
+Pebble's configuration directory. Defaults to "/var/lib/pebble/default" if not specified.
+
+The `$PEBBLE` directory must contain a `layers/` subdirectory that holds a stack of configuration files. See [general model](../explanation/general-model) for more information.
+
+## PEBBLE_COPY_ONCE
+
+If specified, when Pebble daemon starts, Pebble copies the directory specified by `PEBBLE_COPY_ONCE` to the Pebble directory once.
+
+## PEBBLE_DEBUG
+
+If set to "1", debug logs will be printed.
+
+## PEBBLE_REBOOT_DELAY
+
+A duration string for the delay of reboot. Used for tests.
+
+Reboot delay defaults to 1 minute if `PEBBLE_REBOOT_DELAY` is not set.
+
+## PEBBLE_SOCKET
+
+Pebble socket path. Defaults to `$PEBBLE/.pebble.socket` if not specified.
+
+## PEBBLE_VERBOSE
+
+If set to "1", write service logs to Pebble's stdout.
+
+For `pebble run`, allow verbose logging mode (log all output from services to stdout) to be enabled when starting the daemon by setting the environment variable `PEBBLE_VERBOSE=1`.  This is in addition to the existing way of enabling verbose mode with a command line argument: `pebble run --verbose`.
+
+For pebble enter exec, the `--verbose flag` is currently disabled. However, `pebble enter` (including `pebble enter exec`) would still respect `PEBBLE_VERBOSE=1`: the user should know how their applications behave and it’s okay to use with verbose logging turned on.
+
+## SPREAD_SYSTEM
+
+If set, Pebble will think we are running tests, and the progress bar for commands `autorestart`, `replan`, `restart`, `start` and `stop` will be disabled.
+
+## UNSAFE_IO
+
+If set to "1," sync for testing is disabled. This brings massive improvements on certain filesystems (like btrfs) and noticeable improvements in all unit tests in general.
+
+## WATCHDOG_USEC
+
+If the `WATCHDOG_USEC` environment variable is set, systemd expects notifications from Pebble. Systemd will usually terminate a service when it does not get a notification message within the specified time after startup and after each previous message. It is recommended to send a keep-alive notification message every half of the time (in microseconds) specified by `WATCHDOG_USEC`. Notification messages are sent with `sd_notify` with a message string of "WATCHDOG=1".
+
+## XDG_CONFIG_HOME
+
+Pebble CLI state path. Defaults to "$HOME/.config" if not specified.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,6 +14,7 @@ These guides provide technical information about Pebble.
 API <api>
 Changes and tasks <changes-and-tasks>
 CLI commands <cli-commands>
+Environment variables <environment-variables>
 Health checks <health-checks>
 Identities <identities>
 Layer specification <layer-specification>
@@ -39,6 +40,13 @@ Pebble configuration is defined as a stack of "layers".
 The `pebble` command has several subcommands.
 
 * [CLI commands](cli-commands)
+
+
+## Pebble environment variables
+
+You can use environment variables to configure Pebble's behavior:
+
+* [Environment variables](environment-variables)
 
 
 ## Service failures

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -42,7 +42,7 @@ The `pebble` command has several subcommands.
 * [CLI commands](cli-commands)
 
 
-## Pebble environment variables
+## Environment variables
 
 You can use environment variables to configure Pebble's behavior:
 

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/canonical/go-flags"
 
@@ -188,7 +189,9 @@ func (cmd *cmdEnter) Execute(args []string) error {
 		return nil
 	}
 
-	if enterFlags&enterSilenceLogging != 0 && !cmd.Verbose {
+	if enterFlags&enterSilenceLogging != 0 && !cmd.Verbose && os.Getenv("PEBBLE_VERBOSE") != "1" {
+		// Respect PEBBLE_VERBOSE even if --verbose is not explicitly set for "enter",
+		// which is disabled for now.
 		logger.SetLogger(logger.NullLogger)
 	}
 

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -189,9 +189,10 @@ func (cmd *cmdEnter) Execute(args []string) error {
 		return nil
 	}
 
-	if enterFlags&enterSilenceLogging != 0 && !cmd.Verbose && os.Getenv("PEBBLE_VERBOSE") != "1" {
-		// Respect PEBBLE_VERBOSE even if --verbose is not explicitly set for "enter",
-		// which is disabled for now.
+	verbose := os.Getenv("PEBBLE_VERBOSE") == "1" || cmd.Verbose
+	// Turn off stderr logging for certain commands (like "exec") unless
+	// verbose mode is turned on.
+	if enterFlags&enterSilenceLogging != 0 && !verbose {
 		logger.SetLogger(logger.NullLogger)
 	}
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -186,7 +186,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 		Dir:        rcmd.pebbleDir,
 		SocketPath: rcmd.socketPath,
 	}
-	if rcmd.Verbose {
+	if os.Getenv("PEBBLE_VERBOSE") == "1" || rcmd.Verbose {
 		dopts.ServiceOutput = os.Stdout
 	}
 	dopts.HTTPAddress = rcmd.HTTP

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -58,7 +58,7 @@ var sharedRunEnterArgsHelp = map[string]string{
 	"--create-dirs": "Create {{.DisplayName}} directory on startup if it doesn't exist",
 	"--hold":        "Do not start default services automatically",
 	"--http":        `Start HTTP API listening on this address (e.g., ":4000") and expose open-access endpoints`,
-	"--verbose":     "Log all output from services to stdout",
+	"--verbose":     "Log all output from services to stdout (also PEBBLE_VERBOSE=1)",
 	"--args":        "Provide additional arguments to a service",
 	"--identities":  "Seed identities from file (like update-identities --replace)",
 }

--- a/tests/enter_test.go
+++ b/tests/enter_test.go
@@ -37,7 +37,7 @@ sleep 1.1
 		t.Fatal(err)
 	}
 
-	stdoutCh, _ := pebbleEnter(t, pebbleDir, "exec", "/bin/sh", "-c", path)
+	stdoutCh, _ := pebbleDaemon(t, pebbleDir, "enter", "exec", "/bin/sh", "-c", path)
 	waitForText(t, stdoutCh, "hello world", 3*time.Second)
 }
 
@@ -57,7 +57,7 @@ sleep 1.1
 		t.Fatal(err)
 	}
 
-	stdoutCh, stderrCh := pebbleEnter(t, pebbleDir, "exec", "/bin/sh", "-c", path)
+	stdoutCh, stderrCh := pebbleDaemon(t, pebbleDir, "enter", "exec", "/bin/sh", "-c", path)
 	waitForText(t, stderrCh, "Started daemon", 3*time.Second)
 	waitForText(t, stderrCh, "POST /v1/exec", 3*time.Second)
 	waitForText(t, stdoutCh, "hello world", 3*time.Second)

--- a/tests/enter_test.go
+++ b/tests/enter_test.go
@@ -29,7 +29,7 @@ func TestEnterExec(t *testing.T) {
 	script := `
 #!/bin/sh
 echo "hello world"
-sleep 2
+sleep 1.1
 	`
 	path := filepath.Join(pebbleDir, "test.sh")
 	err := os.WriteFile(path, []byte(script), 0755)
@@ -38,19 +38,18 @@ sleep 2
 	}
 
 	stdoutCh, _ := pebbleEnter(t, pebbleDir, "exec", "/bin/sh", "-c", path)
-	waitForText(t, stdoutCh, "hello world", 1*time.Second)
+	waitForText(t, stdoutCh, "hello world", 3*time.Second)
 }
 
 func TestEnterExecVerboseEnabledByEnvVar(t *testing.T) {
-	os.Setenv("PEBBLE_VERBOSE", "1")
-	defer os.Setenv("PEBBLE_VERBOSE", "")
+	t.Setenv("PEBBLE_VERBOSE", "1")
 
 	pebbleDir := t.TempDir()
 
 	script := `
 #!/bin/sh
 echo "hello world"
-sleep 2
+sleep 1.1
 	`
 	path := filepath.Join(pebbleDir, "test.sh")
 	err := os.WriteFile(path, []byte(script), 0755)
@@ -59,7 +58,7 @@ sleep 2
 	}
 
 	stdoutCh, stderrCh := pebbleEnter(t, pebbleDir, "exec", "/bin/sh", "-c", path)
-	waitForText(t, stderrCh, "Started daemon", 1*time.Second)
-	waitForText(t, stderrCh, "POST /v1/exec", 1*time.Second)
-	waitForText(t, stdoutCh, "hello world", 1*time.Second)
+	waitForText(t, stderrCh, "Started daemon", 3*time.Second)
+	waitForText(t, stderrCh, "POST /v1/exec", 3*time.Second)
+	waitForText(t, stdoutCh, "hello world", 3*time.Second)
 }

--- a/tests/enter_test.go
+++ b/tests/enter_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEnterExec(t *testing.T) {
+	pebbleDir := t.TempDir()
+
+	script := `
+#!/bin/sh
+echo "hello world"
+sleep 2
+	`
+	path := filepath.Join(pebbleDir, "test.sh")
+	err := os.WriteFile(path, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdoutCh, _ := pebbleEnter(t, pebbleDir, "exec", "/bin/sh", "-c", path)
+	waitForText(t, stdoutCh, "hello world", 1*time.Second)
+}
+
+func TestEnterExecVerboseEnabledByEnvVar(t *testing.T) {
+	os.Setenv("PEBBLE_VERBOSE", "1")
+	defer os.Setenv("PEBBLE_VERBOSE", "")
+
+	pebbleDir := t.TempDir()
+
+	script := `
+#!/bin/sh
+echo "hello world"
+sleep 2
+	`
+	path := filepath.Join(pebbleDir, "test.sh")
+	err := os.WriteFile(path, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdoutCh, stderrCh := pebbleEnter(t, pebbleDir, "exec", "/bin/sh", "-c", path)
+	waitForText(t, stderrCh, "Started daemon", 1*time.Second)
+	waitForText(t, stderrCh, "POST /v1/exec", 1*time.Second)
+	waitForText(t, stdoutCh, "hello world", 1*time.Second)
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -94,7 +94,7 @@ func pebbleDaemon(t *testing.T, pebbleDir string, runOrEnter string, args ...str
 
 	err = cmd.Start()
 	if err != nil {
-		t.Fatalf("Error starting 'pebble enter': %v", err)
+		t.Fatalf("Error starting 'pebble %s': %v", runOrEnter, err)
 	}
 
 	stopStdout := make(chan struct{})
@@ -167,7 +167,7 @@ func waitForText(t *testing.T, textCh <-chan string, expectedText string, timeou
 		select {
 		case text, ok := <-textCh:
 			if !ok {
-				t.Error("channel closed before expected text was received")
+				t.Fatal("channel closed before expected text was received")
 				return // Exit the loop if the channel is closed
 			}
 			if strings.Contains(text, expectedText) {

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -71,77 +71,16 @@ func createLayer(t *testing.T, pebbleDir, layerFileName, layerYAML string) {
 	}
 }
 
-// pebbleRun starts the pebble daemon (`pebble run`) with optional arguments
-// and returns two channels for standard output and standard error.
-func pebbleRun(t *testing.T, pebbleDir string, args ...string) (stdoutCh chan servicelog.Entry, stderrCh chan servicelog.Entry) {
-	t.Helper()
-
-	stdoutCh = make(chan servicelog.Entry)
-	stderrCh = make(chan servicelog.Entry)
-
-	cmd := exec.Command(*pebbleBin, append([]string{"run"}, args...)...)
-	cmd.Env = append(os.Environ(), "PEBBLE="+pebbleDir)
-
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("Cannot create stdout pipe: %v", err)
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		t.Fatalf("Cannot create stderr pipe: %v", err)
-	}
-
-	err = cmd.Start()
-	if err != nil {
-		t.Fatalf("Error starting 'pebble run': %v", err)
-	}
-
-	stopStdout := make(chan struct{})
-	stopStderr := make(chan struct{})
-
-	t.Cleanup(func() {
-		err := cmd.Process.Signal(os.Interrupt)
-		if err != nil {
-			t.Errorf("Error sending SIGINT/Ctrl+C to pebble: %v", err)
-		}
-		cmd.Wait()
-		close(stopStdout)
-		close(stopStderr)
-	})
-
-	readLogs := func(parser *servicelog.Parser, ch chan servicelog.Entry, stop <-chan struct{}) {
-		for parser.Next() {
-			if err := parser.Err(); err != nil {
-				t.Errorf("Cannot parse Pebble logs: %v", err)
-			}
-			select {
-			case ch <- parser.Entry():
-			case <-stop:
-				return
-			}
-		}
-	}
-
-	// Both stderr and stdout are needed, because pebble logs to stderr
-	// while with "--verbose", services output to stdout.
-	stderrParser := servicelog.NewParser(stderrPipe, 4*1024)
-	stdoutParser := servicelog.NewParser(stdoutPipe, 4*1024)
-
-	go readLogs(stdoutParser, stdoutCh, stopStdout)
-	go readLogs(stderrParser, stderrCh, stopStderr)
-
-	return stdoutCh, stderrCh
-}
-
-// pebbleEnter runs `pebble enter` with optional arguments
-// and returns two channels for standard output and standard error.
-func pebbleEnter(t *testing.T, pebbleDir string, args ...string) (stdoutCh chan string, stderrCh chan string) {
+// pebbleDaemon starts the pebble daemon with optional arguments
+// and returns two channels yielding the lines from standard output and
+// standard error. The runOrEnter argument should be "run" or "enter".
+func pebbleDaemon(t *testing.T, pebbleDir string, runOrEnter string, args ...string) (stdoutCh chan string, stderrCh chan string) {
 	t.Helper()
 
 	stdoutCh = make(chan string)
 	stderrCh = make(chan string)
 
-	cmd := exec.Command(*pebbleBin, append([]string{"enter"}, args...)...)
+	cmd := exec.Command(*pebbleBin, append([]string{runOrEnter}, args...)...)
 	cmd.Env = append(os.Environ(), "PEBBLE="+pebbleDir)
 
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -193,15 +132,19 @@ func pebbleEnter(t *testing.T, pebbleDir string, args ...string) (stdoutCh chan 
 
 // waitForLog waits until an expectedLog from an expectedService appears in the logs channel, or fails the test after a
 // specified timeout if the expectedLog is still not found.
-func waitForLog(t *testing.T, logsCh <-chan servicelog.Entry, expectedService, expectedLog string, timeout time.Duration) {
+func waitForLog(t *testing.T, linesCh <-chan string, expectedService, expectedLog string, timeout time.Duration) {
 	t.Helper()
 
 	timeoutCh := time.After(timeout)
 	for {
 		select {
-		case log, ok := <-logsCh:
+		case line, ok := <-linesCh:
 			if !ok {
-				t.Error("channel closed before all expected logs were received")
+				t.Fatalf("channel closed before all expected logs were received")
+			}
+			log, err := servicelog.Parse([]byte(line))
+			if err != nil {
+				t.Fatalf("cannot parse log: %v", err)
 			}
 
 			if log.Service == expectedService && strings.Contains(log.Message, expectedLog) {

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -203,6 +203,7 @@ func waitForLog(t *testing.T, logsCh <-chan servicelog.Entry, expectedService, e
 			if !ok {
 				t.Error("channel closed before all expected logs were received")
 			}
+
 			if log.Service == expectedService && strings.Contains(log.Message, expectedLog) {
 				return
 			}

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -145,8 +145,7 @@ services:
 // TestVerboseEnabledByEnvVar tests that Pebble logs all output from services to stdout
 // with the environment variable `PEBBLE_VERBOSE` set to "1".
 func TestVerboseEnabledByEnvVar(t *testing.T) {
-	os.Setenv("PEBBLE_VERBOSE", "1")
-	defer os.Setenv("PEBBLE_VERBOSE", "")
+	t.Setenv("PEBBLE_VERBOSE", "1")
 
 	pebbleDir := t.TempDir()
 
@@ -165,12 +164,8 @@ services:
 	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
 }
 
-// TestVerboseFlagOverrideEnvVar tests that Pebble logs all output from services to stdout
-// with the environment variable `PEBBLE_VERBOSE` set to "0" but also with the `--verbose`
-// option.
-func TestVerboseFlagOverrideEnvVar(t *testing.T) {
-	os.Setenv("PEBBLE_VERBOSE", "0")
-	defer os.Setenv("PEBBLE_VERBOSE", "")
+func TestVerboseFlagOverridesEnvVar(t *testing.T) {
+	t.Setenv("PEBBLE_VERBOSE", "0")
 
 	pebbleDir := t.TempDir()
 

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -142,6 +142,53 @@ services:
 	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
 }
 
+// TestVerboseEnabledByEnvVar tests that Pebble logs all output from services to stdout
+// with the environment variable `PEBBLE_VERBOSE` set to "1".
+func TestVerboseEnabledByEnvVar(t *testing.T) {
+	os.Setenv("PEBBLE_VERBOSE", "1")
+	defer os.Setenv("PEBBLE_VERBOSE", "")
+
+	pebbleDir := t.TempDir()
+
+	layersFileName := "001-simple-layer.yaml"
+	layerYAML := `
+services:
+    svc1:
+        override: replace
+        command: /bin/sh -c "echo 'hello world'; sleep 10"
+        startup: enabled
+`
+	createLayer(t, pebbleDir, layersFileName, layerYAML)
+
+	stdoutCh, stderrCh := pebbleRun(t, pebbleDir)
+	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
+	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
+}
+
+// TestVerboseFlagOverrideEnvVar tests that Pebble logs all output from services to stdout
+// with the environment variable `PEBBLE_VERBOSE` set to "0" but also with the `--verbose`
+// option.
+func TestVerboseFlagOverrideEnvVar(t *testing.T) {
+	os.Setenv("PEBBLE_VERBOSE", "0")
+	defer os.Setenv("PEBBLE_VERBOSE", "")
+
+	pebbleDir := t.TempDir()
+
+	layersFileName := "001-simple-layer.yaml"
+	layerYAML := `
+services:
+    svc1:
+        override: replace
+        command: /bin/sh -c "echo 'hello world'; sleep 10"
+        startup: enabled
+`
+	createLayer(t, pebbleDir, layersFileName, layerYAML)
+
+	stdoutCh, stderrCh := pebbleRun(t, pebbleDir, "--verbose")
+	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
+	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
+}
+
 // TestArgs tests that Pebble provides additional arguments to a service
 // with the `--args` option.
 func TestArgs(t *testing.T) {

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -49,7 +49,7 @@ services:
 
 	createLayer(t, pebbleDir, "001-simple-layer.yaml", layerYAML)
 
-	_, _ = pebbleRun(t, pebbleDir)
+	_, _ = pebbleDaemon(t, pebbleDir, "run")
 	waitForFile(t, filepath.Join(pebbleDir, "svc1"), 3*time.Second)
 	waitForFile(t, filepath.Join(pebbleDir, "svc2"), 3*time.Second)
 }
@@ -60,7 +60,7 @@ func TestCreateDirs(t *testing.T) {
 	tmpDir := t.TempDir()
 	pebbleDir := filepath.Join(tmpDir, "pebble")
 
-	_, stderrCh := pebbleRun(t, pebbleDir, "--create-dirs")
+	_, stderrCh := pebbleDaemon(t, pebbleDir, "run", "--create-dirs")
 	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
 
 	st, err := os.Stat(pebbleDir)
@@ -88,7 +88,7 @@ services:
 	)
 	createLayer(t, pebbleDir, "001-simple-layer.yaml", layerYAML)
 
-	_, _ = pebbleRun(t, pebbleDir, "--hold")
+	_, _ = pebbleDaemon(t, pebbleDir, "run", "--hold")
 
 	// Sleep 100 millisecond before checking services because immediate check
 	// can't guarantee that svc1 is not started shortly after the log "Started daemon".
@@ -109,7 +109,7 @@ func TestHTTPPort(t *testing.T) {
 	pebbleDir := t.TempDir()
 
 	port := "61382"
-	_, stderrCh := pebbleRun(t, pebbleDir, "--http=:"+port)
+	_, stderrCh := pebbleDaemon(t, pebbleDir, "run", "--http=:"+port)
 	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
 
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/v1/health", port))
@@ -137,7 +137,7 @@ services:
 `
 	createLayer(t, pebbleDir, layersFileName, layerYAML)
 
-	stdoutCh, stderrCh := pebbleRun(t, pebbleDir, "--verbose")
+	stdoutCh, stderrCh := pebbleDaemon(t, pebbleDir, "run", "--verbose")
 	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
 	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
 }
@@ -159,7 +159,7 @@ services:
 `
 	createLayer(t, pebbleDir, layersFileName, layerYAML)
 
-	stdoutCh, stderrCh := pebbleRun(t, pebbleDir)
+	stdoutCh, stderrCh := pebbleDaemon(t, pebbleDir, "run")
 	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
 	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
 }
@@ -179,7 +179,7 @@ services:
 `
 	createLayer(t, pebbleDir, layersFileName, layerYAML)
 
-	stdoutCh, stderrCh := pebbleRun(t, pebbleDir, "--verbose")
+	stdoutCh, stderrCh := pebbleDaemon(t, pebbleDir, "run", "--verbose")
 	waitForLog(t, stderrCh, "pebble", "Started daemon", 3*time.Second)
 	waitForLog(t, stdoutCh, "svc1", "hello world", 3*time.Second)
 }
@@ -199,7 +199,7 @@ services:
 	layersFileName := "001-simple-layer.yaml"
 	createLayer(t, pebbleDir, layersFileName, layerYAML)
 
-	stdoutCh, stderrCh := pebbleRun(t, pebbleDir, "--verbose",
+	stdoutCh, stderrCh := pebbleDaemon(t, pebbleDir, "run", "--verbose",
 		"--args",
 		"svc1",
 		"-c",
@@ -226,7 +226,7 @@ identities:
 		t.Fatalf("Cannot write identities file: %v", err)
 	}
 
-	_, stderrCh := pebbleRun(t, pebbleDir, "--identities="+filepath.Join(pebbleDir, identitiesFileName))
+	_, stderrCh := pebbleDaemon(t, pebbleDir, "run", "--identities="+filepath.Join(pebbleDir, identitiesFileName))
 
 	// wait for log "Started daemon" like in other test cases then immediately run `pebble identity` would sometimes
 	// fail because the identities are not fully seeded. Waiting for the next log "POST /v1/services" can guarantee


### PR DESCRIPTION
This PR adds a new environment variable "PEBBLE_VERBOSE", which if set to "1", Pebble will print service logs to Pebble's standard output. See [this spec](https://docs.google.com/document/d/1-NCelXSb4dVjZuEGDp_jsTnzV0idq6BXqZ4kGCkO9Nw/edit?tab=t.0) (internal only) for more details.

Summary:

- For `pebble run`, allow verbose logging mode (log all output from services to stdout) to be enabled when starting the daemon by setting the environment variable `PEBBLE_VERBOSE=1`.  This is equivalent to `pebble run --verbose`. Even if `PEBBLE_VERBOSE` is set to "0" explicitly, if the `--verbose` flag is still specified, the verbose logging mode is still enabled: the `--verbose` flag has higher priority.
- For `pebble enter exec`, the `--verbose` flag is currently disabled. However, `pebble enter` (including `pebble enter exec`) would still respect `PEBBLE_VERBOSE=1`.
- Some tests are added to cover the function of this environment variable.
- A new reference doc is created to document all existing environment variables for Pebble.