### PR TITLE
fix: page auto and system dark mode

### DIFF
--- a/docs/.sphinx/_static/swagger-override.css
+++ b/docs/.sphinx/_static/swagger-override.css
@@ -100,4 +100,16 @@
             filter: invert(100%) hue-rotate(180deg);
         }
     }
+
+    @media (prefers-color-scheme: dark) {
+        body[data-theme="auto"] {
+            .swagger-ui {
+                filter: invert(88%) hue-rotate(180deg);
+            }
+
+            .swagger-ui .microlight {
+                filter: invert(100%) hue-rotate(180deg);
+            }
+        }   
+    }
 }


### PR DESCRIPTION
Fix an issue when the page theme is set to "auto", but the system appearance is set to "dark", the Sphinx docs titles and background colour inversion (done in a previous PR to improve readability in dark mode) don't work properly.

After playing with it a bit and getting some help from @dwilding, we figured out that this only occurs when the page is set to auto and the system is set to dark, on both macOS and Ubuntu. If the user explicitly sets the colour theme to dark on the page, it works properly.

See more details [here in this issue](https://github.com/canonical/pebble/issues/614)

Closes https://github.com/canonical/pebble/issues/614.

Preview: https://canonical-ubuntu-documentation-library--617.com.readthedocs.build/pebble/reference/api/#/changes-and-tasks (Remember to set your system colour mode to "dark").
