### PR TITLE
feat: add https-address to /v1/system-info response

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -1227,6 +1227,7 @@ paths:
                   "result": {
                     "boot-id": "e14ed96e-5a98-4402-80f7-d19dd949eac3",
                     "http-address": ":4000",
+                    "https-address": ":4443",
                     "version": "v1.17.0"
                   }
                 }

--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -136,13 +136,15 @@ func v1SystemInfo(c *Command, r *http.Request, _ *UserState) Response {
 	defer state.Unlock()
 
 	result := struct {
-		BootID      string `json:"boot-id"`
-		HTTPAddress string `json:"http-address,omitempty"`
-		Version     string `json:"version"`
+		BootID       string `json:"boot-id"`
+		HTTPAddress  string `json:"http-address,omitempty"`
+		HTTPSAddress string `json:"https-address,omitempty"`
+		Version      string `json:"version"`
 	}{
-		BootID:      restart.BootID(state),
-		HTTPAddress: c.d.options.HTTPAddress,
-		Version:     c.d.Version,
+		BootID:       restart.BootID(state),
+		HTTPAddress:  c.d.options.HTTPAddress,
+		HTTPSAddress: c.d.options.HTTPSAddress,
+		Version:      c.d.Version,
 	}
 	return SyncResponse(result)
 }

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -107,6 +107,7 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	d := s.daemon(c)
 	d.Version = "42b1"
 	d.options.HTTPAddress = ":4000"
+	d.options.HTTPSAddress = ":4443"
 	state := d.overlord.State()
 	state.Lock()
 	_, err := restart.Manager(state, "ffffffff-ffff-ffff-ffff-ffffffffffff", nil)
@@ -118,9 +119,10 @@ func (s *apiSuite) TestSysInfo(c *check.C) {
 	c.Check(rec.Result().Header.Get("Content-Type"), check.Equals, "application/json")
 
 	expected := map[string]any{
-		"boot-id":      "ffffffff-ffff-ffff-ffff-ffffffffffff",
-		"http-address": ":4000",
-		"version":      "42b1",
+		"boot-id":       "ffffffff-ffff-ffff-ffff-ffffffffffff",
+		"http-address":  ":4000",
+		"https-address": ":4443",
+		"version":       "42b1",
 	}
 	var rsp resp
 	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), check.IsNil)


### PR DESCRIPTION
When we added the `--https` option to `pebble run` (#599), we forgot to add the corresponding `https-address` field to the /v1/system-info response. Add that in now.