### PR TITLE
fix: revert making checks report "unknown" before they've been run

### DIFF
--- a/client/checks.go
+++ b/client/checks.go
@@ -57,7 +57,6 @@ const (
 type CheckStatus string
 
 const (
-	CheckStatusUnknown  CheckStatus = "unknown"
 	CheckStatusUp       CheckStatus = "up"
 	CheckStatusDown     CheckStatus = "down"
 	CheckStatusInactive CheckStatus = "inactive"

--- a/docs/reference/health-checks.md
+++ b/docs/reference/health-checks.md
@@ -121,7 +121,7 @@ See also:
 
 ## Checks command
 
-You can view check status using the `pebble checks` command. This reports the checks along with their status and number of failures. For example:
+You can view check status using the `pebble checks` command. This reports the checks along with their status (`up`, `down`, or `inactive`) and number of failures. For example:
 
 ```{terminal}
    :input: pebble checks
@@ -129,16 +129,8 @@ Check   Level  Startup   Status    Failures  Change
 up      alive  enabled   up        0/1       10
 online  ready  enabled   down      1/3       13 (dial tcp 127.0.0.1:8000: connect: connection refused)
 test    -      disabled  down      42/3      14 (Get "http://localhost:8080/": dial t... run "pebble tasks 14" for more)
-slow    -      enabled   unknown   0/3       15
 extra   -      disabled  inactive  -         -
 ```
-
-The "Status" value will be one of the following:
-
-- `unknown`: check has not yet been run at all
-- `up`: check has been run and is healthy
-- `down`: check has failed "threshold" or more times in a row (considered unhealthy by `/v1/health`)
-- `inactive`: check has been stopped
 
 The "Failures" column shows the current number of failures since the check started failing, a slash, and the configured threshold.
 
@@ -221,7 +213,7 @@ Including a check that is already running in a `start-checks` command, or includ
 
 If the `--http` option was given when starting `pebble run`, Pebble exposes a `/v1/health` HTTP endpoint that allows a user to query the health of configured checks, optionally filtered by check level with the query string `?level=<level>` This endpoint returns an HTTP 200 status if the checks are healthy, HTTP 502 otherwise.
 
-Stopped (inactive) checks are ignored for health calculations. Checks that haven't yet been run (unknown) are considered healthy.
+Stopped (inactive) checks are ignored for health calculations.
 
 Each check can specify a `level` of "alive" or "ready". These have semantic meaning: "alive" means the check or the service it's connected to is up and running; "ready" means it's properly accepting network traffic. These correspond to [Kubernetes "liveness" and "readiness" probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
 

--- a/internals/daemon/api_checks_test.go
+++ b/internals/daemon/api_checks_test.go
@@ -60,9 +60,9 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-			map[string]any{"name": "chk2", "startup": "enabled", "status": "unknown", "level": "alive", "threshold": 3.0, "change-id": "C1"},
-			map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C2"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C1"},
+			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -79,8 +79,8 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C1"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with names filter (comma-separated values)
@@ -88,8 +88,8 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C1"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with level filter
@@ -97,7 +97,7 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk2", "startup": "enabled", "status": "unknown", "level": "alive", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C0"},
 	})
 
 	// Request with names and level filters
@@ -105,7 +105,7 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 	})
 }
 
@@ -192,9 +192,9 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 			map[string]any{"name": "chk2", "startup": "disabled", "status": "inactive", "level": "alive", "threshold": 3.0, "change-id": ""},
-			map[string]any{"name": "chk3", "startup": "enabled", "status": "unknown", "threshold": 3.0, "change-id": "C2"},
+			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -247,7 +247,7 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "unknown", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break

--- a/internals/overlord/checkstate/handlers.go
+++ b/internals/overlord/checkstate/handlers.go
@@ -64,7 +64,7 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 				// Update number of failures in check info. In threshold
 				// case, check data will be updated with new change ID by
 				// changeStatusChanged.
-				m.updateCheckData(config, changeID, CheckStatusUp, details.Failures)
+				m.updateCheckData(config, changeID, details.Failures)
 			}
 
 			m.state.Lock()
@@ -91,8 +91,9 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		}
 
 		m.incSuccessCount(config)
-		m.updateCheckData(config, changeID, CheckStatusUp, 0)
 		if details.Failures > 0 {
+			m.updateCheckData(config, changeID, 0)
+
 			m.state.Lock()
 			task.Logf("succeeded after %s", pluralise(details.Failures, "failure", "failures"))
 			details.Failures = 0
@@ -167,7 +168,7 @@ func (m *CheckManager) doRecoverCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		if err != nil {
 			m.incFailureCount(config)
 			details.Failures++
-			m.updateCheckData(config, changeID, CheckStatusDown, details.Failures)
+			m.updateCheckData(config, changeID, details.Failures)
 
 			m.state.Lock()
 			task.Set(checkDetailsAttr, &details)

--- a/internals/overlord/checkstate/manager.go
+++ b/internals/overlord/checkstate/manager.go
@@ -169,7 +169,7 @@ func (m *CheckManager) PlanChanged(newPlan *plan.Plan) {
 			} else {
 				// Check is new and should be inactive - no need to start it,
 				// but we need to add it to the list of existing checks.
-				m.updateCheckData(config, "", CheckStatusInactive, 0)
+				m.updateCheckData(config, "", 0)
 			}
 		}
 	}
@@ -179,7 +179,7 @@ func (m *CheckManager) PlanChanged(newPlan *plan.Plan) {
 		if newOrModified[config.Name] {
 			merged := mergeServiceContext(newPlan, config)
 			changeID := performCheckChange(m.state, merged)
-			m.updateCheckData(config, changeID, CheckStatusUnknown, 0)
+			m.updateCheckData(config, changeID, 0)
 			shouldEnsure = true
 		}
 	}
@@ -198,7 +198,7 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 		}
 		config := m.state.Cached(performConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
 		changeID := recoverCheckChange(m.state, config, details.Failures)
-		m.updateCheckData(config, changeID, CheckStatusDown, details.Failures)
+		m.updateCheckData(config, changeID, details.Failures)
 		shouldEnsure = true
 
 	case change.Kind() == recoverCheckKind && new == state.DoneStatus:
@@ -208,7 +208,7 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 		}
 		config := m.state.Cached(recoverConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
 		changeID := performCheckChange(m.state, config)
-		m.updateCheckData(config, changeID, CheckStatusUp, 0)
+		m.updateCheckData(config, changeID, 0)
 		shouldEnsure = true
 	}
 
@@ -347,17 +347,22 @@ func (m *CheckManager) ensureCheck(name string) *checkData {
 		check = &checkData{
 			name:    name,
 			refresh: make(chan refreshInfo),
-			status:  CheckStatusUnknown,
 		}
 		m.checks[name] = check
 	}
 	return check
 }
 
-func (m *CheckManager) updateCheckData(config *plan.Check, changeID string, status CheckStatus, failures int) {
+func (m *CheckManager) updateCheckData(config *plan.Check, changeID string, failures int) {
 	m.checksLock.Lock()
 	defer m.checksLock.Unlock()
 
+	status := CheckStatusUp
+	if changeID == "" {
+		status = CheckStatusInactive
+	} else if failures >= config.Threshold {
+		status = CheckStatusDown
+	}
 	startup := config.Startup
 	if startup == plan.CheckStartupUnknown {
 		startup = plan.CheckStartupEnabled
@@ -428,7 +433,6 @@ type checkData struct {
 type CheckStatus string
 
 const (
-	CheckStatusUnknown  CheckStatus = "unknown"
 	CheckStatusUp       CheckStatus = "up"
 	CheckStatusDown     CheckStatus = "down"
 	CheckStatusInactive CheckStatus = "inactive"
@@ -441,9 +445,9 @@ type checker interface {
 func (c *checkData) writeMetric(writer metrics.Writer) error {
 	// Don't list any inactive checks because they don't have an up or down status.
 	if c.status != CheckStatusInactive {
-		checkUp := 1
-		if c.status == CheckStatusDown {
-			checkUp = 0
+		checkUp := 0
+		if c.status == CheckStatusUp {
+			checkUp = 1
 		}
 		err := writer.Write(metrics.Metric{
 			Name:       "pebble_check_up",
@@ -551,7 +555,7 @@ func (m *CheckManager) StartChecks(checks []string) (started []string, err error
 			continue
 		}
 		changeID := performCheckChange(m.state, check)
-		m.updateCheckData(check, changeID, CheckStatusUnknown, 0)
+		m.updateCheckData(check, changeID, 0)
 		started = append(started, check.Name)
 	}
 
@@ -602,7 +606,7 @@ func (m *CheckManager) StopChecks(checks []string) (stopped []string, err error)
 		// same, so that people can inspect what the state of the check was when
 		// it was stopped. The status of the check will be "inactive", but the
 		// failure count combined with the threshold will give the full picture.
-		m.updateCheckData(check, "", CheckStatusInactive, checkData.failures)
+		m.updateCheckData(check, "", checkData.failures)
 	}
 
 	return stopped, nil
@@ -611,7 +615,6 @@ func (m *CheckManager) StopChecks(checks []string) (stopped []string, err error)
 // Replan handles starting "startup: enabled" checks when a replan occurs.
 // Checks that are "startup: disabled" but are already running do not get
 // stopped in a replan.
-//
 // The state lock must be held when calling this method.
 func (m *CheckManager) Replan() {
 	currentPlan := m.planMgr.Plan()
@@ -635,7 +638,7 @@ func (m *CheckManager) Replan() {
 			continue
 		}
 		changeID := performCheckChange(m.state, check)
-		m.updateCheckData(check, changeID, CheckStatusUnknown, 0)
+		m.updateCheckData(check, changeID, 0)
 	}
 }
 

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -116,11 +116,11 @@ func (s *ManagerSuite) TestChecks(c *C) {
 		},
 	})
 
-	// Wait for expected checks to be present.
+	// Wait for expected checks to be started.
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "unknown", Level: "alive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Level: "ready", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "up", Level: "alive", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Level: "ready", Threshold: 3},
 	})
 
 	// Re-configuring should update checks.
@@ -138,7 +138,7 @@ func (s *ManagerSuite) TestChecks(c *C) {
 
 	// Wait for checks to be updated.
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk4", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk4", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 }
 
@@ -366,9 +366,9 @@ func (s *ManagerSuite) TestPlanChangedSmarts(c *C) {
 	})
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -399,8 +399,8 @@ func (s *ManagerSuite) TestPlanChangedSmarts(c *C) {
 	})
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 6},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 6},
 	})
 	checks, err = s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -455,8 +455,8 @@ func (s *ManagerSuite) TestPlanChangedServiceContext(c *C) {
 	}
 	s.manager.PlanChanged(origPlan)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -484,8 +484,8 @@ func (s *ManagerSuite) TestPlanChangedServiceContext(c *C) {
 	})
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk2", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk2", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err = s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -647,9 +647,9 @@ func (s *ManagerSuite) TestStartChecks(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -660,9 +660,9 @@ func (s *ManagerSuite) TestStartChecks(c *C) {
 
 	changed, err := s.manager.StartChecks([]string{"chk1", "chk2"})
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
-		{Name: "chk2", Startup: "disabled", Status: "unknown", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
+		{Name: "chk2", Startup: "disabled", Status: "up", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	c.Assert(err, IsNil)
 	c.Assert(changed, DeepEquals, []string{"chk2"})
@@ -697,7 +697,7 @@ func (s *ManagerSuite) TestStartChecksNotFound(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 
 	changed, err := s.manager.StartChecks([]string{"chk1", "chk2"})
@@ -743,9 +743,9 @@ func (s *ManagerSuite) TestStopChecks(c *C) {
 	st.EnsureBefore(0)
 
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 
 	checks, err := s.manager.Checks()
@@ -787,7 +787,7 @@ func (s *ManagerSuite) TestStopChecks(c *C) {
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
 		{Name: "chk1", Startup: "enabled", Status: "inactive", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 
 	// chk3 should still have the same change ID, chk1 and chk2 should not have one.
@@ -828,7 +828,7 @@ func (s *ManagerSuite) TestStopChecksNotFound(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 
 	changed, err := s.manager.StopChecks([]string{"chk1", "chk2"})
@@ -869,15 +869,15 @@ func (s *ManagerSuite) TestReplan(c *C) {
 	err := s.planMgr.AppendLayer(origLayer, false)
 	c.Assert(err, IsNil)
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	s.manager.StopChecks([]string{"chk1"})
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
 		{Name: "chk1", Startup: "enabled", Status: "inactive", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	var originalChangeIDs []string
@@ -889,9 +889,9 @@ func (s *ManagerSuite) TestReplan(c *C) {
 	s.manager.Replan()
 	s.overlord.State().Unlock()
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 		{Name: "chk2", Startup: "disabled", Status: "inactive", Threshold: 3},
-		{Name: "chk3", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk3", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	c.Assert(err, IsNil)
 	checks, err = s.manager.Checks()
@@ -1059,7 +1059,7 @@ func (s *ManagerSuite) TestRefreshCheck(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -1100,7 +1100,7 @@ func (s *ManagerSuite) TestRefreshCheckFailure(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	checks, err := s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -1136,7 +1136,7 @@ func (s *ManagerSuite) TestRefreshStoppedCheck(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	_, err = s.manager.Checks()
 	c.Assert(err, IsNil)
@@ -1183,7 +1183,7 @@ func (s *ManagerSuite) TestRefreshStoppedCheckFailure(c *C) {
 	c.Assert(err, IsNil)
 	s.manager.PlanChanged(s.planMgr.Plan())
 	waitChecks(c, s.manager, []*checkstate.CheckInfo{
-		{Name: "chk1", Startup: "enabled", Status: "unknown", Threshold: 3},
+		{Name: "chk1", Startup: "enabled", Status: "up", Threshold: 3},
 	})
 	_, err = s.manager.Checks()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This reverts PR #620 (commit d7127c9748f2cb56756242f186b3ab5589925bba) as it was too invasive. I had incorrectly assumed that charms weren't using the check status at this level, and it'd be okay to change. However, many charms use `get_checks()` and `CheckStatus.UP` or `.DOWN`, for example:

  + ranger-k8s-operator does get_check().status != CheckStatus.UP in update-status hook, sets MaintenanceStatus if so
  + temporal-ui-k8s-operator (similar)
  + trino-k8s-operator (similar)
  + sunbeam-charms (similar, but set BlockedStatus)
  + katib-operators (similar)
  + superset-k8s-operator (similar)
  + notebook-operators (similar)

The fact that they're comparing `!=UP` means these charms will now report a blocked or maintenance status in that initial "unknown" period before the check is run. And other charms could be doing something more invasive, like restarting a workload based on a health check status `!=UP`.

So we'd like to revert this approach, and then step back and consider how to add this in a backwards-compatible way (or whether the feature is needed by charmers at all).