### PR TITLE
fix: when pruning changes preserve referential integrity for notices

### DIFF
--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -51,7 +51,11 @@ var (
 	// In snapd this is 7d, but also increase that in the context of Pebble.
 	abortWait = 24 * time.Hour * 14
 
+	// Hold no more than 500 completed changes, even if they have not yet expired
 	pruneMaxChanges = 500
+
+	// Hold no more than 1000 completed notices, even if they have not yet expired
+	pruneMaxNotices = 1000
 )
 
 var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
@@ -404,7 +408,7 @@ func (o *Overlord) Loop() {
 			case <-pruneC:
 				st := o.State()
 				st.Lock()
-				st.Prune(o.startOfOperationTime, pruneWait, abortWait, pruneMaxChanges)
+				st.Prune(o.startOfOperationTime, pruneWait, abortWait, pruneMaxChanges, pruneMaxNotices)
 				st.Unlock()
 			}
 		}

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -51,8 +51,8 @@ var (
 	// In snapd this is 7d, but also increase that in the context of Pebble.
 	abortWait = 24 * time.Hour * 14
 
-	// Hold no more than 500 completed changes, even if they have not yet expired
-	pruneMaxChanges = 500
+	// Hold no more than 1000 completed changes, even if they have not yet expired
+	pruneMaxChanges = 1000
 
 	// Hold no more than 1000 completed notices, even if they have not yet expired
 	pruneMaxNotices = 1000

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -218,9 +218,6 @@ type AddNoticeOptions struct {
 
 	// Time, if set, overrides time.Now() as the notice occurrence time.
 	Time time.Time
-
-	// ExpireAfter, if set, overrides the default expiry time
-	ExpireAfter time.Duration
 }
 
 // AddNotice records an occurrence of a notice with the specified type and key
@@ -241,9 +238,6 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 		now = time.Now()
 	}
 	now = now.UTC()
-	if options.ExpireAfter == 0 {
-		options.ExpireAfter = defaultNoticeExpireAfter
-	}
 	newOrRepeated := false
 	uid, hasUserID := flattenUserID(userID)
 	uniqueKey := noticeKey{hasUserID, uid, noticeType, key}
@@ -258,7 +252,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 			key:           key,
 			firstOccurred: now,
 			lastRepeated:  now,
-			expireAfter:   options.ExpireAfter,
+			expireAfter:   defaultNoticeExpireAfter,
 			occurrences:   1,
 		}
 		s.notices[uniqueKey] = notice

--- a/internals/overlord/state/notices.go
+++ b/internals/overlord/state/notices.go
@@ -218,6 +218,9 @@ type AddNoticeOptions struct {
 
 	// Time, if set, overrides time.Now() as the notice occurrence time.
 	Time time.Time
+
+	// ExpireAfter, if set, overrides the default expiry time
+	ExpireAfter time.Duration
 }
 
 // AddNotice records an occurrence of a notice with the specified type and key
@@ -238,6 +241,9 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 		now = time.Now()
 	}
 	now = now.UTC()
+	if options.ExpireAfter == 0 {
+		options.ExpireAfter = defaultNoticeExpireAfter
+	}
 	newOrRepeated := false
 	uid, hasUserID := flattenUserID(userID)
 	uniqueKey := noticeKey{hasUserID, uid, noticeType, key}
@@ -252,7 +258,7 @@ func (s *State) AddNotice(userID *uint32, noticeType NoticeType, key string, opt
 			key:           key,
 			firstOccurred: now,
 			lastRepeated:  now,
-			expireAfter:   defaultNoticeExpireAfter,
+			expireAfter:   options.ExpireAfter,
 			occurrences:   1,
 		}
 		s.notices[uniqueKey] = notice

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -455,14 +455,14 @@ func (s *noticesSuite) TestDeleteExpired(c *C) {
 	})
 	// 6 days ago, so this has not yet expired, but set to expire slightly later
 	addNotice(c, st, nil, state.CustomNotice, "foo.com/six-later", &state.AddNoticeOptions{
-		Time:        now.Add(-6 * 24 * time.Hour + time.Microsecond),
+		Time: now.Add(-6*24*time.Hour + time.Microsecond),
 	})
 	// occurred 10 days ago, but then a second time 5 days ago, so won't expire for a while
 	addNotice(c, st, nil, state.CustomNotice, "foo.com/five", &state.AddNoticeOptions{
-		Time:        now.Add(-10 * 24 * time.Hour + time.Microsecond),
+		Time: now.Add(-10*24*time.Hour + time.Microsecond),
 	})
 	addNotice(c, st, nil, state.CustomNotice, "foo.com/five", &state.AddNoticeOptions{
-		Time:        now.Add(-5 * 24 * time.Hour + time.Microsecond),
+		Time: now.Add(-5*24*time.Hour + time.Microsecond),
 	})
 
 	// 2 days ago, so this has not expired, but it refers to a change that doesn't exist

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -455,7 +455,7 @@ func (s *noticesSuite) TestDeleteExpired(c *C) {
 
 	c.Assert(st.NumNotices(), Equals, 5)
 	c.Assert(st.LatestWarningTime().Equal(old), Equals, true)
-	st.Prune(time.Now(), 0, 0, 0)
+	st.Prune(time.Now(), 0, 0, 0, 0)
 	c.Assert(st.NumNotices(), Equals, 2)
 	c.Assert(st.LatestWarningTime().IsZero(), Equals, true)
 

--- a/internals/overlord/state/notices_test.go
+++ b/internals/overlord/state/notices_test.go
@@ -439,32 +439,79 @@ func (s *noticesSuite) TestDeleteExpired(c *C) {
 	c.Assert(st.NumNotices(), Equals, 0)
 	c.Assert(st.LatestWarningTime().IsZero(), Equals, true)
 
-	old := time.Now().Add(-8 * 24 * time.Hour)
-	addNotice(c, st, nil, state.CustomNotice, "foo.com/w", &state.AddNoticeOptions{
+	now := time.Now()
+	old := now.Add(-8 * 24 * time.Hour)
+	// 8 days ago, which is outside the 7 day expiry window
+	addNotice(c, st, nil, state.CustomNotice, "foo.com/eight", &state.AddNoticeOptions{
 		Time: old,
 	})
-	addNotice(c, st, nil, state.CustomNotice, "foo.com/x", &state.AddNoticeOptions{
-		Time: old,
-	})
+	// Expired warning notice
 	addNotice(c, st, nil, state.WarningNotice, "warning!", &state.AddNoticeOptions{
 		Time: old,
 	})
-	addNotice(c, st, nil, state.CustomNotice, "foo.com/y", nil)
-	time.Sleep(time.Microsecond)
-	addNotice(c, st, nil, state.CustomNotice, "foo.com/z", nil)
+	// 6 days ago, so this has not yet expired, however, it is close to expiring
+	addNotice(c, st, nil, state.CustomNotice, "foo.com/six", &state.AddNoticeOptions{
+		Time: now.Add(-6 * 24 * time.Hour),
+	})
+	// 6 days ago, so this has not yet expired, but set to expire even later
+	addNotice(c, st, nil, state.CustomNotice, "foo.com/six-longer", &state.AddNoticeOptions{
+		Time:        now.Add(-6 * 24 * time.Hour + time.Microsecond),
+		ExpireAfter: 10 * 24 * time.Hour,
+	})
+	// 5 days ago (so happened more recently), but set to expire at the same time as six
+	addNotice(c, st, nil, state.CustomNotice, "foo.com/five", &state.AddNoticeOptions{
+		Time:        now.Add(-5 * 24 * time.Hour),
+		ExpireAfter: 6 * 24 * time.Hour,
+	})
 
-	c.Assert(st.NumNotices(), Equals, 5)
-	c.Assert(st.LatestWarningTime().Equal(old), Equals, true)
-	st.Prune(time.Now(), 0, 0, 0, 0)
-	c.Assert(st.NumNotices(), Equals, 2)
-	c.Assert(st.LatestWarningTime().IsZero(), Equals, true)
+	// 
+	// 2 days ago, so this has not expired, but it refers to a change that doesn't exist
+	// so this should still be pruned
+	addNotice(c, st, nil, state.ChangeUpdateNotice, "999", &state.AddNoticeOptions{
+		Time: time.Now().Add(-2 * 24 * time.Hour),
+	})
+	// Right now, definitely not expired
+	addNotice(c, st, nil, state.CustomNotice, "foo.com/almost-now", &state.AddNoticeOptions{
+		Time: now,
+	})
+	now = now.Add(time.Microsecond)
+	addNotice(c, st, nil, state.CustomNotice, "foo.com/now", &state.AddNoticeOptions{
+		Time: now,
+	})
+
+	c.Check(st.NumNotices(), Equals, 8)
+	c.Check(st.LatestWarningTime().Equal(old), Equals, true)
+	// Prune everything that has expired by now
+	st.Prune(now, 0, 0, 0, 100)
+	c.Check(st.NumNotices(), Equals, 5)
+	c.Check(st.LatestWarningTime().IsZero(), Equals, true)
 
 	notices := st.Notices(nil)
-	c.Assert(notices, HasLen, 2)
+	c.Assert(notices, HasLen, 5)
 	n := noticeToMap(c, notices[0])
-	c.Assert(n["key"], Equals, "foo.com/y")
+	c.Check(n["key"], Equals, "foo.com/six")
 	n = noticeToMap(c, notices[1])
-	c.Assert(n["key"], Equals, "foo.com/z")
+	c.Check(n["key"], Equals, "foo.com/six-longer")
+	n = noticeToMap(c, notices[2])
+	c.Check(n["key"], Equals, "foo.com/five")
+	n = noticeToMap(c, notices[3])
+	c.Check(n["key"], Equals, "foo.com/almost-now")
+	n = noticeToMap(c, notices[4])
+	c.Check(n["key"], Equals, "foo.com/now")
+
+	// Now we force the prune to be count based, and it should prefer to remove six. five and six both expire at the
+	// same time, but five occurred more recently
+	st.Prune(now, 0, 0, 0, 4)
+	notices = st.Notices(nil)
+	c.Assert(notices, HasLen, 4)
+	n = noticeToMap(c, notices[0])
+	c.Check(n["key"], Equals, "foo.com/six-longer")
+	n = noticeToMap(c, notices[1])
+	c.Check(n["key"], Equals, "foo.com/five")
+	n = noticeToMap(c, notices[2])
+	c.Check(n["key"], Equals, "foo.com/almost-now")
+	n = noticeToMap(c, notices[3])
+	c.Check(n["key"], Equals, "foo.com/now")
 }
 
 func (s *noticesSuite) TestWaitNoticesExisting(c *C) {

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -632,7 +632,7 @@ func (p *pruneStats) IncludeNotice(n *Notice) {
 func (p *pruneStats) Log() {
 	if p.numChangesPruned == 0 && p.numNoticesPruned == 0 {
 		// For this common case, just log a single line, we might want to move this to Debug
-		logger.Noticef("Prune() removed no Changes or Notices")
+		logger.Noticef("pruned 0 changes and 0 notices")
 	} else {
 		if p.numChangesPruned == 0 {
 			logger.Noticef("pruned 0 changes")

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -589,8 +589,23 @@ NextChange:
 	if len(s.notices) > maxNotices {
 		s.pruneMaxNotices(maxNotices, stats)
 	}
-	logger.Noticef("pruned %d changes from %s to %s", stats.numChangesPruned, stats.oldestChangePruned, stats.newestChangePruned)
-	logger.Noticef("pruned %d notices from %s to %s", stats.numNoticesPruned, stats.oldestNoticePruned, stats.newestNoticePruned)
+	if stats.numChangesPruned == 0 && stats.numNoticesPruned == 0 {
+		// For this common case, just log a single line, we might want to move this to Debug
+		logger.Noticef("Prune() removed no Changes or Notices")
+	} else {
+		if stats.numChangesPruned == 0 {
+			logger.Noticef("pruned 0 changes")
+		} else {
+			logger.Noticef("pruned %d changes from %s to %s",
+				stats.numChangesPruned, stats.oldestChangePruned, stats.newestChangePruned)
+		}
+		if stats.numNoticesPruned == 0 {
+			logger.Noticef("pruned 0 notices")
+		} else {
+			logger.Noticef("pruned %d notices from %s to %s",
+				stats.numNoticesPruned, stats.oldestNoticePruned, stats.newestNoticePruned)
+		}
+	}
 }
 
 type pruneStats struct {

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -501,9 +501,9 @@ func (s *State) RegisterPendingChangeByAttr(attr string, f func(*Change) bool) {
 //
 //   - it removes expired warnings and notices. If the notice refers to a
 //     change that was removed, then the notice is removed, if there are still
-//     more than maxNotices they are removed until we reach maxNotices. The
-//     order of pruning is based on which notices would expire first, and then
-//     by oldest lastOccurred
+//     more than maxNotices they are removed until we reach maxNotices. When pruning
+//     down to maxNotices, the oldest lastOccurred are removed (iow, we keep
+//     recent notices in favor of older notices.)
 func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Duration, maxReadyChanges, maxNotices int) {
 	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -606,7 +606,7 @@ type pruneStats struct {
 func (s *pruneStats) IncludeChange(chg *Change) {
 	s.numChanges++
 	if chg == nil {
-		logger.Noticef("IncludeChange called with a nil Change")
+		logger.Noticef("InternalError: IncludeChange called with a nil Change")
 	}
 	if chg.readyTime.IsZero() {
 		return
@@ -622,10 +622,10 @@ func (s *pruneStats) IncludeChange(chg *Change) {
 func (s *pruneStats) IncludeNotice(n *Notice) {
 	s.numNotices++
 	if n == nil {
-		logger.Noticef("IncludeNotice called with a nil Notice")
+		logger.Noticef("InternalError: IncludeNotice called with a nil Notice")
 	}
 	if n.lastOccurred.IsZero() {
-		logger.Noticef("IncludeNotice called with a Notice that has no lastOccurred time")
+		logger.Noticef("InternalError: IncludeNotice called with a Notice that has no lastOccurred time")
 		return
 	}
 	if s.oldestNotice.IsZero() || n.lastOccurred.Before(s.oldestNotice) {
@@ -657,13 +657,7 @@ func (s *State) pruneMaxNotices(maxNotices int, stats *pruneStats) {
 		notices = append(notices, n)
 	}
 	slices.SortFunc(notices, func(a, b *Notice) int {
-		if a.lastOccurred.Before(b.lastOccurred) {
-			return -1
-		}
-		if a.lastOccurred.Equal(b.lastOccurred) {
-			return 0
-		}
-		return 1
+		return a.lastOccurred.Compare(b.lastOccurred)
 	})
 	numToRemove := len(s.notices) - maxNotices
 	for _, n := range notices[:numToRemove] {

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -502,8 +502,8 @@ func (s *State) RegisterPendingChangeByAttr(attr string, f func(*Change) bool) {
 //   - it removes expired warnings and notices. If the notice refers to a
 //     change that was removed, then the notice is removed, if there are still
 //     more than maxNotices they are removed until we reach maxNotices. When pruning
-//     down to maxNotices, the oldest lastOccurred are removed (iow, we keep
-//     recent notices in favor of older notices.)
+//     down to maxNotices, the oldest lastOccurred are removed (in other words,
+//     we keep recent notices in favor of older notices.)
 func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Duration, maxReadyChanges, maxNotices int) {
 	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -607,6 +607,7 @@ func (s *pruneStats) IncludeChange(chg *Change) {
 	s.numChanges++
 	if chg == nil {
 		logger.Noticef("InternalError: IncludeChange called with a nil Change")
+		return
 	}
 	if chg.readyTime.IsZero() {
 		return
@@ -623,6 +624,7 @@ func (s *pruneStats) IncludeNotice(n *Notice) {
 	s.numNotices++
 	if n == nil {
 		logger.Noticef("InternalError: IncludeNotice called with a nil Notice")
+		return
 	}
 	if n.lastOccurred.IsZero() {
 		logger.Noticef("InternalError: IncludeNotice called with a Notice that has no lastOccurred time")

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -498,8 +498,12 @@ func (s *State) RegisterPendingChangeByAttr(attr string, f func(*Change) bool) {
 //     changes than the limit set via "maxReadyChanges" those changes in ready
 //     state will also removed even if they are below the pruneWait duration.
 //
-//   - it removes expired warnings and notices.
-func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Duration, maxReadyChanges int) {
+//   - it removes expired warnings and notices. If the notice refers to a
+//     change that was removed, then the notice is removed, if there are still
+//     more than maxReadyNotices they are removed until we reach maxReady. The
+//     order of pruning is based on which notices would expire first, and then
+//     by oldest lastOccurred
+func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Duration, maxReadyChanges, maxReadyNotices int) {
 	now := time.Now()
 	pruneLimit := now.Add(-pruneWait)
 	abortLimit := now.Add(-abortWait)

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -531,7 +531,7 @@ func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Dura
 	}
 	s.latestWarningTime.Store(&latestWarningTime)
 
-	prunedChangeIds := map[string]struct{}{}
+	prunedChangeIDs := make(map[string]struct{})
 
 NextChange:
 	for _, chg := range changes {
@@ -561,7 +561,7 @@ NextChange:
 				delete(s.tasks, t.ID())
 			}
 			delete(s.changes, chg.ID())
-			prunedChangeIds[chg.ID()] = struct{}{}
+			prunedChangeIDs[chg.ID()] = struct{}{}
 			readyChangesCount--
 		}
 	}
@@ -576,11 +576,12 @@ NextChange:
 	// Remove all the notices that refer to changes that have been pruned
 	// Note that we are using the fact that noticeKey redundantly references
 	//  several items from the notice object
-	for k := range s.notices {
-		if k.noticeType == ChangeUpdateNotice {
-			if _, pruned := prunedChangeIds[k.key]; pruned {
-				delete(s.notices, k)
-			}
+	for n := range s.notices {
+		if n.noticeType != ChangeUpdateNotice {
+			continue
+		}
+		if _, pruned := prunedChangeIDs[n.key]; pruned {
+			delete(s.notices, n)
 		}
 	}
 }

--- a/internals/overlord/state/state_test.go
+++ b/internals/overlord/state/state_test.go
@@ -46,13 +46,13 @@ type mgrState2 struct {
 	C *Count2
 }
 
-func (ss *stateSuite) TestLockUnlock(c *C) {
+func (ss *stateSuite) TestLockUnlock(_ *C) {
 	st := state.New(nil)
 	st.Lock()
 	st.Unlock()
 }
 
-func (ss *stateSuite) TestUnlocker(c *C) {
+func (ss *stateSuite) TestUnlocker(_ *C) {
 	st := state.New(nil)
 	unlocker := st.Unlocker()
 	st.Lock()
@@ -271,14 +271,14 @@ func (ss *stateSuite) TestImplicitCheckpointRetry(c *C) {
 
 	retries := 0
 	boom := errors.New("boom")
-	error := func() error {
+	err := func() error {
 		retries++
 		if retries == 2 {
 			return nil
 		}
 		return boom
 	}
-	b := &fakeStateBackend{error: error}
+	b := &fakeStateBackend{error: err}
 	st := state.New(b)
 	st.Lock()
 
@@ -779,20 +779,20 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.Set("foo", 1) },
 		func() { st.NewChange("install", "...") },
 		func() { st.NewTask("download", "...") },
-		func() { st.UnmarshalJSON(nil) },
+		func() { _ = st.UnmarshalJSON(nil) },
 		func() { st.NewLane() },
 		func() { st.Warnf("hello") },
 	}
 
 	reads := []func(){
-		func() { st.Get("foo", nil) },
+		func() { _ = st.Get("foo", nil) },
 		func() { st.Cached("foo") },
 		func() { st.Cache("foo", 1) },
 		func() { st.Changes() },
 		func() { st.Change("foo") },
 		func() { st.Tasks() },
 		func() { st.Task("foo") },
-		func() { st.MarshalJSON() },
+		func() { _, _ = st.MarshalJSON() },
 		func() { st.Prune(time.Now(), time.Hour, time.Hour, 100) },
 		func() { st.TaskCount() },
 	}
@@ -834,9 +834,14 @@ func (ss *stateSuite) TestPrune(c *C) {
 	chg1.AddTask(t1)
 	state.FakeChangeTimes(chg1, now.Add(-abortWait), unset)
 
+	n1_id, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg1.ID(), nil)
+	c.Assert(err, IsNil)
+
 	chg2 := st.NewChange("prune", "...")
 	chg2.AddTask(t2)
 	c.Assert(chg2.Status(), Equals, state.DoStatus)
+	n2_id, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg2.ID(), nil)
+	c.Assert(err, IsNil)
 	state.FakeChangeTimes(chg2, now.Add(-pruneWait), now.Add(-pruneWait))
 
 	chg3 := st.NewChange("ready-but-recent", "...")
@@ -846,6 +851,13 @@ func (ss *stateSuite) TestPrune(c *C) {
 	chg4 := st.NewChange("old-but-not-ready", "...")
 	chg4.AddTask(t4)
 	state.FakeChangeTimes(chg4, now.Add(-pruneWait/2), unset)
+
+	n4_id, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg4.ID(), &state.AddNoticeOptions{
+		// Prune ignores the pruneWait for notices, it only ever pays attention to expireAfter
+		// attribute of the notice, which is hard coded to
+		// defaultNoticeExpireAfter = 7 * 24 * time.Hour
+		Time: now.Add(-8 * 24 * time.Hour),
+	})
 
 	// unlinked task
 	t5 := st.NewTask("unliked", "...")
@@ -874,6 +886,12 @@ func (ss *stateSuite) TestPrune(c *C) {
 	c.Assert(t4.Status(), Equals, state.DoStatus)
 
 	c.Check(st.TaskCount(), Equals, 3)
+
+	// n1 didn't expire, n2 was pruned because change 2 was removed, and
+	// n4 was pruned because its last occurance was old
+	c.Assert(st.Notice(n1_id), NotNil)
+	c.Assert(st.Notice(n2_id), IsNil)
+	c.Assert(st.Notice(n4_id), IsNil)
 }
 
 func (ss *stateSuite) TestRegisterPendingChangeByAttr(c *C) {

--- a/internals/overlord/state/state_test.go
+++ b/internals/overlord/state/state_test.go
@@ -46,13 +46,13 @@ type mgrState2 struct {
 	C *Count2
 }
 
-func (ss *stateSuite) TestLockUnlock(_ *C) {
+func (ss *stateSuite) TestLockUnlock(c *C) {
 	st := state.New(nil)
 	st.Lock()
 	st.Unlock()
 }
 
-func (ss *stateSuite) TestUnlocker(_ *C) {
+func (ss *stateSuite) TestUnlocker(c *C) {
 	st := state.New(nil)
 	unlocker := st.Unlocker()
 	st.Lock()
@@ -779,20 +779,20 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.Set("foo", 1) },
 		func() { st.NewChange("install", "...") },
 		func() { st.NewTask("download", "...") },
-		func() { _ = st.UnmarshalJSON(nil) },
+		func() { st.UnmarshalJSON(nil) },
 		func() { st.NewLane() },
 		func() { st.Warnf("hello") },
 	}
 
 	reads := []func(){
-		func() { _ = st.Get("foo", nil) },
+		func() { st.Get("foo", nil) },
 		func() { st.Cached("foo") },
 		func() { st.Cache("foo", 1) },
 		func() { st.Changes() },
 		func() { st.Change("foo") },
 		func() { st.Tasks() },
 		func() { st.Task("foo") },
-		func() { _, _ = st.MarshalJSON() },
+		func() { st.MarshalJSON() },
 		func() { st.Prune(time.Now(), time.Hour, time.Hour, 100) },
 		func() { st.TaskCount() },
 	}
@@ -834,13 +834,13 @@ func (ss *stateSuite) TestPrune(c *C) {
 	chg1.AddTask(t1)
 	state.FakeChangeTimes(chg1, now.Add(-abortWait), unset)
 
-	n1_id, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg1.ID(), nil)
+	n1ID, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg1.ID(), nil)
 	c.Assert(err, IsNil)
 
 	chg2 := st.NewChange("prune", "...")
 	chg2.AddTask(t2)
 	c.Assert(chg2.Status(), Equals, state.DoStatus)
-	n2_id, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg2.ID(), nil)
+	n2ID, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg2.ID(), nil)
 	c.Assert(err, IsNil)
 	state.FakeChangeTimes(chg2, now.Add(-pruneWait), now.Add(-pruneWait))
 
@@ -852,12 +852,13 @@ func (ss *stateSuite) TestPrune(c *C) {
 	chg4.AddTask(t4)
 	state.FakeChangeTimes(chg4, now.Add(-pruneWait/2), unset)
 
-	n4_id, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg4.ID(), &state.AddNoticeOptions{
+	n4ID, err := st.AddNotice(nil, state.ChangeUpdateNotice, chg4.ID(), &state.AddNoticeOptions{
 		// Prune ignores the pruneWait for notices, it only ever pays attention to expireAfter
 		// attribute of the notice, which is hard coded to
 		// defaultNoticeExpireAfter = 7 * 24 * time.Hour
 		Time: now.Add(-8 * 24 * time.Hour),
 	})
+	c.Assert(err, IsNil)
 
 	// unlinked task
 	t5 := st.NewTask("unliked", "...")
@@ -889,9 +890,9 @@ func (ss *stateSuite) TestPrune(c *C) {
 
 	// n1 didn't expire, n2 was pruned because change 2 was removed, and
 	// n4 was pruned because its last occurance was old
-	c.Assert(st.Notice(n1_id), NotNil)
-	c.Assert(st.Notice(n2_id), IsNil)
-	c.Assert(st.Notice(n4_id), IsNil)
+	c.Assert(st.Notice(n1ID), NotNil)
+	c.Assert(st.Notice(n2ID), IsNil)
+	c.Assert(st.Notice(n4ID), IsNil)
 }
 
 func (ss *stateSuite) TestRegisterPendingChangeByAttr(c *C) {

--- a/internals/overlord/state/taskrunner_test.go
+++ b/internals/overlord/state/taskrunner_test.go
@@ -190,7 +190,7 @@ func (ts *taskRunnerSuite) TestSequenceTests(c *C) {
 		st.Lock()
 
 		// Delete previous changes.
-		st.Prune(past, 1, 1, 1)
+		st.Prune(past, 1, 1, 1, 1)
 
 		chg := st.NewChange("install", "...")
 		tasks := make(map[string]*state.Task)


### PR DESCRIPTION
When pruning changes, also prune notices under a few rules:

1) Remove Changes down to 1000 (changed from 500) according to the existing logic.
2) Remove "change-update" Notices that refer to changes that do not exist.
3) Further remove Notices down to 1000 Notices.
4) Log an aggregate result of what changes and notices have been pruned.

This is an update to https://github.com/canonical/pebble/pull/611, built off of 1.19.0. Some of the key differences to 611 are:
a) We prune all notices that refer to an unknown change, not just the ones that were recently pruned. This is better for consistency, and it means we don't need to track an extra set of what has changed.
b) Notices are also kept to an absolute maximum count.

I ran this with a lightly customized overload.go and state/notices.go to run prune every minute, and to not prune expired notices on load. The new messages look like (before review changes):

```
2025-05-09T08:48:59.675Z [pebble] pruned 500 changes from 2025-04-29 23:00:12.035231144 +0000 UTC to 2025-05-01 13:24:18.814988887 +0000 UTC
2025-05-09T08:48:59.675Z [pebble] pruned 2003 notices from 2025-04-24 21:40:52.669570839 +0000 UTC to 2025-05-01 13:24:18.814994277 +0000 UTC
2025-05-09T08:49:59.693Z [pebble] pruned 0 changes and 0 notices
2025-05-09T08:42:31.452Z [pebble] pruned 500 changes from 2025-04-29 23:00:12.035231144 +0000 UTC to 2025-05-01 13:24:18.814988887 +0000 UTC
2025-05-09T08:42:31.452Z [pebble] pruned 0 notices
```
