### PR TITLE
test: fix tests when run on timezones west of UTC

### DIFF
--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -77,6 +77,9 @@ func (s *PebbleSuite) TestGetChangesFails(c *check.C) {
 }
 
 func (s *PebbleSuite) TestChanges(c *check.C) {
+	restore := cli.FakeTimeLocalUTC()
+	defer restore()
+
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, check.Equals, "GET")
 		c.Check(r.URL.Path, check.Equals, "/v1/changes")

--- a/internals/cli/cmd_ls_test.go
+++ b/internals/cli/cmd_ls_test.go
@@ -62,6 +62,9 @@ func (s *PebbleSuite) TestLsDirectory(c *C) {
 }
 
 func (s *PebbleSuite) TestLsLongFormat(c *C) {
+	restore := cli.FakeTimeLocalUTC()
+	defer restore()
+
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, Equals, "GET")
 		c.Assert(r.URL.Path, Equals, "/v1/files")

--- a/internals/cli/export_test.go
+++ b/internals/cli/export_test.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/canonical/go-flags"
 
@@ -82,6 +83,14 @@ func FakeIsStdinTTY(t bool) (restore func()) {
 	isStdinTTY = t
 	return func() {
 		isStdinTTY = oldIsStdinTTY
+	}
+}
+
+func FakeTimeLocalUTC() (restore func()) {
+	oldLocal := time.Local
+	time.Local = time.UTC
+	return func() {
+		time.Local = oldLocal
 	}
 }
 

--- a/internals/timeutil/schedule_test.go
+++ b/internals/timeutil/schedule_test.go
@@ -496,6 +496,18 @@ func (ts *timeutilSuite) TestParseSchedule(c *C) {
 func (ts *timeutilSuite) TestScheduleNext(c *C) {
 	const shortForm = "2006-01-02 15:04"
 
+	// force timezone for tests to UTC otherwise if run in a
+	// different timezone where there was a daylight savings
+	// transition across one of the intervals (ie in Australia in
+	// 2019 DST started on 6th October) then the result will be
+	// different and the test will fail
+	oldLocal := time.Local
+	local, _ := time.LoadLocation("UTC")
+	time.Local = local
+	defer func() {
+		time.Local = oldLocal
+	}()
+
 	for _, t := range []struct {
 		schedule   string
 		last       string
@@ -777,7 +789,7 @@ func (ts *timeutilSuite) TestScheduleNext(c *C) {
 
 			c.Check(next >= minDist && next <= maxDist,
 				Equals, true,
-				Commentf("invalid  distance for schedule %q with last refresh %q, now %q, expected %v, got %v, date %s",
+				Commentf("invalid distance for schedule %q with last refresh %q, now %q, expected %v, got %v, date %s",
 					t.schedule, t.last, t.now, t.next, next, fakeNow.Add(next)))
 			previous = next
 		}


### PR DESCRIPTION
The test failures happen because we're displaying local time and matching on the same day as the UTC time, which is correct east of UTC but not west of UTC. To repro, run:

```
TZ="America/Sao_Paulo" go test ./... -count=1
```

This pulls in the fix for `timeutil.TestScheduleNext` from https://github.com/canonical/snapd/pull/12859, and does a similar fix for the `cli` tests that have the same issue.

I don't *love* patching the package variable `time.Local`, but because these use `timeutil.Human`, which uses `time.Local` directly, there's not a much better way around it.

Fixes #592.