### PR TITLE
docs: document how to tail file logs

### DIFF
--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -1,4 +1,4 @@
-# How to tail file logs
+# How to capture logs from files
 
 Some applications do not log to `stdout` or `stderr`, but instead write logs directly to
 files such as `access.log`, `audit.log` or `error.log`. While Pebble does not natively

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -27,8 +27,9 @@ services:
     startup: enabled
 ```
 
-The separate helper service `tail -F` starts before the main service.
-The `-F` option ensures that logs are captured reliably, even if log files are rotated.
+The helper service `foo-error-log` starts before the main service.
+The `-F` option of the `tail` command ensures that logs are captured reliably,
+even if log files are rotated.
 
 This setup handles a variety of common corner cases:
 - the log file doesn't exist when the service starts

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -14,8 +14,6 @@ To use `tail`, we'll define a layer that has a main service (`foo`) and a helper
 for `tail`:
 
 ```{code-block} yaml
-  :emphasize-lines: 5, 7, 10
-
 services:
   foo:
     command: foo
@@ -30,6 +28,10 @@ services:
 ```
 
 The helper service `foo-error-log` starts before the main service.
+Likewise, if the services are disabled, the helper service `foo-error-log` will be
+stopped after the main service `foo`.
+This ensures that logs emitted during both startup and termination are captured.
+
 The `-F` option of the `tail` command ensures that logs are captured reliably,
 even if log files are rotated.
 
@@ -37,7 +39,6 @@ This setup handles common corner cases:
 - The log file doesn't exist when the service starts
 - The log file is truncated, deleted or replaced
 - A safety net if the log file is large at startup
-- Controlled stop order if services are disabled
 
 A separate helper service is required for each log file.
 
@@ -64,4 +65,4 @@ To learn more about Rockcraft and `rockcraft.yaml` files, see the
 ## See more
 
 - After capturing logs, you can [forward the logs to Loki](./forward-logs-to-loki).
-- If `tail` is insufficient, consider using Promtail instead of `tail`.
+- If `tail` is insufficient, consider using the Promtail binary instead.

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -3,13 +3,13 @@
 Some applications do not log to `stdout` or `stderr`, but instead write logs directly to
 files such as `access.log`, `audit.log` or `error.log`. While Pebble does not natively
 support tailing files, you can use `tail` from `coreutils` in a separate Pebble service
-to route file contents into Pebble’s log stream.
+to route file contents into Pebble's log stream.
 
 This guide shows how to set that up.
 
 ## Example Pebble layer
 
-Here’s how to tail a log file alongside your main service:
+Here's how to tail a log file alongside your main service:
 
 ```{code-block} yaml
   :emphasize-lines: 5, 7, 10

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -1,11 +1,12 @@
 # How to capture logs from files
 
-Some applications do not log to `stdout` or `stderr`, but instead write logs directly to
-files such as `access.log`, `audit.log` or `error.log`. While Pebble does not natively
-support tailing files, you can use `tail` from `coreutils` in a separate Pebble service
-to route file contents into Pebble's log stream.
+Pebble stores the most recent `stdout` and `stderr` from each service. However, some
+applications don't log to `stdout` or `stderr`. Instead, they write logs directly to
+files such as `access.log`, `audit.log`, or `error.log`.
 
-This guide shows how to set that up.
+This guide demonstrates how to use the `tail` command to print log files to `stdout`,
+so that Pebble can capture the logs. The `tail` command is provided by the `coreutils`
+package.
 
 ## Define a layer
 

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -41,7 +41,10 @@ A separate helper service is required for each log file.
 
 ## Include `tail` in a rock image
 
-If your workload is packaged as a rock, you may need to explicitly add `tail`:
+If your main service runs inside a container image created by Rockcraft,
+you might need to explicitly include `tail` when you build the image.
+
+To include `tail`, add the following part to your `rockcraft.yaml` file:
 
 ```yaml
 parts:
@@ -52,6 +55,9 @@ parts:
     organize:
       usr/bin/tail: usr/bin/tail
 ```
+
+To learn more about Rockcraft and `rockcraft.yaml` files, see the
+[Rockcraft documenttion](https://documentation.ubuntu.com/rockcraft/en/stable/).
 
 ## See more
 

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -42,27 +42,32 @@ This setup handles common corner cases:
 
 A separate helper service is required for each log file.
 
-## Include `tail` in a rock image
+## Include `tail` in a chiselled rock
 
-If your main service runs inside a container image created by Rockcraft,
-you might need to explicitly include `tail` when you build the image.
-
-To include `tail`, add the following part to your `rockcraft.yaml` file:
+Chiselled rocks often exclude tools like `coreutils`. To add `/usr/bin/tail`, extend
+[the official example](https://documentation.ubuntu.com/rockcraft/en/latest/how-to/rocks/chisel-existing-rock/)
+by staging `coreutils_bins` slice in your `rockcraft.yaml` file:
 
 ```yaml
-parts:
-  tail:
+  install-python-slices:
     plugin: nil
     stage-packages:
-      - coreutils
-    organize:
-      usr/bin/tail: usr/bin/tail
+      - base-files_release-info
+      - python3.11_core
+      - coreutils_bins  # includes /usr/bin/tail and the required libraries
 ```
 
-To learn more about Rockcraft and `rockcraft.yaml` files, see the
-[Rockcraft documentation](https://documentation.ubuntu.com/rockcraft/en/stable/).
+The `coreutils_bins` slice brings in around a dozen shared objects and some hundred binaries.
+For a truly minimal rock, consider
+[defining a custom chisel slice](https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/create-slice/).
+
+See the
+[Rockcraft documentation](https://documentation.ubuntu.com/rockcraft/en/stable/)
+to learn more.
 
 ## See more
 
 - After capturing logs, you can [forward the logs to Loki](./forward-logs-to-loki).
-- If `tail` is insufficient, consider using the Promtail binary instead.
+- If `tail` is insufficient, consider using the
+  [Promtail binary](https://github.com/canonical/loki-k8s-operator/blob/main/.github/workflows/build-promtail-release.yaml)
+  instead.

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -10,7 +10,8 @@ package.
 
 ## Define a layer
 
-Here's how to tail a log file alongside your main service:
+To use `tail`, we'll define a layer that has a main service (`foo`) and a helper service
+for `tail`:
 
 ```{code-block} yaml
   :emphasize-lines: 5, 7, 10

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -46,7 +46,7 @@ A separate helper service is required for each log file.
 
 Chiselled rocks often exclude tools like `coreutils`. To add `/usr/bin/tail`, extend
 [the official example](https://documentation.ubuntu.com/rockcraft/en/latest/how-to/rocks/chisel-existing-rock/)
-by staging `coreutils_bins` slice in your `rockcraft.yaml` file:
+by staging the `coreutils_bins` slice in your `rockcraft.yaml` file:
 
 ```yaml
   install-python-slices:

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -7,7 +7,7 @@ to route file contents into Pebble's log stream.
 
 This guide shows how to set that up.
 
-## Example Pebble layer
+## Define a layer
 
 Here's how to tail a log file alongside your main service:
 
@@ -39,7 +39,7 @@ This setup handles common corner cases:
 
 A separate helper service is required for each log file.
 
-## Rockcraft
+## Include `tail` in a rock image
 
 If your workload is packaged as a rock, you may need to explicitly add `tail`:
 

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -57,7 +57,7 @@ parts:
 ```
 
 To learn more about Rockcraft and `rockcraft.yaml` files, see the
-[Rockcraft documenttion](https://documentation.ubuntu.com/rockcraft/en/stable/).
+[Rockcraft documentation](https://documentation.ubuntu.com/rockcraft/en/stable/).
 
 ## See more
 

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -31,11 +31,11 @@ The helper service `foo-error-log` starts before the main service.
 The `-F` option of the `tail` command ensures that logs are captured reliably,
 even if log files are rotated.
 
-This setup handles a variety of common corner cases:
-- the log file doesn't exist when the service starts
-- the log file is truncated, deleted or replaced
-- a safety net if the log file is large at startup
-- controlled stop order if services are disabled
+This setup handles common corner cases:
+- The log file doesn't exist when the service starts
+- The log file is truncated, deleted or replaced
+- A safety net if the log file is large at startup
+- Controlled stop order if services are disabled
 
 A separate helper service is required for each log file.
 

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -53,9 +53,7 @@ parts:
       usr/bin/tail: usr/bin/tail
 ```
 
-## Further reading
+## See more
 
-This recipe can be composed with [forwarding logs to Loki](./forward-logs-to-loki.md).
-
-Consider Promtail instead of `tail` for advanced use cases or if the latter proves to be
-insufficient.
+- After capturing logs, you can [forward the logs to Loki](./forward-logs-to-loki).
+- If `tail` is insufficient, consider using Promtail instead of `tail`.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -49,7 +49,7 @@ To better understand the operation of the services, you may need to work with lo
 :maxdepth: 1
 
 Forward logs to Loki <forward-logs-to-loki>
-Tail file logs <tail-file-logs>
+Capture logs from files <capture-logs-from-files>
 ```
 
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -49,6 +49,7 @@ To better understand the operation of the services, you may need to work with lo
 :maxdepth: 1
 
 Forward logs to Loki <forward-logs-to-loki>
+Tail file logs <tail-file-logs>
 ```
 
 

--- a/docs/how-to/tail-file-logs.md
+++ b/docs/how-to/tail-file-logs.md
@@ -1,0 +1,60 @@
+# How to tail file logs
+
+Some applications do not log to `stdout` or `stderr`, but instead write logs directly to
+files such as `access.log`, `audit.log` or `error.log`. While Pebble does not natively
+support tailing files, you can use `tail` from `coreutils` in a separate Pebble service
+to route file contents into Pebble’s log stream.
+
+This guide shows how to set that up.
+
+## Example Pebble layer
+
+Here’s how to tail a log file alongside your main service:
+
+```{code-block} yaml
+  :emphasize-lines: 5, 7, 10
+
+services:
+  foo:
+    command: foo
+    startup: enabled
+    requires:
+      - foo-error-log
+    after:
+      - foo-error-log
+  foo-error-log:
+    command: tail -F /var/log/foo/error.log
+    startup: enabled
+```
+
+The separate helper service `tail -F` starts before the main service.
+The `-F` option ensures that logs are captured reliably, even if log files are rotated.
+
+This setup handles a variety of common corner cases:
+- the log file doesn't exist when the service starts
+- the log file is truncated, deleted or replaced
+- a safety net if the log file is large at startup
+- controlled stop order if services are disabled
+
+A separate helper service is required for each log file.
+
+## Rockcraft
+
+If your workload is packaged as a rock, you may need to explicitly add `tail`:
+
+```yaml
+parts:
+  tail:
+    plugin: nil
+    stage-packages:
+      - coreutils
+    organize:
+      usr/bin/tail: usr/bin/tail
+```
+
+## Further reading
+
+This recipe can be composed with [forwarding logs to Loki](./forward-logs-to-loki.md).
+
+Consider Promtail instead of `tail` for advanced use cases or if the latter proves to be
+insufficient.


### PR DESCRIPTION
The proposal to add file tailing functionality directly to Pebble was rejected.
This PR documents the workaround.