### PR TITLE
docs: improve description for Snap Store listing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,18 +5,26 @@ description: |
   Pebble helps you to orchestrate a set of local service processes
   as an organized set. It resembles well-known tools such as supervisord,
   runit, or s6, in that it can easily manage non-system processes
-  independently from the system services, but it was designed with unique
+  independently from system services, but it was designed with unique
   features that help with more specific use cases.
 
   **Usage**
 
-  * The Pebble snap's default directory is `$SNAP_USER_DATA` (which translates
-  to `$HOME/snap/pebble/<rev>/`).
+  You can use the `pebble` command to:
+
+  * Start and stop services that are defined in Pebble's service configuration.
+  * Modify Pebble's service configuration by adding or removing layers.
+  * Check the health of services.
+  * Manage services remotely, as a client interacting with Pebble in a separate system.
+  * And more!
+
+  When Pebble is installed as a snap, Pebble uses the working directory
+  `$HOME/snap/pebble/<snap_revision>/` when it runs services.
+  You can override the working directory on a per-service basis in Pebble's service configuration.
 
   **Documentation**
 
-  To learn more about Pebble please check the project's documentation at
-  https://github.com/canonical/pebble.
+  To learn more about Pebble, see https://documentation.ubuntu.com/pebble/.
 issues: https://github.com/canonical/pebble/issues
 source-code: https://github.com/canonical/pebble
 license: GPL-3.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,9 +18,9 @@ description: |
   * Manage services remotely, as a client interacting with Pebble in a separate system.
   * And more!
 
-  When Pebble is installed as a snap, Pebble uses the working directory
-  `$HOME/snap/pebble/<snap_revision>/` when it runs services.
-  You can override the working directory on a per-service basis in Pebble's service configuration.
+  Pebble stores its service configuration in the `$PEBBLE/layers` directory.
+  When Pebble is installed as a snap, the `PEBBLE` environment variable is
+  set to `$HOME/snap/pebble/<snap_revision>/` by default.
 
   **Documentation**
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ description: |
 
   Pebble stores its service configuration in the `$PEBBLE/layers` directory.
   When Pebble is installed as a snap, the `PEBBLE` environment variable is
-  set to `$HOME/snap/pebble/<snap_revision>/` by default.
+  set to `$HOME/snap/pebble/<snap_revision>` by default.
 
   **Documentation**
 


### PR DESCRIPTION
This PR improves the description that appears on the [Snap Store page](https://snapcraft.io/pebble) for Pebble.

Note that I removed mention of `SNAP_USER_DATA` by name, as that variable is not set outside of the snap. Outside of the snap, the most relevant point is that layer config is stored in `$PEBBLE/layers`, where `PEBBLE` is set to `$HOME/snap/pebble/<snap_revision>` by default.