### PR TITLE
docs: document how to check health based on logs

### DIFF
--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -1,1 +1,28 @@
 # How to check health based on logs
+
+Need to be clear that this is not the primary way to check health. It's kind of a hack...
+
+## Define a layer
+
+```yaml
+services:
+  foo:
+    override: replace
+    command: foo
+    startup: enabled
+checks:
+  foo-warning:
+    override: replace
+    threshold: 1
+    exec:
+      command: bash -c '! pebble logs | grep -q WARNING'
+```
+
+- `pebble check foo-warning`
+- `pebble health foo-warning`
+
+## See more
+
+- [`pebble check`](#reference_pebble_check_command) command
+- [`pebble health`](#reference_pebble_health_command) command
+- [](/reference/health-checks)

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -1,0 +1,1 @@
+# How to check health based on logs

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -1,8 +1,8 @@
 # How to check health based on logs
 
-Pebble stores the most recent `stdout` and `stderr` from each service. This guide demonstrates how to set up a health check that fails if the logs contain a particular line, such as a warning message.
+Pebble stores the most recent `stdout` and `stderr` from each service. This guide demonstrates how to set up a check that fails if the logs contain a particular line, such as a warning message.
 
-This is an indirect and potentially unreliable way to catch issues with services. Whenever possible, you should set up health checks that query the service status directly. For more information, see [](./run-services-reliably).
+This method is an alternative to directly querying a service. Directly querying a service is typically a more reliable method of catching issues. For more information, see [](./run-services-reliably).
 
 ## Define a layer
 
@@ -23,7 +23,7 @@ checks:
       # Because of YAML escaping rules, we need to use \\[ to pass \[ to grep.
 ```
 
-The check searches Pebble's service logs for lines such as:
+The check searches Pebble's service logs for lines matching the pattern, such as:
 
 ```text
 2025-04-26T03:22:20.315Z [foo] some WARNING reported by the service
@@ -31,9 +31,7 @@ The check searches Pebble's service logs for lines such as:
 
 If a match is found, the `bash -c '...'` command exits with 1 and the check fails.
 
-When the check fails, Pebble doesn't restart `foo`. If `foo` were to restart, the check would still be considered "down" (because the logs would still contain the warning message) and Pebble wouldn't restart `foo` again if another warning occurred.
-
-It's possible to [configure a service to restart when a check fails](#restart-a-service-when-the-health-check-fails). However, we don't recommend that you configure `foo` to restart. Instead, we recommend that you monitor the check and alert a human operator if the check fails.
+By default, Pebble keeps a service running without restarting it even if a check fails. Although we can configure a service to restart on check failure, this approach isn't helpful here. That's because restarting `foo` won't remove the logged warning from the logs, so the check remains "down", and subsequent failures won't trigger additional restarts. So, in this particular case, it's better to monitor the check and alert a human operator to investigate.
 
 ## Get the status of the check
 
@@ -63,7 +61,7 @@ logs: |
 
 ## See more
 
-- [`pebble logs`](#reference_pebble_logs_command) command
-- [`pebble health`](#reference_pebble_health_command) command
 - [`pebble check`](#reference_pebble_check_command) command
+- [`pebble health`](#reference_pebble_health_command) command
+- [`pebble logs`](#reference_pebble_logs_command) command
 - [](/reference/health-checks)

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -1,28 +1,65 @@
 # How to check health based on logs
 
-Need to be clear that this is not the primary way to check health. It's kind of a hack...
+<!-- TODO: Need to be clear that this is not the primary way to check health. It's kind of a hack. This is an aid to monitoring/diagnosis. It's not recommended as an unattended way to ensure that a service runs reliably. -->
 
 ## Define a layer
+
+We'll define service called `foo` and a check called `foo-warning` that inspects the logs from `foo`:
 
 ```yaml
 services:
   foo:
     override: replace
-    command: foo
+    command: /bin/foo
     startup: enabled
 checks:
   foo-warning:
     override: replace
     threshold: 1
     exec:
-      command: bash -c '! pebble logs | grep -q WARNING'
+      command: bash -c '! pebble logs | grep -q "\\[foo\\] .*WARNING"'
 ```
 
-- `pebble check foo-warning`
-- `pebble health foo-warning`
+The check searches Pebble's service logs for lines such as:
+
+```text
+2025-04-26T03:22:20.315Z [foo] some WARNING reported by the service
+```
+
+If a match is found, the `bash -c '...'` command exits with 1 and the check fails.
+
+When the check fails, Pebble doesn't restart `foo`. To learn how to automatically restart `foo`, see [](#restart-a-service-when-the-health-check-fails). However, we recommend that you don't configure `foo` to restart. After restarting `foo`, Pebble's service logs would still contain the warning line, so the check would still be considered "down" and Pebble wouldn't restart `foo` if another warning is logged.
+
+Instead of configuring `foo` to restart, we recommend that you monitor the check and alert a human operator if the check fails.
+
+## Get the status of the check
+
+To display the status of the check:
+
+```{terminal}
+   :input: pebble health foo-warning
+unhealthy
+```
+
+This command exits with 0 if the check is healthy, or 1 if the check is unhealthy.
+
+To display detailed status information about the check:
+
+```{terminal}
+   :input: pebble check foo-warning
+name: foo-warning
+startup: enabled
+status: down
+failures: 3
+threshold: 1
+change-id: "60"
+logs: |
+    2025-04-26T11:22:27+08:00 ERROR exit status 1
+    2025-04-26T11:22:37+08:00 ERROR exit status 1
+```
 
 ## See more
 
-- [`pebble check`](#reference_pebble_check_command) command
 - [`pebble health`](#reference_pebble_health_command) command
+- [`pebble check`](#reference_pebble_check_command) command
 - [](/reference/health-checks)

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -31,7 +31,7 @@ The check searches Pebble's service logs for lines matching the pattern, such as
 
 If a match is found, the `bash -c '...'` command exits with 1 and the check fails.
 
-By default, Pebble keeps a service running even if a check fails. Although we can configure a service to restart on check failure, this approach isn't helpful here. That's because restarting `foo` won't remove the warning from the logs, so the check remains "down", and subsequent failures won't trigger additional restarts. So, in this particular case, it's better to monitor the check and alert a human operator to investigate.
+By default, Pebble keeps a service running even if a check fails. Although we can configure a service to restart on check failure, this approach isn't helpful here. That's because restarting `foo` won't remove the warning from the logs, so the check remains "down", and subsequent failures won't trigger additional restarts. In this particular case, it's better to monitor the check and alert a human operator to investigate.
 
 ## Get the status of the check
 

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -1,6 +1,8 @@
 # How to check health based on logs
 
-<!-- TODO: Need to be clear that this is not the primary way to check health. It's kind of a hack. This is an aid to monitoring/diagnosis. It's not recommended as an unattended way to ensure that a service runs reliably. -->
+Pebble stores the most recent `stdout` and `stderr` from each service. This guide demonstrates how to set up a health check that fails if the logs contain a particular line, such as a warning message.
+
+This is an indirect and potentially unreliable way to catch issues with services. Whenever possible, you should set up health checks that query the service status directly. For more information, see [](./run-services-reliably).
 
 ## Define a layer
 
@@ -18,6 +20,7 @@ checks:
     threshold: 1
     exec:
       command: bash -c '! pebble logs | grep -q "\\[foo\\] .*WARNING"'
+      # Because of YAML escaping rules, we need to use \\[ to pass \[ to grep.
 ```
 
 The check searches Pebble's service logs for lines such as:
@@ -28,9 +31,9 @@ The check searches Pebble's service logs for lines such as:
 
 If a match is found, the `bash -c '...'` command exits with 1 and the check fails.
 
-When the check fails, Pebble doesn't restart `foo`. To learn how to automatically restart `foo`, see [](#restart-a-service-when-the-health-check-fails). However, we recommend that you don't configure `foo` to restart. After restarting `foo`, Pebble's service logs would still contain the warning line, so the check would still be considered "down" and Pebble wouldn't restart `foo` if another warning is logged.
+When the check fails, Pebble doesn't restart `foo`. If `foo` were to restart, the check would still be considered "down" (because the logs would still contain the warning message) and Pebble wouldn't restart `foo` again if another warning occurred.
 
-Instead of configuring `foo` to restart, we recommend that you monitor the check and alert a human operator if the check fails.
+It's possible to [configure a service to restart when a check fails](#restart-a-service-when-the-health-check-fails). However, we don't recommend that you configure `foo` to restart. Instead, we recommend that you monitor the check and alert a human operator if the check fails.
 
 ## Get the status of the check
 
@@ -60,6 +63,7 @@ logs: |
 
 ## See more
 
+- [`pebble logs`](#reference_pebble_logs_command) command
 - [`pebble health`](#reference_pebble_health_command) command
 - [`pebble check`](#reference_pebble_check_command) command
 - [](/reference/health-checks)

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -31,7 +31,7 @@ The check searches Pebble's service logs for lines matching the pattern, such as
 
 If a match is found, the `bash -c '...'` command exits with 1 and the check fails.
 
-By default, Pebble keeps a service running without restarting it even if a check fails. Although we can configure a service to restart on check failure, this approach isn't helpful here. That's because restarting `foo` won't remove the logged warning from the logs, so the check remains "down", and subsequent failures won't trigger additional restarts. So, in this particular case, it's better to monitor the check and alert a human operator to investigate.
+By default, Pebble keeps a service running even if a check fails. Although we can configure a service to restart on check failure, this approach isn't helpful here. That's because restarting `foo` won't remove the warning from the logs, so the check remains "down", and subsequent failures won't trigger additional restarts. So, in this particular case, it's better to monitor the check and alert a human operator to investigate.
 
 ## Get the status of the check
 

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -14,6 +14,7 @@ services:
     override: replace
     command: /bin/foo
     startup: enabled
+
 checks:
   foo-warning:
     override: replace

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -50,6 +50,7 @@ To better understand the operation of the services, you may need to work with lo
 
 Forward logs to Loki <forward-logs-to-loki>
 Capture logs from files <capture-logs-from-files>
+Check health based on logs <check-health-based-on-logs>
 ```
 
 

--- a/docs/how-to/run-services-reliably.md
+++ b/docs/how-to/run-services-reliably.md
@@ -41,6 +41,7 @@ checks:
 
 Besides the `http` type, there are two more health check types in Pebble: `tcp`, which opens the given TCP port, and `exec`, which executes a user-specified command. For more information, see [Health checks](../reference/health-checks) and [Layer specification](../reference/layer-specification).
 
+(restart-a-service-when-the-health-check-fails)=
 ## Restart a service when the health check fails
 
 To automatically restart services when a health check fails, use `on-check-failure` in the service configuration.

--- a/docs/reference/health-checks.md
+++ b/docs/reference/health-checks.md
@@ -114,6 +114,11 @@ checks:
             url: http://localhost:8080/test
 ```
 
+See also:
+
+- [](/how-to/run-services-reliably)
+- [](/how-to/check-health-based-on-logs)
+
 ## Checks command
 
 You can view check status using the `pebble checks` command. This reports the checks along with their status (`up`, `down`, or `inactive`) and number of failures. For example:


### PR DESCRIPTION
This PR adds a how-to guide called "How to check health based on logs". Closes #601

**[Preview doc](https://canonical-ubuntu-documentation-library--607.com.readthedocs.build/pebble/how-to/check-health-based-on-logs/)**

This PR also adds a couple of "see also" links after the examples on the health checks reference page ([see preview](https://canonical-ubuntu-documentation-library--607.com.readthedocs.build/pebble/reference/health-checks/#examples)).