### PR TITLE
feat(https): add https API server [3/4]

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -869,6 +869,9 @@ pebble run --args myservice --port 8080 \; --hold
           --http=        Start HTTP API listening on this address in
                          "<address>:port" format (for example, ":4000",
                          "192.0.2.0:4000", "[2001:db8::1]:4000")
+          --https=       Start HTTPS API listening on this address in
+                         "<address>:port" format (for example, ":8443",
+                         "192.0.2.0:8443", "[2001:db8::1]:8443")
       -v, --verbose      Log all output from services to stdout (also
                          PEBBLE_VERBOSE=1)
           --args=        Provide additional arguments to a service

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -63,7 +63,7 @@ var sharedRunEnterArgsHelp = map[string]string{
 	"--create-dirs": "Create {{.DisplayName}} directory on startup if it doesn't exist",
 	"--hold":        "Do not start default services automatically",
 	"--http":        `Start HTTP API listening on this address in "<address>:port" format (for example, ":4000", "192.0.2.0:4000", "[2001:db8::1]:4000")`,
-	"--https":       `Start HTTPS API listening on this address (e.g., ":8443")`,
+	"--https":       `Start HTTPS API listening on this address in "<address>:port" format (for example, ":8443", "192.0.2.0:8443", "[2001:db8::1]:8443")`,
 	"--verbose":     "Log all output from services to stdout (also PEBBLE_VERBOSE=1)",
 	"--args":        "Provide additional arguments to a service",
 	"--identities":  "Seed identities from file (like update-identities --replace)",

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -199,7 +199,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	dopts := daemon.Options{
 		Dir:          rcmd.pebbleDir,
 		SocketPath:   rcmd.socketPath,
-		IDSigner:   idSigner,
+		IDSigner:     idSigner,
 		HTTPAddress:  rcmd.HTTP,
 		HTTPSAddress: rcmd.HTTPS,
 	}

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -53,6 +53,7 @@ type sharedRunEnterOpts struct {
 	CreateDirs bool       `long:"create-dirs"`
 	Hold       bool       `long:"hold"`
 	HTTP       string     `long:"http"`
+	HTTPS      string     `long:"https"`
 	Verbose    bool       `short:"v" long:"verbose"`
 	Args       [][]string `long:"args" terminator:";"`
 	Identities string     `long:"identities"`
@@ -62,6 +63,7 @@ var sharedRunEnterArgsHelp = map[string]string{
 	"--create-dirs": "Create {{.DisplayName}} directory on startup if it doesn't exist",
 	"--hold":        "Do not start default services automatically",
 	"--http":        `Start HTTP API listening on this address in "<address>:port" format (for example, ":4000", "192.0.2.0:4000", "[2001:db8::1]:4000")`,
+	"--https":       `Start HTTPS API listening on this address (e.g., ":8443")`,
 	"--verbose":     "Log all output from services to stdout (also PEBBLE_VERBOSE=1)",
 	"--args":        "Provide additional arguments to a service",
 	"--identities":  "Seed identities from file (like update-identities --replace)",
@@ -195,14 +197,15 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	}
 
 	dopts := daemon.Options{
-		Dir:        rcmd.pebbleDir,
-		SocketPath: rcmd.socketPath,
+		Dir:          rcmd.pebbleDir,
+		SocketPath:   rcmd.socketPath,
 		IDSigner:   idSigner,
+		HTTPAddress:  rcmd.HTTP,
+		HTTPSAddress: rcmd.HTTPS,
 	}
 	if os.Getenv("PEBBLE_VERBOSE") == "1" || rcmd.Verbose {
 		dopts.ServiceOutput = os.Stdout
 	}
-	dopts.HTTPAddress = rcmd.HTTP
 
 	d, err := daemon.New(&dopts)
 	if err != nil {
@@ -318,8 +321,8 @@ out:
 	}
 
 	// Close the client idle connection to the server (self connection) before we
-	// start with the HTTP shutdown process. This will speed up the server shutdown,
-	// and allow the Pebble process to exit faster.
+	// start with the HTTP/HTTPS shutdown process. This will speed up the server
+	// shutdown, and allow the Pebble process to exit faster.
 	rcmd.client.CloseIdleConnections()
 
 	return d.Stop(ch)

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -380,6 +380,7 @@ func (d *Daemon) Init() error {
 
 	if d.httpsAddress != "" {
 		tlsConf := &tls.Config{
+			NextProtos: []string{"h2", "http/1.1"},
 			MinVersion: tls.VersionTLS13,
 			MaxVersion: tls.VersionTLS13,
 			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -67,7 +67,7 @@ type Options struct {
 	// Defaults to "layers" inside the pebble directory.
 	LayersDir string
 
-	// TLSDir is an optional path for where TLS keypairs are persisted.
+	// TLSDir is an optional path for where the TLS manager persists PEM files.
 	// Defaults to "tls" inside the pebble directory.
 	TLSDir string
 
@@ -380,21 +380,11 @@ func (d *Daemon) Init() error {
 
 	if d.httpsAddress != "" {
 		tlsConf := &tls.Config{
-			NextProtos: []string{"h2", "http/1.1"},
-			MinVersion: tls.VersionTLS13,
-			MaxVersion: tls.VersionTLS13,
-			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-				tlsMgr := d.overlord.TLSManager()
-				tlsKeyPair, err := tlsMgr.TLSKeyPair()
-				if err != nil {
-					return nil, err
-				}
-				tlsCert, err := tlsKeyPair.TLSCertificate()
-				if err != nil {
-					return nil, err
-				}
-				return tlsCert, nil
-			},
+			// We now support HTTP1.1 and HTTP2 when using HTTPS.
+			NextProtos:     []string{"h2", "http/1.1"},
+			MinVersion:     tls.VersionTLS13,
+			MaxVersion:     tls.VersionTLS13,
+			GetCertificate: d.overlord.TLSManager().GetCertificate,
 		}
 		listener, err := tls.Listen("tcp", d.httpsAddress, tlsConf)
 		if err != nil {

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -16,6 +16,8 @@ package daemon
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -94,11 +96,14 @@ func (s *daemonSuite) TearDownTest(c *C) {
 }
 
 func (s *daemonSuite) newDaemon(c *C) *Daemon {
+	_, signer, err := ed25519.GenerateKey(rand.Reader)
+	c.Assert(err, IsNil)
 	d, err := New(&Options{
 		Dir:          s.pebbleDir,
 		SocketPath:   s.socketPath,
 		HTTPAddress:  s.httpAddress,
 		HTTPSAddress: s.httpsAddress,
+		IDSigner:     signer,
 	})
 	c.Assert(err, IsNil)
 	d.addRoutes()

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -174,7 +174,7 @@ func New(opts *Options) (*Overlord, error) {
 	if tlsDir == "" {
 		tlsDir = filepath.Join(opts.PebbleDir, "tls")
 	}
-	o.tlsMgr, err = tlsstate.NewManager(tlsDir)
+	o.tlsMgr, err = tlsstate.NewManager(tlsDir, opts.IDSigner)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create TLS manager: %w", err)
 	}

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -16,7 +16,6 @@
 package overlord
 
 import (
-	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -82,8 +81,8 @@ type Options struct {
 	Extension Extension
 	// IDSigner is a private key representing the identity of a Pebble
 	// instance (machine, container or device), which implements the
-	// crypto.Signer interface (allowing it to sign TLS keypairs).
-	IDSigner crypto.Signer
+	// tlsstate.IDSigner interface (allowing it to sign digests).
+	IDSigner tlsstate.IDSigner
 }
 
 // Overlord is the central manager of the system, keeping track
@@ -174,10 +173,7 @@ func New(opts *Options) (*Overlord, error) {
 	if tlsDir == "" {
 		tlsDir = filepath.Join(opts.PebbleDir, "tls")
 	}
-	o.tlsMgr, err = tlsstate.NewManager(tlsDir, opts.IDSigner)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create TLS manager: %w", err)
-	}
+	o.tlsMgr = tlsstate.NewManager(tlsDir, opts.IDSigner)
 	o.stateEng.AddManager(o.tlsMgr)
 
 	o.logMgr = logstate.NewLogManager()


### PR DESCRIPTION
**Enable the API over HTTPS**

Pebble can now be started with the API enabled on HTTPS:

```
~/> ./pebble run --https=:8888 --http=:4000 --create-dirs
2025-04-08T15:14:40.523Z [pebble] HTTP API server listening on ":4000".
2025-04-08T15:14:40.524Z [pebble] HTTPS API server listening on ":8888".
2025-04-08T15:14:40.524Z [pebble] Started daemon.
2025-04-08T15:14:40.525Z [pebble] POST /v1/services 190.249µs 400
2025-04-08T15:14:40.525Z [pebble] Cannot start default services: no default services
```

The HTTPS (TLS) keypair is signed by the identity certificate (also included in the certificate chain from the server), so you need to connect with the client configured to allow for an untrusted connection.

The typical connection process will require a trust exchange step that allows the client to trust (pin) the identity certificate. This trust exchange processes (or pairing process) will be added in a future patch.

Note that this patch now enables HTTP2 negotiation (using TLS ALPN), with fallback to HTTP1.1 if the client does not explicitly agree.

```
~/>  curl -k https://localhost:8888/v1/health -vv
* Host localhost:8888 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8888...
* Connected to localhost (::1) port 8888
* ALPN: curl offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / ED25519
* ALPN: server accepted h2
* Server certificate:
*  subject: [NONE]
*  start date: Apr 22 13:30:40 2025 GMT
*  expire date: Apr 22 14:30:40 2025 GMT
*   Certificate level 0: Public key type ED25519 (256/128 Bits/secBits), signed using ED25519
*   Certificate level 1: Public key type ED25519 (256/128 Bits/secBits), signed using ED25519
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://localhost:8888/v1/health
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: localhost:8888]
* [HTTP/2] [1] [:path: /v1/health]
* [HTTP/2] [1] [user-agent: curl/8.5.0]
* [HTTP/2] [1] [accept: */*]
> GET /v1/health HTTP/2
> Host: localhost:8888
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/2 200 
< content-type: application/json
< content-length: 73
< date: Tue, 22 Apr 2025 13:30:41 GMT
< 
* Connection #0 to host localhost left intact
{"type":"sync","status-code":200,"status":"OK","result":{"healthy":true}}
```