### PR TITLE
feat(identities): add client identity enrollment feature [4/5]

### DIFF
--- a/client/identities.go
+++ b/client/identities.go
@@ -115,6 +115,13 @@ func (client *Client) RemoveIdentities(identityNames map[string]struct{}) error 
 	return client.postIdentities("remove", identities)
 }
 
+// RequestEnrollmentWindow requests the daemon to enable a client enrollment
+// window specifically for encrypted HTTPS. The daemon will provide
+// a short window of time for an external HTTPS client to add its identity.
+func (client *Client) RequestEnrollmentWindow() error {
+	return client.postIdentities("request-enrollment-window", nil)
+}
+
 func (client *Client) postIdentities(action string, identities map[string]*Identity) error {
 	payload := identitiesPayload{
 		Action:     action,

--- a/client/identities_test.go
+++ b/client/identities_test.go
@@ -104,6 +104,24 @@ func (cs *clientSuite) TestRemoveIdentities(c *C) {
 	})
 }
 
+func (cs *clientSuite) TestRequestEnrollmentWindow(c *C) {
+	cs.rsp = `{"type": "sync", "result": null}`
+	err := cs.cli.RequestEnrollmentWindow()
+	c.Assert(err, IsNil)
+	c.Assert(cs.req.Method, Equals, "POST")
+	c.Assert(cs.req.URL.Path, Equals, "/v1/identities")
+
+	body, err := io.ReadAll(cs.req.Body)
+	c.Assert(err, IsNil)
+	var m map[string]any
+	err = json.Unmarshal(body, &m)
+	c.Assert(err, IsNil)
+	c.Assert(m, DeepEquals, map[string]any{
+		"action":     "request-enrollment-window",
+		"identities": nil,
+	})
+}
+
 func (cs *clientSuite) testPostIdentities(c *C, action string, clientFunc func(map[string]*client.Identity) error) {
 	cs.rsp = `{"type": "sync", "result": null}`
 	err := clientFunc(map[string]*client.Identity{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.23
+go 1.24
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.24
+go 1.23
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/internals/daemon/access_test.go
+++ b/internals/daemon/access_test.go
@@ -15,6 +15,10 @@
 package daemon_test
 
 import (
+	"context"
+	"net/http"
+	"net/url"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internals/daemon"
@@ -65,9 +69,86 @@ func (s *accessSuite) TestAdminAccess(c *C) {
 	// AdminAccess denies access without peer credentials.
 	c.Check(ac.CheckAccess(nil, nil, nil), DeepEquals, errUnauthorized)
 
-	// But not ReadAccess or UntrustedAccess
+	// ReadAccess or UntrustedAccess always denies access.
 	user := &daemon.UserState{Access: state.ReadAccess}
 	c.Check(ac.CheckAccess(nil, nil, user), DeepEquals, errUnauthorized)
 	user = &daemon.UserState{Access: state.UntrustedAccess}
 	c.Check(ac.CheckAccess(nil, nil, user), DeepEquals, errUnauthorized)
+}
+
+func (s *accessSuite) TestIdentityWriteAccess(c *C) {
+	// Enrollment window state
+	activeEnrollment := false
+
+	restore := daemon.FakeIdentEnrollmentActive(func(d *daemon.Daemon) bool {
+		previous := activeEnrollment
+		activeEnrollment = false
+		return previous
+	})
+	defer restore()
+
+	var ac daemon.AccessChecker = daemon.IdentityWriteAccess{}
+
+	// If the end-point is not identities, this checker cannot be used.
+	r := &http.Request{
+		URL: &url.URL{},
+	}
+	r = r.WithContext(context.WithValue(context.Background(), daemon.RequestSrcCtxKey, daemon.RequestSrcUnknown))
+	user := &daemon.UserState{Access: state.AdminAccess}
+	c.Check(ac.CheckAccess(nil, r, user), DeepEquals, errUnauthorized)
+
+	// If the end-point is identities, admin works fine.
+	r = &http.Request{
+		URL: &url.URL{
+			Path: "/v1/identities",
+		},
+	}
+	r = r.WithContext(context.WithValue(context.Background(), daemon.RequestSrcCtxKey, daemon.RequestSrcUnknown))
+	user = &daemon.UserState{Access: state.AdminAccess}
+	activeEnrollment = true
+	c.Check(ac.CheckAccess(nil, r, user), IsNil)
+	// Make sure a normal access also closes the enrollment window.
+	c.Check(activeEnrollment, Equals, false)
+
+	// ReadAccess is not authorized.
+	user = &daemon.UserState{Access: state.ReadAccess}
+	activeEnrollment = true
+	c.Check(ac.CheckAccess(nil, r, user), DeepEquals, errUnauthorized)
+	// Must also close the enrollment window.
+	c.Check(activeEnrollment, Equals, false)
+
+	// UntrustedAccess is not authorized.
+	user = &daemon.UserState{Access: state.UntrustedAccess}
+	activeEnrollment = true
+	c.Check(ac.CheckAccess(nil, r, user), DeepEquals, errUnauthorized)
+	// Must also close the enrollment window.
+	c.Check(activeEnrollment, Equals, false)
+
+	// No user is not authorized.
+	activeEnrollment = false
+	c.Check(ac.CheckAccess(nil, r, nil), DeepEquals, errUnauthorized)
+
+	// No user is allows only during the enrollment window, but not without HTTPS.
+	r = &http.Request{
+		URL: &url.URL{
+			Path: "/v1/identities",
+		},
+	}
+	r = r.WithContext(context.WithValue(context.Background(), daemon.RequestSrcCtxKey, daemon.RequestSrcUnknown))
+	activeEnrollment = true
+	c.Check(ac.CheckAccess(nil, r, nil), DeepEquals, errUnauthorized)
+	// Must also close the enrollment window.
+	c.Check(activeEnrollment, Equals, false)
+
+	// No user is allows only during the enrollment window, but not without HTTPS.
+	r = &http.Request{
+		URL: &url.URL{
+			Path: "/v1/identities",
+		},
+	}
+	r = r.WithContext(context.WithValue(context.Background(), daemon.RequestSrcCtxKey, daemon.RequestSrcHTTPS))
+	activeEnrollment = true
+	c.Check(ac.CheckAccess(nil, r, nil), IsNil)
+	// Must also close the enrollment window.
+	c.Check(activeEnrollment, Equals, false)
 }

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -115,6 +115,10 @@ var API = []*Command{{
 	GET:         v1GetIdentities,
 	POST:        v1PostIdentities,
 }, {
+	Path:        "/v1/identities/enroll",
+	WriteAccess: IdentityEnrollAccess{},
+	POST:        v1PostIdentitiesEnroll,
+}, {
 	Path:       "/v1/metrics",
 	ReadAccess: MetricsAccess{},
 	GET:        v1GetMetrics,

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -111,7 +111,7 @@ var API = []*Command{{
 }, {
 	Path:        "/v1/identities",
 	ReadAccess:  UserAccess{},
-	WriteAccess: AdminAccess{},
+	WriteAccess: IdentityWriteAccess{},
 	GET:         v1GetIdentities,
 	POST:        v1PostIdentities,
 }, {

--- a/internals/daemon/api_identities.go
+++ b/internals/daemon/api_identities.go
@@ -58,10 +58,6 @@ func v1PostIdentities(c *Command, r *http.Request, _ *UserState) Response {
 			}
 			identityNames[name] = struct{}{}
 		}
-	case "request-enrollment-window":
-		if payload.Identities != nil {
-			return BadRequest(`identities must be null for %s operation`, payload.Action)
-		}
 	default:
 		return BadRequest(`invalid action %q, must be "add", "update", "replace", or "remove"`, payload.Action)
 	}
@@ -80,12 +76,18 @@ func v1PostIdentities(c *Command, r *http.Request, _ *UserState) Response {
 		err = st.ReplaceIdentities(payload.Identities)
 	case "remove":
 		err = st.RemoveIdentities(identityNames)
-	case "request-enrollment-window":
-		err = c.d.EnableIdentityEnrollment()
 	}
 	if err != nil {
 		return BadRequest("%v", err)
 	}
 
+	return SyncResponse(nil)
+}
+
+func v1PostIdentitiesEnroll(c *Command, r *http.Request, _ *UserState) Response {
+	err := c.d.EnableIdentityEnrollment()
+	if err != nil {
+		return BadRequest("%v", err)
+	}
 	return SyncResponse(nil)
 }

--- a/internals/daemon/api_identities.go
+++ b/internals/daemon/api_identities.go
@@ -81,7 +81,7 @@ func v1PostIdentities(c *Command, r *http.Request, _ *UserState) Response {
 	case "remove":
 		err = st.RemoveIdentities(identityNames)
 	case "request-enrollment-window":
-		err = c.d.enableIdentityEnrollment()
+		err = c.d.EnableIdentityEnrollment()
 	}
 	if err != nil {
 		return BadRequest("%v", err)

--- a/internals/daemon/api_identities.go
+++ b/internals/daemon/api_identities.go
@@ -58,6 +58,10 @@ func v1PostIdentities(c *Command, r *http.Request, _ *UserState) Response {
 			}
 			identityNames[name] = struct{}{}
 		}
+	case "request-enrollment-window":
+		if payload.Identities != nil {
+			return BadRequest(`identities must be null for %s operation`, payload.Action)
+		}
 	default:
 		return BadRequest(`invalid action %q, must be "add", "update", "replace", or "remove"`, payload.Action)
 	}
@@ -76,6 +80,8 @@ func v1PostIdentities(c *Command, r *http.Request, _ *UserState) Response {
 		err = st.ReplaceIdentities(payload.Identities)
 	case "remove":
 		err = st.RemoveIdentities(identityNames)
+	case "request-enrollment-window":
+		err = c.d.enableIdentityEnrollment()
 	}
 	if err != nil {
 		return BadRequest("%v", err)

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -198,11 +198,11 @@ func userFromRequest(st *state.State, r *http.Request, ucred *Ucrednet, username
 	return nil, nil
 }
 
-// enableIdentityEnrollment enables the identity enrollment window, if not
+// EnableIdentityEnrollment enables the identity enrollment window, if not
 // already active. The enrollment window is automatcially closed after the
 // timeout period, unless an actualy identity enrollment takes place, in
 // which case the window is immediately closed following the request approval.
-func (d *Daemon) enableIdentityEnrollment() error {
+func (d *Daemon) EnableIdentityEnrollment() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.identEnrollTimer == nil {
@@ -253,6 +253,9 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		InternalError(c.d.degradedErr.Error()).ServeHTTP(w, r)
 		return
 	}
+
+	source, _ := r.Context().Value(requestSrcCtxKey).(requestSrc)
+	fmt.Println("Request Source:", source)
 
 	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err != nil && err != errNoID {

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -254,9 +254,6 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	source, _ := r.Context().Value(requestSrcCtxKey).(requestSrc)
-	fmt.Println("Request Source:", source)
-
 	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err != nil && err != errNoID {
 		logger.Noticef("Cannot parse UID from remote address %q: %s", r.RemoteAddr, err)

--- a/internals/daemon/export_test.go
+++ b/internals/daemon/export_test.go
@@ -23,6 +23,14 @@ import (
 	"github.com/canonical/pebble/internals/overlord/state"
 )
 
+const (
+	RequestSrcCtxKey     = requestSrcCtxKey
+	RequestSrcUnknown    = requestSrcUnknown
+	RequestSrcUnixSocket = requestSrcUnixSocket
+	RequestSrcHTTP       = requestSrcHTTP
+	RequestSrcHTTPS      = requestSrcHTTPS
+)
+
 func FakeMuxVars(f func(*http.Request) map[string]string) (restore func()) {
 	old := muxVars
 	muxVars = f
@@ -60,5 +68,21 @@ func FakeSyscallReboot(f func(cmd int) error) (restore func()) {
 	syscallReboot = f
 	return func() {
 		syscallReboot = old
+	}
+}
+
+func FakeIdentEnrollmentTimeout(d time.Duration) (restore func()) {
+	old := identityEnrollmentTimeout
+	identityEnrollmentTimeout = d
+	return func() {
+		identityEnrollmentTimeout = old
+	}
+}
+
+func FakeIdentEnrollmentActive(f func(d *Daemon) bool) (restore func()) {
+	old := identityEnrollmentActive
+	identityEnrollmentActive = f
+	return func() {
+		identityEnrollmentActive = old
 	}
 }


### PR DESCRIPTION
**Add a feature to allow a new external (HTTPS) client to enroll its identity**

The identity enrollment window feature is a very carefully controlled period of time that allows an HTTPS client (using an encrypted TLS connection) to add a single identity with a request having no identity provided. This attempt will immediately close the enrollment window, and the identity write endpoint will return to only being writable as an Admin user. The enrollment window is open for 60 seconds (or until the identities write endpoint is accessed), and automatically closed by the daemon.

How the client enrollment window is activated, is a matter of product policy:

1. The first option is that a Pebble based project can directly ask the daemon to enable the enrollment window:

```go
    d.EnableIdentityEnrollment()
```

2. The second option is to use the identities client request "request-enrollment-window". This can only be performed by an admin user. This will allow privileged user-space services with access to the unix-socket to trigger this enrollment window.

**Identity Enrollment Example**

```sh
// Using HTTPS without an identity
~/> ./pebble add-identities --from myid.yaml 
error: access denied (try with sudo)
```

Identity Enrollment triggered by the daemon right here.

```sh
// Using HTTPS without an identity
~/> ./pebble add-identities --from myid.yaml 
Added 1 new identity.
```

Pebble debug log:
```sh
~/> sudo ./pebble run --http=:4000 --https=:8888 -v
2025-04-09T20:59:35.114Z [pebble] HTTP API server listening on ":4000".
2025-04-09T20:59:35.114Z [pebble] HTTPS API server listening on ":8888".
2025-04-09T20:59:35.114Z [pebble] Started daemon.
2025-04-09T20:59:35.114Z [pebble] POST /v1/services 122.157µs 400
2025-04-09T20:59:35.115Z [pebble] Cannot start default services: no default services

// Enrollment triggered from Unix Socket
2025-04-09T21:01:31.077Z [pebble] POST /v1/identities 112.641µs 200
2025-04-09T21:01:31.077Z [pebble] HTTPS identity enrollment active

// Identity added
2025-04-09T21:01:35.237Z [pebble] 127.0.0.1:55064 POST /v1/identities 9.212766ms 200
2025-04-09T21:01:35.237Z [pebble] HTTPS identity enrollment closed
```
