### PR TITLE
fix: tighten permissions of --create-dirs directory from 0o755 to 0o700

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -14,7 +14,11 @@ For more information, see [](api-and-clients.md) and [](../how-to/manage-identit
 
 Pebble stores its configuration, internal state, and Unix socket in the directory specified by the `PEBBLE` environment variable. If `$PEBBLE` is not set, Pebble uses the directory `/var/lib/pebble/default`.
 
-The `$PEBBLE` directory must be readable and writable by the UID of the pebble process. Make sure that no other UIDs can read or write to the $PEBBLE directory.
+The `$PEBBLE` directory must be readable and writable by the UID of the pebble process. Make sure that no other UIDs can read or write to the $PEBBLE directory. You can do that with `chmod`, for example:
+
+```{terminal}
+   :input: chmod 700 /var/lib/pebble/default
+```
 
 The file `$PEBBLE/.pebble.state` contains the internal state of the Pebble daemon. You shouldn't try to edit this file or change its permissions.
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -174,7 +174,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	t0 := time.Now().Truncate(time.Millisecond)
 
 	if rcmd.CreateDirs {
-		err := os.MkdirAll(rcmd.pebbleDir, 0755)
+		err := os.MkdirAll(rcmd.pebbleDir, 0o700)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Also add an example to the docs of how to tighten up this directly if it already exists.