### PR TITLE
feat: add default Content-Type header to client requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -155,6 +155,9 @@ type Config struct {
 
 	// UserAgent is the User-Agent header sent to the Pebble daemon.
 	UserAgent string
+
+	// ContentType is the Content-Type header sent to the Pebble daemon.
+	ContentType string
 }
 
 // defaultTLSVerifier blocks all TLS (HTTPS) access by always rejecting the
@@ -196,6 +199,11 @@ func New(config *Config) (*Client, error) {
 	// The default verifier never trusts any server TLS certificates.
 	if localConfig.VerifyTLSConnection == nil {
 		localConfig.VerifyTLSConnection = defaultTLSVerifier
+	}
+
+	// Set default content type if not specified.
+	if localConfig.ContentType == "" {
+		localConfig.ContentType = "application/json"
 	}
 
 	client := &Client{}
@@ -268,6 +276,9 @@ func (rq *defaultRequester) dispatch(ctx context.Context, method, urlpath string
 	}
 	if rq.userAgent != "" {
 		req.Header.Set("User-Agent", rq.userAgent)
+	}
+	if rq.contentType != "" {
+		req.Header.Set("Content-Type", rq.contentType)
 	}
 
 	if rq.basicUsername != "" && rq.basicPassword != "" {
@@ -566,6 +577,7 @@ type defaultRequester struct {
 	baseURL       *url.URL
 	doer          doer
 	userAgent     string
+	contentType   string
 	basicUsername string
 	basicPassword string
 	transport     *http.Transport
@@ -624,6 +636,7 @@ func newDefaultRequester(client *Client, opts *Config) (*defaultRequester, error
 
 	requester.doer = &http.Client{Transport: requester.transport}
 	requester.userAgent = opts.UserAgent
+	requester.contentType = opts.ContentType
 	requester.client = client
 
 	return requester, nil

--- a/client/client.go
+++ b/client/client.go
@@ -567,7 +567,6 @@ type defaultRequester struct {
 	baseURL       *url.URL
 	doer          doer
 	userAgent     string
-	contentType   string
 	basicUsername string
 	basicPassword string
 	transport     *http.Transport

--- a/client/client.go
+++ b/client/client.go
@@ -155,9 +155,6 @@ type Config struct {
 
 	// UserAgent is the User-Agent header sent to the Pebble daemon.
 	UserAgent string
-
-	// ContentType is the Content-Type header sent to the Pebble daemon.
-	ContentType string
 }
 
 // defaultTLSVerifier blocks all TLS (HTTPS) access by always rejecting the
@@ -199,11 +196,6 @@ func New(config *Config) (*Client, error) {
 	// The default verifier never trusts any server TLS certificates.
 	if localConfig.VerifyTLSConnection == nil {
 		localConfig.VerifyTLSConnection = defaultTLSVerifier
-	}
-
-	// Set default content type if not specified.
-	if localConfig.ContentType == "" {
-		localConfig.ContentType = "application/json"
 	}
 
 	client := &Client{}
@@ -277,9 +269,7 @@ func (rq *defaultRequester) dispatch(ctx context.Context, method, urlpath string
 	if rq.userAgent != "" {
 		req.Header.Set("User-Agent", rq.userAgent)
 	}
-	if rq.contentType != "" {
-		req.Header.Set("Content-Type", rq.contentType)
-	}
+	req.Header.Set("Content-Type", "application/json")
 
 	if rq.basicUsername != "" && rq.basicPassword != "" {
 		req.SetBasicAuth(rq.basicUsername, rq.basicPassword)
@@ -636,7 +626,6 @@ func newDefaultRequester(client *Client, opts *Config) (*defaultRequester, error
 
 	requester.doer = &http.Client{Transport: requester.transport}
 	requester.userAgent = opts.UserAgent
-	requester.contentType = opts.ContentType
 	requester.client = client
 
 	return requester, nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -292,7 +292,7 @@ func (cs *clientSuite) TestUserAgent(c *C) {
 	c.Check(cs.req.Header.Get("User-Agent"), Equals, "some-agent/9.87")
 }
 
-func (cs *clientSuite) TestContenType(c *C) {
+func (cs *clientSuite) TestContentType(c *C) {
 	cli, err := client.New(&client.Config{})
 	c.Assert(err, IsNil)
 	cli.SetDoer(cs)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -292,6 +292,23 @@ func (cs *clientSuite) TestUserAgent(c *C) {
 	c.Check(cs.req.Header.Get("User-Agent"), Equals, "some-agent/9.87")
 }
 
+func (cs *clientSuite) TestContenType(c *C) {
+	cli, err := client.New(&client.Config{})
+	c.Assert(err, IsNil)
+	cli.SetDoer(cs)
+
+	resp, err := cli.Requester().Do(context.Background(), &client.RequestOptions{
+		Type:   client.RawRequest,
+		Method: "GET",
+		Path:   "/",
+	})
+	c.Assert(err, IsNil)
+	var v string
+	err = resp.DecodeResult(&v)
+	c.Assert(err, NotNil)
+	c.Check(cs.req.Header.Get("Content-Type"), Equals, "application/json")
+}
+
 func (cs *clientSuite) TestClientJSONError(c *C) {
 	cs.rsp = `some non-json error message`
 	_, err := cs.cli.SysInfo()

--- a/client/exec.go
+++ b/client/exec.go
@@ -149,16 +149,12 @@ func (client *Client) Exec(opts *ExecOptions) (*ExecProcess, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode JSON payload: %w", err)
 	}
-	headers := map[string]string{
-		"Content-Type": "application/json",
-	}
 	var result execResult
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
-		Type:    AsyncRequest,
-		Method:  "POST",
-		Path:    "/v1/exec",
-		Headers: headers,
-		Body:    &body,
+		Type:   AsyncRequest,
+		Method: "POST",
+		Path:   "/v1/exec",
+		Body:   &body,
 	})
 	if err != nil {
 		return nil, err

--- a/client/files.go
+++ b/client/files.go
@@ -292,15 +292,11 @@ func (client *Client) MakeDir(opts *MakeDirOptions) error {
 	}
 
 	var result []fileResult
-	headers := map[string]string{
-		"Content-Type": "application/json",
-	}
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
-		Type:    SyncRequest,
-		Method:  "POST",
-		Path:    "/v1/files",
-		Headers: headers,
-		Body:    &body,
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "/v1/files",
+		Body:   &body,
 	})
 	if err != nil {
 		return err
@@ -370,15 +366,11 @@ func (client *Client) RemovePath(opts *RemovePathOptions) error {
 	}
 
 	var result []fileResult
-	headers := map[string]string{
-		"Content-Type": "application/json",
-	}
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
-		Type:    SyncRequest,
-		Method:  "POST",
-		Path:    "/v1/files",
-		Headers: headers,
-		Body:    &body,
+		Type:   SyncRequest,
+		Method: "POST",
+		Path:   "/v1/files",
+		Body:   &body,
 	})
 	if err != nil {
 		return err

--- a/client/services.go
+++ b/client/services.go
@@ -80,7 +80,6 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 		Type:    AsyncRequest,
 		Method:  "POST",
 		Path:    "/v1/services",
-		Headers: nil,
 		Body:    bytes.NewBuffer(data),
 	})
 	if err != nil {

--- a/client/services.go
+++ b/client/services.go
@@ -77,10 +77,10 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 	}
 
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
-		Type:    AsyncRequest,
-		Method:  "POST",
-		Path:    "/v1/services",
-		Body:    bytes.NewBuffer(data),
+		Type:   AsyncRequest,
+		Method: "POST",
+		Path:   "/v1/services",
+		Body:   bytes.NewBuffer(data),
 	})
 	if err != nil {
 		return "", err

--- a/client/services.go
+++ b/client/services.go
@@ -75,15 +75,12 @@ func (client *Client) doMultiServiceAction(actionName string, services []string)
 	if err != nil {
 		return "", fmt.Errorf("cannot marshal multi-service action: %w", err)
 	}
-	headers := map[string]string{
-		"Content-Type": "application/json",
-	}
 
 	resp, err := client.Requester().Do(context.Background(), &RequestOptions{
 		Type:    AsyncRequest,
 		Method:  "POST",
 		Path:    "/v1/services",
-		Headers: headers,
+		Headers: nil,
 		Body:    bytes.NewBuffer(data),
 	})
 	if err != nil {


### PR DESCRIPTION
Add a default `Content-Type` header for the client requester. If not specified, use "application/json". It will be overridden when calling `client.Requester().Do` with headers set in `RequestOptions`. Also, remove the explicit Content-Type header with "application/json" in specific client calls.

Closes https://github.com/canonical/pebble/issues/561.
