### PR TITLE
docs: remove openapi spec auth

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -810,8 +810,6 @@ paths:
         When used over TCP, this endpoint requires HTTP basic authentication using an identity of type "basic". See [Identities](../identities) for more information.
       tags:
         - metrics
-      security:
-        - basicAuth: []
       responses:
         "200":
           description: Metrics in OpenMetrics format.
@@ -1188,10 +1186,6 @@ paths:
                   }
                 }
 components:
-  securitySchemes:
-    basicAuth:
-      type: http
-      scheme: basic
   schemas:
     BaseResponse:
       type: object


### PR DESCRIPTION
This PR removes the lock icon and the authorize section in the rendered swagger UI:

![Screenshot from 2025-03-05 08-11-05](https://github.com/user-attachments/assets/833f824d-1db0-40b0-917c-a6040919c3f1)

After adding basic auth for the metrics endpoint, the Swagger UI renders an auth section that doesn't look nice or function properly. When clicked, it asks for a username and password, which would not work anyway since we don't have an API server.

Although adding the auth section means there is a lock logo on the `/v1/metrics` endpoint which is nice to have, it's not exactly necessary, because users need to read the descriptions about basic identities anyway. So, after a discussion with David, we decided to remove this.

[Current rendered result](https://documentation.ubuntu.com/pebble/reference/api/#api-endpoints), [metrics endpoint lock logo](https://documentation.ubuntu.com/pebble/reference/api/#/metrics); see the preview after deleting this part [here](https://canonical-ubuntu-documentation-library--583.com.readthedocs.build/pebble/reference/api/#api-endpoints), no lock logo on the metrics endpoint either.