### PR TITLE
chore: add targets for links from Ops docs

### DIFF
--- a/docs/how-to/use-layers.md
+++ b/docs/how-to/use-layers.md
@@ -1,3 +1,4 @@
+(how-to-use-layers)=
 # How to use layers
 
 Managing multiple services across different environments becomes complex as systems scale. Pebble simplifies this with layered configurations, improving readability and maintainability.
@@ -36,6 +37,8 @@ checks:
 
 For full details of all fields, see [layer specification](../reference/layer-specification).
 
+
+(use_layers_layer_override)=
 ## Layer override
 
 Each layer can define new services (and health checks and log targets) or modify existing ones defined in preceding layers. The layers -- ordered by numerical prefix -- are combined into the final plan.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -30,23 +30,23 @@ Service auto-restart <service-auto-restart>
 
 Pebble configuration is defined as a stack of "layers".
 
-* [Layers](layer-specification)
-* [Layer specification](layer-specification)
+* [Layers](./layer-specification)
+* [Layer specification](./layer-specification)
 
 
 ## Pebble commands
 
 The `pebble` command has several subcommands.
 
-* [CLI commands](cli-commands)
+* [CLI commands](./cli-commands)
 
 
 ## Service failures
 
 Pebble provides two ways to automatically restart services when they fail. Auto-restart is based on exit codes from services. Health checks are a more sophisticated way to test and report the availability of services.
 
-* [Service auto-restart](service-auto-restart)
-* [Health checks](health-checks)
+* [Service auto-restart](./service-auto-restart)
+* [Health checks](./health-checks)
 
 
 % COMMENT: After this point, match the alphabetical listing of pages
@@ -56,31 +56,31 @@ Pebble provides two ways to automatically restart services when they fail. Auto-
 
 Pebble tracks system changes as "tasks" grouped into "change" objects.
 
-* [Changes and tasks](changes-and-tasks)
+* [Changes and tasks](./changes-and-tasks)
 
 
 ## Identities
 
 You can set up named "identities" to control access to the API.
 
-* [Identities](identities)
+* [Identities](./identities)
 
 
 ## Log forwarding
 
 Pebble can send service logs to a centralized logging system.
 
-* [Log forwarding](log-forwarding)
+* [Log forwarding](./log-forwarding)
 
 
 ## Notices
 
 Pebble records events as "notices". In addition to the built-in notices, clients can report custom notices.
 
-* [Notices](notices)
+* [Notices](./notices)
 
 ## Accessing the API
 
 Pebble exposes API over HTTP to allow remote clients to interact with the daemon.
 
-* [API](api)
+* [API](./api)

--- a/docs/reference/layer-specification.md
+++ b/docs/reference/layer-specification.md
@@ -1,3 +1,4 @@
+(layer-specification)=
 # Layer specification
 
 Below is the full specification for a Pebble configuration layer. Layers are added statically using a file in `$PEBBLE/layers`, or dynamically via the layers API or `pebble add`.


### PR DESCRIPTION
This PR adds intersphinx targets needed by https://github.com/canonical/operator/pull/1603. We haven't been entirely consistent with `-` vs `_` in targets in Pebble, so I've tried to be as consistent as possible:
- Use `-` for title targets
- Match the format of siblings for section targets