### PR TITLE
feat(idkey): add identity key [1/4]

### DIFF
--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -167,7 +167,7 @@ func (s *PebbleSuite) TestEnterExecListDir(c *C) {
 
 	exitCode := cli.PebbleMain()
 	c.Check(s.Stderr(), Equals, "")
-	c.Check(s.Stdout(), Equals, "bar\nbaz\nfoo\n")
+	c.Check(s.Stdout(), Equals, "bar\nbaz\nfoo\nidentity\n")
 	c.Check(exitCode, Equals, 0)
 }
 

--- a/internals/cli/cmd_enter_test.go
+++ b/internals/cli/cmd_enter_test.go
@@ -162,12 +162,12 @@ func (s *PebbleSuite) TestEnterExecListDir(c *C) {
 		}
 	}
 
-	restore := fakeArgs("pebble", "enter", "exec", "ls", s.pebbleDir)
+	restore := fakeArgs("pebble", "enter", "exec", "ls", "--hide=identity", s.pebbleDir)
 	defer restore()
 
 	exitCode := cli.PebbleMain()
 	c.Check(s.Stderr(), Equals, "")
-	c.Check(s.Stdout(), Equals, "bar\nbaz\nfoo\nidentity\n")
+	c.Check(s.Stdout(), Equals, "bar\nbaz\nfoo\n")
 	c.Check(exitCode, Equals, 0)
 }
 

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -189,7 +189,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	plan.RegisterSectionExtension(workloads.WorkloadsField, &workloads.WorkloadsSectionExtension{})
 
 	idPath := filepath.Join(rcmd.pebbleDir, "identity")
-	idSigner, err := idkey.New(idPath)
+	idSigner, err := idkey.Get(idPath)
 	if err != nil {
 		return err
 	}

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"github.com/canonical/pebble/client"
 	"github.com/canonical/pebble/cmd"
 	"github.com/canonical/pebble/internals/daemon"
+	"github.com/canonical/pebble/internals/idkey"
 	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/plan"
 	"github.com/canonical/pebble/internals/reaper"
@@ -186,9 +188,16 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 
 	plan.RegisterSectionExtension(workloads.WorkloadsField, &workloads.WorkloadsSectionExtension{})
 
+	idPath := filepath.Join(rcmd.pebbleDir, "identity")
+	idSigner, err := idkey.New(idPath)
+	if err != nil {
+		return err
+	}
+
 	dopts := daemon.Options{
 		Dir:        rcmd.pebbleDir,
 		SocketPath: rcmd.socketPath,
+		IDSigner:   idSigner,
 	}
 	if os.Getenv("PEBBLE_VERBOSE") == "1" || rcmd.Verbose {
 		dopts.ServiceOutput = os.Stdout

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -67,8 +67,8 @@ type Options struct {
 	LayersDir string
 
 	// IDSigner is a private key representing the identity of a Pebble
-	// instance (machine, countainer or device), which implements the
-	// crypto.Signer interface (allowing it to sign TLS keypairs).
+	// instance (machine, container or device), which implements the
+	// crypto.Signer interface (for digest signing).
 	IDSigner crypto.Signer
 
 	// SocketPath is an optional path for the unix socket used for the client

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -17,6 +17,7 @@ package daemon
 import (
 	"bufio"
 	"context"
+	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -64,6 +65,11 @@ type Options struct {
 	// LayersDir is an optional path for the layers directory.
 	// Defaults to "layers" inside the pebble directory.
 	LayersDir string
+
+	// IDSigner is a private key representing the identity of a Pebble
+	// instance (machine, countainer or device), which implements the
+	// crypto.Signer interface (allowing it to sign TLS keypairs).
+	IDSigner crypto.Signer
 
 	// SocketPath is an optional path for the unix socket used for the client
 	// to communicate with the daemon. Defaults to a hidden (dotted) name inside
@@ -844,6 +850,7 @@ func New(opts *Options) (*Daemon, error) {
 		RestartHandler: d,
 		ServiceOutput:  opts.ServiceOutput,
 		Extension:      opts.OverlordExtension,
+		IDSigner:       opts.IDSigner,
 	}
 
 	ovld, err := overlord.New(&ovldOptions)

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -12,11 +12,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// idkey supplies an identity key for a machine or device. This package
-// provides an implementation based on an Ed25519 based key, currently
+// idkey supplies an identity key for a machine, container or device. This
+// package provides an implementation based on an Ed25519 based key, currently
 // only supporting a file based key storage solution. This can later be
-// extended to support more secure hardware backed keystore, such as
-// TPM, OP-TEE or UbiKey.
+// extended to support more secure hardware backed keystores, such as TPM,
+// OP-TEE or UbiKey.
 package idkey
 
 import (
@@ -46,10 +46,10 @@ type IDKey struct {
 	key    any
 }
 
-// New checks if an existing identity key exists, and loads the key if it
-// does. It creates a new private identity key and persists it to disk if
-// no key was found. Cases where explicit control is desired on when to
-// generate or load can use GenerateKey and LoadKeyFromFile.
+// New checks if an existing private identity key exists, and loads the key
+// if it does. It creates a new private identity key and persists it to disk
+// if no key was found. Cases where explicit control is desired on when to
+// generate or load can use GenerateKey and LoadKey directly.
 func New(keyDir string) (*IDKey, error) {
 	keyPath := filepath.Join(keyDir, identityKeyFile)
 	_, err := os.Stat(keyPath)
@@ -60,16 +60,16 @@ func New(keyDir string) (*IDKey, error) {
 		}
 		return nil, err
 	}
-	return LoadKeyFromFile(keyDir)
+	return LoadKey(keyDir)
 }
 
 // GenerateKey generates a new identity key and persists it to disk. This
-// function should only ever be called on the first boot of a machine or
-// device, otherwise a new identity will be created.
+// function should only ever be called on the first boot otherwise a new
+// identity will be created.
 //
 // This function is equivalent to running:
 //
-// 	openssl genpkey -algorithm Ed25519 -out key.pem
+//	openssl genpkey -algorithm Ed25519 -out key.pem
 func GenerateKey(keyDir string) (*IDKey, error) {
 	key := &IDKey{
 		keyDir: keyDir,
@@ -87,8 +87,8 @@ func GenerateKey(keyDir string) (*IDKey, error) {
 	return key, nil
 }
 
-// LoadKeyFromFile loads an existing identity key from disk.
-func LoadKeyFromFile(keyDir string) (*IDKey, error) {
+// LoadKey loads an existing identity key from disk.
+func LoadKey(keyDir string) (*IDKey, error) {
 	key := &IDKey{
 		keyDir: keyDir,
 	}

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -20,7 +20,6 @@
 package idkey
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -205,11 +204,7 @@ func (k *IDKey) save() (err error) {
 		Type:  "PRIVATE KEY",
 		Bytes: keyBytes,
 	}
-	var pemBuffer bytes.Buffer
-	if err = pem.Encode(&pemBuffer, pemPrivateBlock); err != nil {
-		return err
-	}
-	if _, err = pemFile.Write(pemBuffer.Bytes()); err != nil {
+	if err = pem.Encode(pemFile, pemPrivateBlock); err != nil {
 		return err
 	}
 	if err = pemFile.Sync(); err != nil {

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -241,10 +241,9 @@ func expectPermission(path string, perm fs.FileMode) error {
 // operation reports an unrelated error, the error is returned.
 func pathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// idkey supplies an identity key for a machine or device. This package
+// provides an implementation based on an Ed25519 based key, currently
+// only supporting a file based key storage solution. This can later be
+// extended to support more secure hardware backed keystore, such as
+// TPM, OP-TEE or UbiKey.
+package idkey
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base32"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const identityKeyFile = "key.pem"
+
+// Identity key must implement a crypto signer.
+var _ crypto.Signer = (*IDKey)(nil)
+
+type IDKey struct {
+	keyDir string
+	key    any
+}
+
+// New checks if an existing identity key exists, and loads the key if it
+// does. It creates a new private identity key and persists it to disk if
+// no key was found. Cases where explicit control is desired on when to
+// generate or load can use GenerateKey and LoadKeyFromFile.
+func New(keyDir string) (*IDKey, error) {
+	keyPath := filepath.Join(keyDir, identityKeyFile)
+	_, err := os.Stat(keyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Generate a new key and persist.
+			return GenerateKey(keyDir)
+		}
+		return nil, err
+	}
+	return LoadKeyFromFile(keyDir)
+}
+
+// GenerateKey generates a new identity key and persists it to disk. This
+// function should only ever be called on the first boot of a machine or
+// device, otherwise a new identity will be created.
+func GenerateKey(keyDir string) (*IDKey, error) {
+	key := &IDKey{
+		keyDir: keyDir,
+	}
+	// Generate new ed25519 private key.
+	err := key.newEd25519()
+	if err != nil {
+		return nil, err
+	}
+	// Persist to disk.
+	err = key.save()
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// LoadKeyFromFile loads an existing identity key from disk.
+func LoadKeyFromFile(keyDir string) (*IDKey, error) {
+	key := &IDKey{
+		keyDir: keyDir,
+	}
+	// Load from disk.
+	err := key.load()
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+// Public implements the crypto.Signer.
+func (k *IDKey) Public() crypto.PublicKey {
+	signer := k.key.(crypto.Signer)
+	return signer.Public()
+}
+
+// Sign implements the crypto.Signer.
+func (k *IDKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	signer := k.key.(crypto.Signer)
+	return signer.Sign(rand, digest, opts)
+}
+
+// newEd25519 generates a new ed25519 key.
+func (k *IDKey) newEd25519() error {
+	var err error
+	_, k.key, err = ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("cannot generate ed25519 key: %w", err)
+	}
+	return nil
+}
+
+// load loads the private identity key from storage.
+func (k *IDKey) load() error {
+	// Check the permissions are what we expect.
+	_, err := os.Stat(k.keyDir)
+	if err != nil {
+		return fmt.Errorf("cannot find identity key: directory %q is not accessible", k.keyDir)
+	}
+	err = expectPermission(k.keyDir, 0o700)
+	if err != nil {
+		return fmt.Errorf("cannot verify identity key directory permissions: %w", err)
+	}
+	pemPath := filepath.Join(k.keyDir, identityKeyFile)
+	err = expectPermission(pemPath, 0o600)
+	if err != nil {
+		return fmt.Errorf("cannot verify PEM permission for %q: %w", pemPath, err)
+	}
+	// Load the key.
+	pemData, err := os.ReadFile(pemPath)
+	if err != nil {
+		return err
+	}
+	for {
+		var block *pem.Block
+		block, pemData = pem.Decode(pemData)
+		if block == nil {
+			break
+		}
+		switch block.Type {
+		case "PRIVATE KEY":
+			k.key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("cannot load private identity key from block %q in PEM file %q", block.Type, pemPath)
+		}
+	}
+	if k.key == nil {
+		return fmt.Errorf("cannot find private identity key in PEM file %q", pemPath)
+	}
+	return nil
+}
+
+// save saves the private identity key to storage.
+func (k *IDKey) save() error {
+	// If the identity key directory does not yet exist, create it.
+	_, err := os.Stat(k.keyDir)
+	if os.IsNotExist(err) {
+		// Create the leaf directory node with 0700 permissions.
+		err = os.Mkdir(k.keyDir, 0o700)
+	} else {
+		err = expectPermission(k.keyDir, 0o700)
+		if err != nil {
+			return fmt.Errorf("cannot verify identity key directory permissions: %w", err)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("cannot create directory leaf of path %v: %w", k.keyDir, err)
+	}
+	// Create the new private identity file.
+	pemPath := filepath.Join(k.keyDir, identityKeyFile)
+	pemFile, err := os.OpenFile(pemPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, pemFile.Sync())
+		err = errors.Join(err, pemFile.Close())
+	}()
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(k.key)
+	if err != nil {
+		return err
+	}
+	pemPrivateBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyBytes,
+	}
+	var pemBuffer bytes.Buffer
+	if err := pem.Encode(&pemBuffer, pemPrivateBlock); err != nil {
+		return fmt.Errorf("cannot convert key to PEM: %w", err)
+	}
+	if _, err = pemFile.Write(pemBuffer.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Fingerprint returns the identity fingerprint. This is the SHA512/384 hash
+// of the public key, encoded in base32 (without padding). This is a
+// convenient shorthand form of the identity that can be used to identify
+// a specfic machine or device.
+func (k *IDKey) Fingerprint() string {
+	publicBytes := k.Public().(ed25519.PublicKey)
+	hashBytes := sha512.Sum384(publicBytes)
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hashBytes[:])
+}
+
+// expectPermission return an error if the specified directory or file
+// path is not matching the supplied permissions.
+func expectPermission(path string, perm fs.FileMode) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	actualPerm := info.Mode().Perm()
+	if actualPerm != perm {
+		return fmt.Errorf("expected permission 0o%o (got 0o%o) for %q", perm, actualPerm, path)
+	}
+	return nil
+}

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -16,7 +16,7 @@
 // package provides an implementation based on an Ed25519 based key, currently
 // only supporting a file based key storage solution. This can later be
 // extended to support more secure hardware backed keystores, such as TPM,
-// OP-TEE or UbiKey.
+// OP-TEE or YubiKey.
 package idkey
 
 import (

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -66,6 +66,10 @@ func New(keyDir string) (*IDKey, error) {
 // GenerateKey generates a new identity key and persists it to disk. This
 // function should only ever be called on the first boot of a machine or
 // device, otherwise a new identity will be created.
+//
+// This function is equivalent to running:
+//
+// 	openssl genpkey -algorithm Ed25519 -out key.pem
 func GenerateKey(keyDir string) (*IDKey, error) {
 	key := &IDKey{
 		keyDir: keyDir,

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -149,9 +149,12 @@ func (k *IDKey) load() error {
 	if err != nil {
 		return err
 	}
-	block, _ := pem.Decode(pemData)
+	block, rest := pem.Decode(pemData)
 	if block == nil || block.Type != "PRIVATE KEY" {
 		return fmt.Errorf("missing 'PRIVATE KEY' block in %q", pemPath)
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("unexpected bytes after 'PRIVATE KEY' block in %q", pemPath)
 	}
 	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -146,7 +146,7 @@ func (ks *keySuite) TestKeySign(c *C) {
 // BenchmarkKeyGeneration prints some performance metrics. To run this test
 // use: go test -check.b
 func (ks *keySuite) BenchmarkKeyGeneration(c *C) {
-	for i:=0; i< c.N; i++ {
+	for i := 0; i < c.N; i++ {
 		keyDir := filepath.Join(c.MkDir(), "identity")
 		_, err := idkey.GenerateKey(keyDir)
 		c.Assert(err, IsNil)

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -142,3 +142,13 @@ func (ks *keySuite) TestKeySign(c *C) {
 	ok = ed25519.Verify(pubKey, message, signature)
 	c.Assert(ok, Equals, true)
 }
+
+// BenchmarkKeyGeneration prints some performance metrics. To run this test
+// use: go test -check.b
+func (ks *keySuite) BenchmarkKeyGeneration(c *C) {
+	for i:=0; i< c.N; i++ {
+		keyDir := filepath.Join(c.MkDir(), "identity")
+		_, err := idkey.GenerateKey(keyDir)
+		c.Assert(err, IsNil)
+	}
+}

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -35,7 +35,7 @@ func (ks *keySuite) TestNoDirectory(c *C) {
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	nextBoot, err := idkey.LoadKeyFromFile(keyDir)
+	nextBoot, err := idkey.LoadKey(keyDir)
 	c.Assert(err, IsNil)
 
 	// Both should be the same identity.
@@ -67,7 +67,7 @@ func (ks *keySuite) TestDirectoryInvalid(c *C) {
 	c.Assert(err, IsNil)
 
 	// Loading
-	_, err = idkey.LoadKeyFromFile(keyDir)
+	_, err = idkey.LoadKey(keyDir)
 	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
 
 	// Saving
@@ -97,7 +97,7 @@ func (ks *keySuite) TestInvalidKey(c *C) {
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	_, err = idkey.LoadKeyFromFile(keyDir)
+	_, err = idkey.LoadKey(keyDir)
 	c.Assert(err, ErrorMatches, "cannot verify PEM permission .*")
 }
 
@@ -116,7 +116,7 @@ func (ks *keySuite) TestCorruptKey(c *C) {
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	_, err = idkey.LoadKeyFromFile(keyDir)
+	_, err = idkey.LoadKey(keyDir)
 	c.Assert(err, ErrorMatches, "cannot find private identity key .*")
 }
 

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -82,7 +82,7 @@ func (ks *keySuite) TestDirInvalid(c *C) {
 
 	// Saving
 	_, err := idkey.GenerateKey(keyDir)
-	c.Assert(err, ErrorMatches, "cannot create directory leaf .*")
+	c.Assert(err, ErrorMatches, "cannot create identity directory.*")
 }
 
 // TestInvalidKey checks permission of the key file.
@@ -98,11 +98,11 @@ func (ks *keySuite) TestInvalidKey(c *C) {
 
 	// Load the identity key (other boots)
 	_, err = idkey.LoadKey(keyDir)
-	c.Assert(err, ErrorMatches, "cannot verify PEM permission .*")
+	c.Assert(err, ErrorMatches, "cannot load identity key.*")
 }
 
-// TestCorruptKey checks a corrupt key fails to load.
-func (ks *keySuite) TestCorruptKey(c *C) {
+// TestEmptyKey checks if a key fails to load.
+func (ks *keySuite) TestEmptyKey(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
@@ -117,10 +117,10 @@ func (ks *keySuite) TestCorruptKey(c *C) {
 
 	// Load the identity key (other boots)
 	_, err = idkey.LoadKey(keyDir)
-	c.Assert(err, ErrorMatches, "cannot find private identity key .*")
+	c.Assert(err, ErrorMatches, ".* empty PEM file .*")
 }
 
-// MTestKeySign makes sure the crypto.Signer works.
+// TestKeySign makes sure the crypto.Signer works.
 func (ks *keySuite) TestKeySign(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -31,28 +31,28 @@ func (ks *keySuite) TestNoDirectory(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	firstBoot, err := idkey.GenerateKey(keyDir)
+	firstBoot, err := idkey.Generate(keyDir)
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	nextBoot, err := idkey.LoadKey(keyDir)
+	nextBoot, err := idkey.Load(keyDir)
 	c.Assert(err, IsNil)
 
 	// Both should be the same identity.
 	c.Assert(firstBoot.Fingerprint(), Equals, nextBoot.Fingerprint())
 }
 
-// TestNew checks if the New() function correctly only creates a new
+// TestGet checks if the Get() function correctly only creates a new
 // identity the first time.
-func (ks *keySuite) TestNew(c *C) {
+func (ks *keySuite) TestGet(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	firstBoot, err := idkey.New(keyDir)
+	firstBoot, err := idkey.Get(keyDir)
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	nextBoot, err := idkey.New(keyDir)
+	nextBoot, err := idkey.Get(keyDir)
 	c.Assert(err, IsNil)
 
 	// Both should be the same identity.
@@ -67,11 +67,11 @@ func (ks *keySuite) TestDirectoryInvalid(c *C) {
 	c.Assert(err, IsNil)
 
 	// Loading
-	_, err = idkey.LoadKey(keyDir)
+	_, err = idkey.Load(keyDir)
 	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
 
 	// Saving
-	_, err = idkey.GenerateKey(keyDir)
+	_, err = idkey.Generate(keyDir)
 	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
 }
 
@@ -81,7 +81,7 @@ func (ks *keySuite) TestDirInvalid(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "foo/identity")
 
 	// Saving
-	_, err := idkey.GenerateKey(keyDir)
+	_, err := idkey.Generate(keyDir)
 	c.Assert(err, ErrorMatches, "cannot create identity directory.*")
 }
 
@@ -90,15 +90,15 @@ func (ks *keySuite) TestInvalidKey(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	_, err := idkey.GenerateKey(keyDir)
+	_, err := idkey.Generate(keyDir)
 	c.Assert(err, IsNil)
 
 	err = os.Chmod(filepath.Join(keyDir, "key.pem"), 0o644)
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	_, err = idkey.LoadKey(keyDir)
-	c.Assert(err, ErrorMatches, "cannot load identity key.*")
+	_, err = idkey.Load(keyDir)
+	c.Assert(err, ErrorMatches, ".*expected permission.*")
 }
 
 // TestEmptyKey checks if a key fails to load.
@@ -106,7 +106,7 @@ func (ks *keySuite) TestEmptyKey(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	_, err := idkey.GenerateKey(keyDir)
+	_, err := idkey.Generate(keyDir)
 	c.Assert(err, IsNil)
 
 	// Zero the existing file.
@@ -116,8 +116,8 @@ func (ks *keySuite) TestEmptyKey(c *C) {
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	_, err = idkey.LoadKey(keyDir)
-	c.Assert(err, ErrorMatches, ".* empty PEM file .*")
+	_, err = idkey.Load(keyDir)
+	c.Assert(err, ErrorMatches, ".*missing 'PRIVATE KEY' block.*")
 }
 
 // TestKeySign makes sure the crypto.Signer works.
@@ -125,7 +125,7 @@ func (ks *keySuite) TestKeySign(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	signer, err := idkey.GenerateKey(keyDir)
+	signer, err := idkey.Generate(keyDir)
 	c.Assert(err, IsNil)
 
 	message := []byte("hello world")
@@ -148,7 +148,7 @@ func (ks *keySuite) TestKeySign(c *C) {
 func (ks *keySuite) BenchmarkKeyGeneration(c *C) {
 	for i := 0; i < c.N; i++ {
 		keyDir := filepath.Join(c.MkDir(), "identity")
-		_, err := idkey.GenerateKey(keyDir)
+		_, err := idkey.Generate(keyDir)
 		c.Assert(err, IsNil)
 	}
 }

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -53,6 +53,7 @@ func (ks *keySuite) TestNew(c *C) {
 
 	// Load the identity key (other boots)
 	nextBoot, err := idkey.New(keyDir)
+	c.Assert(err, IsNil)
 
 	// Both should be the same identity.
 	c.Assert(firstBoot.Fingerprint(), Equals, nextBoot.Fingerprint())

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package idkey_test
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/idkey"
+)
+
+// TestNoDirectory checks if leaf directory creation works.
+func (ks *keySuite) TestNoDirectory(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "identity")
+
+	// Create a new identity key (first boot)
+	firstBoot, err := idkey.GenerateKey(keyDir)
+	c.Assert(err, IsNil)
+
+	// Load the identity key (other boots)
+	nextBoot, err := idkey.LoadKeyFromFile(keyDir)
+	c.Assert(err, IsNil)
+
+	// Both should be the same identity.
+	c.Assert(firstBoot.Fingerprint(), Equals, nextBoot.Fingerprint())
+}
+
+// TestNew checks if the New() function correctly only creates a new
+// identity the first time.
+func (ks *keySuite) TestNew(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "identity")
+
+	// Create a new identity key (first boot)
+	firstBoot, err := idkey.New(keyDir)
+	c.Assert(err, IsNil)
+
+	// Load the identity key (other boots)
+	nextBoot, err := idkey.New(keyDir)
+
+	// Both should be the same identity.
+	c.Assert(firstBoot.Fingerprint(), Equals, nextBoot.Fingerprint())
+}
+
+// TestDirectoryInvalid confirms that if the leaf directory has invalid
+// permissions we exit.
+func (ks *keySuite) TestDirectoryInvalid(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "identity")
+	err := os.MkdirAll(keyDir, 0o740)
+	c.Assert(err, IsNil)
+
+	// Loading
+	_, err = idkey.LoadKeyFromFile(keyDir)
+	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
+
+	// Saving
+	_, err = idkey.GenerateKey(keyDir)
+	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
+}
+
+// TestDirInvalid checks for a missing non-leaf directory. The caller
+// must create this.
+func (ks *keySuite) TestDirInvalid(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "foo/identity")
+
+	// Saving
+	_, err := idkey.GenerateKey(keyDir)
+	c.Assert(err, ErrorMatches, "cannot create directory leaf .*")
+}
+
+// TestInvalidKey checks permission of the key file.
+func (ks *keySuite) TestInvalidKey(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "identity")
+
+	// Create a new identity key (first boot)
+	_, err := idkey.GenerateKey(keyDir)
+	c.Assert(err, IsNil)
+
+	err = os.Chmod(filepath.Join(keyDir, "key.pem"), 0o644)
+	c.Assert(err, IsNil)
+
+	// Load the identity key (other boots)
+	_, err = idkey.LoadKeyFromFile(keyDir)
+	c.Assert(err, ErrorMatches, "cannot verify PEM permission .*")
+}
+
+// TestCorruptKey checks a corrupt key fails to load.
+func (ks *keySuite) TestCorruptKey(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "identity")
+
+	// Create a new identity key (first boot)
+	_, err := idkey.GenerateKey(keyDir)
+	c.Assert(err, IsNil)
+
+	// Zero the existing file.
+	f, err := os.OpenFile(filepath.Join(keyDir, "key.pem"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	c.Assert(err, IsNil)
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	// Load the identity key (other boots)
+	_, err = idkey.LoadKeyFromFile(keyDir)
+	c.Assert(err, ErrorMatches, "cannot find private identity key .*")
+}
+
+// MTestKeySign makes sure the crypto.Signer works.
+func (ks *keySuite) TestKeySign(c *C) {
+	keyDir := filepath.Join(c.MkDir(), "identity")
+
+	// Create a new identity key (first boot)
+	signer, err := idkey.GenerateKey(keyDir)
+	c.Assert(err, IsNil)
+
+	message := []byte("hello world")
+
+	// Hash is optional for Ed25519, but crypto.Signer requires a hash function
+	signature, err := signer.Sign(rand.Reader, message, crypto.Hash(0))
+	c.Assert(err, IsNil)
+
+	// Extract the public key
+	pubKey, ok := signer.Public().(ed25519.PublicKey)
+	c.Assert(ok, Equals, true)
+
+	// Verify signature
+	ok = ed25519.Verify(pubKey, message, signature)
+	c.Assert(ok, Equals, true)
+}

--- a/internals/idkey/package_test.go
+++ b/internals/idkey/package_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package idkey_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up check.v1 into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }
+
+type keySuite struct{}
+
+var _ = Suite(&keySuite{})

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -16,6 +16,7 @@
 package overlord
 
 import (
+	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -76,6 +77,10 @@ type Options struct {
 	ServiceOutput io.Writer
 	// Extension allows extending the overlord with externally defined features.
 	Extension Extension
+	// IDSigner is a private key representing the identity of a Pebble
+	// instance (machine, container or device), which implements the
+	// crypto.Signer interface (allowing it to sign TLS keypairs).
+	IDSigner crypto.Signer
 }
 
 // Overlord is the central manager of the system, keeping track


### PR DESCRIPTION
Add support for Pebble to have a machine, container or device identity that is based on an Ed25519 private key.

This identity key implements the crypto.Signer interface, allowing it to sign, for example, TLS certificates.

The identity key should eventually be stored in a hardware backed key-store, such as a TPM, OP-TEE or even YubiKey. The first implementation of the package implements disk based storage with restricted permissions, similar to what you would find when looking at your ~/.ssh directory.

The purpose of this package is to allow a machine, container or device to have a lifelong identity, including a standardized fingerprint that represents that identity. 

**Example use-case**

The identity private key can be used to sign short-lived TLS keypairs for the HTTPS Pebble API server, whereby it acts as the signing authority (CA). In this case, an x509 identity certificate with CA signing permissions will be included in the certificate chain, allowing the client to pin the identity certificate (which does not change over time) during a physical trust exchange process (think button press and user assisted identity confirmation).

**Benchmark information**

The identity will only be generated on first boot, and will incur the following startup penalty:

 **3.0 ms** - AMD FX(tm)-8350 Eight-Core Processor
**5.5ms** - Raspberry Pi 5 (Sdcard)
**14.5ms** - Raspberry Pi 3b+ (Sdcard)