### PR TITLE
fix: avoid panic when Pebble restarts after stop-checks

### DIFF
--- a/internals/overlord/checkstate/manager.go
+++ b/internals/overlord/checkstate/manager.go
@@ -600,7 +600,6 @@ func (m *CheckManager) StopChecks(checks []string) (stopped []string, err error)
 		change := m.state.Change(checkData.changeID)
 		if change != nil {
 			change.Abort()
-			change.SetStatus(state.AbortStatus)
 			stopped = append(stopped, check.Name)
 		}
 		// We pass in the current number of failures so that it remains the


### PR DESCRIPTION
Calling change.Abort() is enough. We had previously added the SetStatus in commit f9250f69a92f297fb7f1bfbe16b145605ca71262 as the test was seeing a Hold status, but that was because it hadn't done an Ensure to actually move the checks to Doing. So fix the test as well, and the change should end up as Done.

Fixes #621