### PR TITLE
refactor: move performCheck/recoverCheck logic into their own functions

### DIFF
--- a/internals/overlord/checkstate/handlers.go
+++ b/internals/overlord/checkstate/handlers.go
@@ -43,57 +43,66 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 	defer ticker.Stop()
 
 	chk := newChecker(config)
+
+	performCheck := func() (shouldExit bool, err error) {
+		err = runCheck(tomb.Context(nil), chk, config.Timeout.Value)
+		if !tomb.Alive() {
+			return true, checkStopped(config.Name, task.Kind(), tomb.Err())
+		}
+		if err != nil {
+			m.incFailureCount(config)
+			// Record check failure and perform any action if the threshold
+			// is reached (for example, restarting a service).
+			details.Failures++
+			atThreshold := details.Failures >= config.Threshold
+			if !atThreshold {
+				// Update number of failures in check info. In threshold
+				// case, check data will be updated with new change ID by
+				// changeStatusChanged.
+				m.updateCheckData(config, changeID, details.Failures)
+			}
+
+			m.state.Lock()
+			if atThreshold {
+				details.Proceed = true
+			} else {
+				// Add error to task log, but only if we haven't reached the
+				// threshold. When we hit the threshold, the "return err"
+				// below will cause the error to be logged.
+				logTaskError(task, err)
+			}
+			task.Set(checkDetailsAttr, &details)
+			m.state.Unlock()
+
+			logger.Noticef("Check %q failure %d/%d: %v", config.Name, details.Failures, config.Threshold, err)
+			if atThreshold {
+				logger.Noticef("Check %q threshold %d hit, triggering action and recovering", config.Name, config.Threshold)
+				m.callFailureHandlers(config.Name)
+				// Returning the error means perform-check goes to Error status
+				// and logs the error to the task log.
+				return true, err
+			}
+		} else {
+			m.incSuccessCount(config)
+			if details.Failures > 0 {
+				m.updateCheckData(config, changeID, 0)
+
+				m.state.Lock()
+				task.Logf("succeeded after %s", pluralise(details.Failures, "failure", "failures"))
+				details.Failures = 0
+				task.Set(checkDetailsAttr, &details)
+				m.state.Unlock()
+			}
+		}
+		return false, nil
+	}
+
 	for {
 		select {
 		case <-ticker.C:
-			err := runCheck(tomb.Context(nil), chk, config.Timeout.Value)
-			if !tomb.Alive() {
-				return checkStopped(config.Name, task.Kind(), tomb.Err())
-			}
-			if err != nil {
-				m.incFailureCount(config)
-				// Record check failure and perform any action if the threshold
-				// is reached (for example, restarting a service).
-				details.Failures++
-				atThreshold := details.Failures >= config.Threshold
-				if !atThreshold {
-					// Update number of failures in check info. In threshold
-					// case, check data will be updated with new change ID by
-					// changeStatusChanged.
-					m.updateCheckData(config, changeID, details.Failures)
-				}
-
-				m.state.Lock()
-				if atThreshold {
-					details.Proceed = true
-				} else {
-					// Add error to task log, but only if we haven't reached the
-					// threshold. When we hit the threshold, the "return err"
-					// below will cause the error to be logged.
-					logTaskError(task, err)
-				}
-				task.Set(checkDetailsAttr, &details)
-				m.state.Unlock()
-
-				logger.Noticef("Check %q failure %d/%d: %v", config.Name, details.Failures, config.Threshold, err)
-				if atThreshold {
-					logger.Noticef("Check %q threshold %d hit, triggering action and recovering", config.Name, config.Threshold)
-					m.callFailureHandlers(config.Name)
-					// Returning the error means perform-check goes to Error status
-					// and logs the error to the task log.
-					return err
-				}
-			} else {
-				m.incSuccessCount(config)
-				if details.Failures > 0 {
-					m.updateCheckData(config, changeID, 0)
-
-					m.state.Lock()
-					task.Logf("succeeded after %s", pluralise(details.Failures, "failure", "failures"))
-					details.Failures = 0
-					task.Set(checkDetailsAttr, &details)
-					m.state.Unlock()
-				}
+			shouldExit, err := performCheck()
+			if shouldExit {
+				return err
 			}
 
 		case <-tomb.Dying():
@@ -129,36 +138,44 @@ func (m *CheckManager) doRecoverCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 	defer ticker.Stop()
 
 	chk := newChecker(config)
+
+	recoverCheck := func() (shouldExit bool, err error) {
+		err = runCheck(tomb.Context(nil), chk, config.Timeout.Value)
+		if !tomb.Alive() {
+			return true, checkStopped(config.Name, task.Kind(), tomb.Err())
+		}
+		if err != nil {
+			m.incFailureCount(config)
+			details.Failures++
+			m.updateCheckData(config, changeID, details.Failures)
+
+			m.state.Lock()
+			task.Set(checkDetailsAttr, &details)
+			logTaskError(task, err)
+			m.state.Unlock()
+
+			logger.Noticef("Check %q failure %d/%d: %v", config.Name, details.Failures, config.Threshold, err)
+			return false, nil
+		}
+
+		// Check succeeded, switch to performing a succeeding check.
+		// Check info will be updated with new change ID by changeStatusChanged.
+		m.incSuccessCount(config)
+		details.Failures = 0 // not strictly needed, but just to be safe
+		details.Proceed = true
+		m.state.Lock()
+		task.Set(checkDetailsAttr, &details)
+		m.state.Unlock()
+		return true, nil
+	}
+
 	for {
 		select {
 		case <-ticker.C:
-			err := runCheck(tomb.Context(nil), chk, config.Timeout.Value)
-			if !tomb.Alive() {
-				return checkStopped(config.Name, task.Kind(), tomb.Err())
+			shouldExit, err := recoverCheck()
+			if shouldExit {
+				return err
 			}
-			if err != nil {
-				m.incFailureCount(config)
-				details.Failures++
-				m.updateCheckData(config, changeID, details.Failures)
-
-				m.state.Lock()
-				task.Set(checkDetailsAttr, &details)
-				logTaskError(task, err)
-				m.state.Unlock()
-
-				logger.Noticef("Check %q failure %d/%d: %v", config.Name, details.Failures, config.Threshold, err)
-				break
-			}
-
-			// Check succeeded, switch to performing a succeeding check.
-			// Check info will be updated with new change ID by changeStatusChanged.
-			m.incSuccessCount(config)
-			details.Failures = 0 // not strictly needed, but just to be safe
-			details.Proceed = true
-			m.state.Lock()
-			task.Set(checkDetailsAttr, &details)
-			m.state.Unlock()
-			return nil
 
 		case <-tomb.Dying():
 			return checkStopped(config.Name, task.Kind(), tomb.Err())


### PR DESCRIPTION
This moves the logic inside each `ticker.C` case into an inner function. This is a reasonable change by itself, as it makes the for+select loop easier to read. It also reduces the indent one level. However, it's mainly in preparation for the new logic required for RefreshCheck (pebble check --refresh). See: https://github.com/canonical/pebble/pull/577/files

There shouldn't be any logic change here. I've simply replaced the `return`s to return `shouldExit==true` so the caller knows to return.

Note: the changes are *much* easier to review with [whitespace hidden](https://github.com/canonical/pebble/pull/582/files?diff=split&w=1) in GitHub.