### PR TITLE
chore: bump the docs Jinja2 version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -60,7 +60,7 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   myst-parser
     #   sphinx


### PR DESCRIPTION
Jinja2 3.1.6 fixes an issue with using `|attr` an having the Jinja sandbox apply. This should not be relevant to building the Pebble docs, but bumping the version is simple to do and silences the warning about a security issue with a dependency.

[Preview](https://canonical-ubuntu-documentation-library--584.com.readthedocs.build/pebble/) (nothing appears to have changed, as expected).