### PR TITLE
feat: add http-address to /v1/system-info

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -866,8 +866,9 @@ pebble run --args myservice --port 8080 \; --hold
 [run command options]
           --create-dirs  Create Pebble directory on startup if it doesn't exist
           --hold         Do not start default services automatically
-          --http=        Start HTTP API listening on this address (e.g.,
-                         ":4000") and expose open-access endpoints
+          --http=        Start HTTP API listening on this address in
+                         "[ipv4_or_v6_address]:port" format (for example,
+                         ":4000")
       -v, --verbose      Log all output from services to stdout (also
                          PEBBLE_VERBOSE=1)
           --args=        Provide additional arguments to a service

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -867,8 +867,8 @@ pebble run --args myservice --port 8080 \; --hold
           --create-dirs  Create Pebble directory on startup if it doesn't exist
           --hold         Do not start default services automatically
           --http=        Start HTTP API listening on this address in
-                         "[ipv4_or_v6_address]:port" format (for example,
-                         ":4000")
+                         "<address>:port" format (for example, ":4000",
+                         "192.0.2.0:4000", "[2001:db8::1]:4000")
       -v, --verbose      Log all output from services to stdout (also
                          PEBBLE_VERBOSE=1)
           --args=        Provide additional arguments to a service

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -1226,6 +1226,7 @@ paths:
                   "status": "OK",
                   "result": {
                     "boot-id": "e14ed96e-5a98-4402-80f7-d19dd949eac3",
+                    "http-address": ":4000",
                     "version": "v1.17.0"
                   }
                 }
@@ -1675,12 +1676,18 @@ components:
     systemInfo:
       type: object
       properties:
-        version:
-          type: string
-          description: Version of the Pebble daemon.
         boot-id:
           type: string
           description: A unique string that represents this boot of the server.
+        http-address:
+          type: string
+          description: Address the HTTP server is listening on, for example `:4000`. Only present if the daemon was started with the `--http` argument.
+        version:
+          type: string
+          description: Version of the Pebble daemon.
+      required:
+        - boot-id
+        - version
     checkInfo:
       type: object
       properties:

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -1209,7 +1209,7 @@ paths:
   /v1/system-info:
     get:
       summary: Get system information
-      description: Get the version of the Pebble daemon and the boot ID of the system.
+      description: Get information about the Pebble daemon and the boot ID of the system.
       tags:
         - system info
       responses:

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -59,7 +59,7 @@ type sharedRunEnterOpts struct {
 var sharedRunEnterArgsHelp = map[string]string{
 	"--create-dirs": "Create {{.DisplayName}} directory on startup if it doesn't exist",
 	"--hold":        "Do not start default services automatically",
-	"--http":        `Start HTTP API listening on this address in "[ipv4_or_v6_address]:port" format (for example, ":4000")`,
+	"--http":        `Start HTTP API listening on this address in "<address>:port" format (for example, ":4000", "192.0.2.0:4000", "[2001:db8::1]:4000")`,
 	"--verbose":     "Log all output from services to stdout (also PEBBLE_VERBOSE=1)",
 	"--args":        "Provide additional arguments to a service",
 	"--identities":  "Seed identities from file (like update-identities --replace)",

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -59,7 +59,7 @@ type sharedRunEnterOpts struct {
 var sharedRunEnterArgsHelp = map[string]string{
 	"--create-dirs": "Create {{.DisplayName}} directory on startup if it doesn't exist",
 	"--hold":        "Do not start default services automatically",
-	"--http":        `Start HTTP API listening on this address (e.g., ":4000") and expose open-access endpoints`,
+	"--http":        `Start HTTP API listening on this address in "[ipv4_or_v6_address]:port" format (for example, ":4000")`,
 	"--verbose":     "Log all output from services to stdout (also PEBBLE_VERBOSE=1)",
 	"--args":        "Provide additional arguments to a service",
 	"--identities":  "Seed identities from file (like update-identities --replace)",

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -134,9 +134,15 @@ func v1SystemInfo(c *Command, r *http.Request, _ *UserState) Response {
 	state := c.d.overlord.State()
 	state.Lock()
 	defer state.Unlock()
-	result := map[string]any{
-		"version": c.d.Version,
-		"boot-id": restart.BootID(state),
+
+	result := struct {
+		BootID      string `json:"boot-id"`
+		HTTPAddress string `json:"http-address,omitempty"`
+		Version     string `json:"version"`
+	}{
+		BootID:      restart.BootID(state),
+		HTTPAddress: c.d.options.HTTPAddress,
+		Version:     c.d.Version,
 	}
 	return SyncResponse(result)
 }

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -106,6 +106,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 
 	d := s.daemon(c)
 	d.Version = "42b1"
+	d.options.HTTPAddress = ":4000"
 	state := d.overlord.State()
 	state.Lock()
 	_, err := restart.Manager(state, "ffffffff-ffff-ffff-ffff-ffffffffffff", nil)
@@ -117,8 +118,9 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	c.Check(rec.Result().Header.Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]any{
-		"version": "42b1",
-		"boot-id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+		"boot-id":      "ffffffff-ffff-ffff-ffff-ffffffffffff",
+		"http-address": ":4000",
+		"version":      "42b1",
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)


### PR DESCRIPTION
Per discussion on Matrix > Juju, we'd like to add the ability to get the HTTP port that Pebble is listening on (if any) to the /v1/system-info API response. This PR simply adds that field.

For example, if the Pebble daemon is started with `pebble run --http=:4040`, the API returns this:

```
$ curl --unix-socket /var/lib/pebble/default/.pebble.socket http://_/v1/system-info|jq
{
  "type": "sync",
  "status-code": 200,
  "status": "OK",
  "result": {
    "boot-id": "30435cc9-b428-4e25-a821-c9477fc339eb",
    "http-address": ":4040",
    "version": "v1.21.0-dev"
  }
}
```