### PR TITLE
feat: make checks report "unknown" before they've been run

### DIFF
--- a/client/checks.go
+++ b/client/checks.go
@@ -57,6 +57,7 @@ const (
 type CheckStatus string
 
 const (
+	CheckStatusUnknown  CheckStatus = "unknown"
 	CheckStatusUp       CheckStatus = "up"
 	CheckStatusDown     CheckStatus = "down"
 	CheckStatusInactive CheckStatus = "inactive"

--- a/internals/daemon/api_checks_test.go
+++ b/internals/daemon/api_checks_test.go
@@ -60,9 +60,9 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-			map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C1"},
-			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C2"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk2", "startup": "enabled", "status": "unknown", "level": "alive", "threshold": 3.0, "change-id": "C1"},
+			map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -79,8 +79,8 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C1"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with names filter (comma-separated values)
@@ -88,8 +88,8 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C1"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with level filter
@@ -97,7 +97,7 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk2", "startup": "enabled", "status": "unknown", "level": "alive", "threshold": 3.0, "change-id": "C0"},
 	})
 
 	// Request with names and level filters
@@ -105,7 +105,7 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 	})
 }
 
@@ -192,9 +192,9 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 			map[string]any{"name": "chk2", "startup": "disabled", "status": "inactive", "level": "alive", "threshold": 3.0, "change-id": ""},
-			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C2"},
+			map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -247,7 +247,7 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break

--- a/internals/overlord/checkstate/handlers.go
+++ b/internals/overlord/checkstate/handlers.go
@@ -64,7 +64,7 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 				// Update number of failures in check info. In threshold
 				// case, check data will be updated with new change ID by
 				// changeStatusChanged.
-				m.updateCheckData(config, changeID, details.Failures)
+				m.updateCheckData(config, changeID, CheckStatusUp, details.Failures)
 			}
 
 			m.state.Lock()
@@ -91,9 +91,8 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		}
 
 		m.incSuccessCount(config)
+		m.updateCheckData(config, changeID, CheckStatusUp, 0)
 		if details.Failures > 0 {
-			m.updateCheckData(config, changeID, 0)
-
 			m.state.Lock()
 			task.Logf("succeeded after %s", pluralise(details.Failures, "failure", "failures"))
 			details.Failures = 0
@@ -168,7 +167,7 @@ func (m *CheckManager) doRecoverCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		if err != nil {
 			m.incFailureCount(config)
 			details.Failures++
-			m.updateCheckData(config, changeID, details.Failures)
+			m.updateCheckData(config, changeID, CheckStatusDown, details.Failures)
 
 			m.state.Lock()
 			task.Set(checkDetailsAttr, &details)

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -116,11 +116,11 @@ func (s *ManagerSuite) TestChecks(c *C) {
 		},
 	})
 
-	// Wait for expected checks to be started.
+	// Wait for expected checks to be present.
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "up", Level: "alive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Level: "ready", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "unknown", Level: "alive", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Level: "ready", Threshold: 3},
 	})
 
 	// Re-configuring should update checks.
@@ -138,7 +138,7 @@ func (s *ManagerSuite) TestChecks(c *C) {
 
 	// Wait for checks to be updated.
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk4", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk4", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 }
 
@@ -366,9 +366,9 @@ func (s *ManagerSuite) TestPlanChangedSmarts(c *C) {
 	})
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -399,8 +399,8 @@ func (s *ManagerSuite) TestPlanChangedSmarts(c *C) {
 	})
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 6},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 6},
 	})
 	checks, err = s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -455,8 +455,8 @@ func (s *ManagerSuite) TestPlanChangedServiceContext(c *C) {
 	}
 	s.manager.PlanChanged(origPlan)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -484,8 +484,8 @@ func (s *ManagerSuite) TestPlanChangedServiceContext(c *C) {
 	})
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err = s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -647,9 +647,9 @@ func (s *ManagerSuite) TestStartChecks(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -660,9 +660,9 @@ func (s *ManagerSuite) TestStartChecks(c *C) {
 
 	changed, err := s.manager.StartChecks([]string{"chk1", "chk2"})
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
-		{Name: "chk2", Startup: "disabled", Status: "up", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk2", Startup: "disabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	c.Assert(err, IsNil)
 	c.Assert(changed, DeepEquals, []string{"chk2"})
@@ -697,7 +697,7 @@ func (s *ManagerSuite) TestStartChecksNotFound(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 
 	changed, err := s.manager.StartChecks([]string{"chk1", "chk2"})
@@ -738,9 +738,9 @@ func (s *ManagerSuite) TestStopChecks(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -753,7 +753,7 @@ func (s *ManagerSuite) TestStopChecks(c *C) {
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
 		{Name: "chk1", Startup: "enabled", Status: "inactive", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	c.Assert(err, IsNil)
 	c.Assert(changed, DeepEquals, []string{"chk1"})
@@ -787,7 +787,7 @@ func (s *ManagerSuite) TestStopChecksNotFound(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 
 	changed, err := s.manager.StopChecks([]string{"chk1", "chk2"})
@@ -828,15 +828,15 @@ func (s *ManagerSuite) TestReplan(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	s.manager.StopChecks([]string{"chk1"})
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
 		{Name: "chk1", Startup: "enabled", Status: "inactive", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	var originalChangeIDs []string
@@ -848,9 +848,9 @@ func (s *ManagerSuite) TestReplan(c *C) {
 	s.manager.Replan()
 	s.overlord.State().Unlock()
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	c.Assert(err, IsNil)
 	checks, err = s.manager.Checks()
@@ -1018,7 +1018,7 @@ func (s *ManagerSuite) TestRefreshCheck(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -1059,7 +1059,7 @@ func (s *ManagerSuite) TestRefreshCheckFailure(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -1095,7 +1095,7 @@ func (s *ManagerSuite) TestRefreshStoppedCheck(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	_, err = s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -1142,7 +1142,7 @@ func (s *ManagerSuite) TestRefreshStoppedCheckFailure(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
 	})
 	_, err = s.manager.Checks()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Currently `/v1/checks` returns a status of "up" before a check has been run the first time. This is misleading, as it's not really up, but "unknown". This changes the API to return "unknown" for this state.

However, the `/v1/health` endpoint still returns healthy (true) for this period, to avoid too a breaking change with health probes (plus, it's not clear that that's incorrect -- a boolean is all we have there, and it's not "down" either).

Fixes #164