### PR TITLE
feat: add "successes" field to checks API and CLI output

### DIFF
--- a/client/checks.go
+++ b/client/checks.go
@@ -90,8 +90,8 @@ type CheckInfo struct {
 
 	// Successes is the number of times this check has succeeded. It is reset
 	// when the check succeeds again after the check's failure threshold was
-	// reached. This will be zero if the check has never run, or has never run
-	// successfully.
+	// reached, or if the check is stopped and started again. This will be
+	// zero if the check has never run, or has never run successfully.
 	//
 	// This field will be nil if running against a version of the daemon
 	// before this field was added to the API.

--- a/client/checks.go
+++ b/client/checks.go
@@ -88,6 +88,15 @@ type CheckInfo struct {
 	// the check is inactive.
 	Status CheckStatus `json:"status"`
 
+	// Successes is the number of times this check has succeeded. It is reset
+	// when the check succeeds again after the check's failure threshold was
+	// reached. This will be zero if the check has never run, or has never run
+	// successfully.
+	//
+	// This field will be nil if running against a version of the daemon
+	// before this field was added to the API.
+	Successes *int `json:"successes"`
+
 	// Failures is the number of times in a row this check has failed. It is
 	// reset to zero as soon as the check succeeds.
 	Failures int `json:"failures"`

--- a/docs/how-to/check-health-based-on-logs.md
+++ b/docs/how-to/check-health-based-on-logs.md
@@ -52,12 +52,14 @@ To display detailed status information about the check:
 name: foo-warning
 startup: enabled
 status: down
+successes: 0
 failures: 3
 threshold: 1
 change-id: "60"
 logs: |
     2025-04-26T11:22:27+08:00 ERROR exit status 1
     2025-04-26T11:22:37+08:00 ERROR exit status 1
+    2025-04-26T11:22:47+08:00 ERROR exit status 1
 ```
 
 ## See more

--- a/docs/reference/health-checks.md
+++ b/docs/reference/health-checks.md
@@ -127,9 +127,9 @@ You can view check status using the `pebble checks` command. This reports the ch
    :input: pebble checks
 Check   Level  Startup   Status    Successes  Failures  Change
 up      alive  enabled   up        5          0/1       10
-online  ready  enabled   down      2          1/3       13 (dial tcp 127.0.0.1:8000: connect: connection refused)
+online  ready  enabled   up        2          1/3       13 (dial tcp 127.0.0.1:8000: connect: connection refused)
 test    -      disabled  down      0          42/3      14 (Get "http://localhost:8080/": dial t... run "pebble tasks 14" for more)
-extra   -      disabled  inactive  0          -         -
+extra   -      disabled  inactive  -          -         -
 ```
 
 The "Successes" column shows the number of times the check has succeeded. It is reset when the check succeeds again after the check's failure threshold was reached. This will be zero if the check has never run, or has never run successfully.

--- a/docs/reference/health-checks.md
+++ b/docs/reference/health-checks.md
@@ -154,6 +154,7 @@ You can run a check immediately using the `pebble check <name> --refresh` comman
 name: chk1
 startup: enabled
 status: up
+successes: 1
 failures: 0
 threshold: 3
 change-id: "1"
@@ -166,6 +167,7 @@ If running the check fails, the result will also show the error and logs:
 name: chk1
 startup: enabled
 status: up
+successes: 0
 failures: 1
 threshold: 3
 change-id: "1"
@@ -174,13 +176,14 @@ logs: |
     2025-03-13T10:05:45+08:00 ERROR non-2xx status code 500; Health check failed
 ```
 
-You can run a check even if it's inactive (for example, if the check has `startup: disabled` or was stopped by [`pebble stop-checks`](#reference_health_checks_start_stop_command)). This will run the check immediately but won't start the check. If running a stopped check fails, Pebble won't change the status or the failure count, and the result won't include logs:
+You can run a check even if it's inactive (for example, if the check has `startup: disabled` or was stopped by [`pebble stop-checks`](#reference_health_checks_start_stop_command)). This will run the check immediately but won't start the check. If running a stopped check fails, Pebble won't change the status or the success or failure count, and the result won't include logs:
 
 ```{terminal}
    :input: pebble check chk1 --refresh
 name: chk1
 startup: disabled
 status: inactive
+successes: 0
 failures: 0
 threshold: 3
 error: non-2xx status code 500; Health check failed
@@ -193,6 +196,7 @@ Without the `--refresh` flag, `pebble check <name>` gets the details of a check 
 name: chk1
 startup: enabled
 status: up
+successes: 0
 failures: 1
 threshold: 3
 change-id: "1"

--- a/docs/reference/health-checks.md
+++ b/docs/reference/health-checks.md
@@ -125,12 +125,14 @@ You can view check status using the `pebble checks` command. This reports the ch
 
 ```{terminal}
    :input: pebble checks
-Check   Level  Startup   Status    Failures  Change
-up      alive  enabled   up        0/1       10
-online  ready  enabled   down      1/3       13 (dial tcp 127.0.0.1:8000: connect: connection refused)
-test    -      disabled  down      42/3      14 (Get "http://localhost:8080/": dial t... run "pebble tasks 14" for more)
-extra   -      disabled  inactive  -         -
+Check   Level  Startup   Status    Successes  Failures  Change
+up      alive  enabled   up        5          0/1       10
+online  ready  enabled   down      2          1/3       13 (dial tcp 127.0.0.1:8000: connect: connection refused)
+test    -      disabled  down      0          42/3      14 (Get "http://localhost:8080/": dial t... run "pebble tasks 14" for more)
+extra   -      disabled  inactive  0          -         -
 ```
+
+The "Successes" column shows the number of times the check has succeeded. It is reset when the check succeeds again after the check's failure threshold was reached. This will be zero if the check has never run, or has never run successfully.
 
 The "Failures" column shows the current number of failures since the check started failing, a slash, and the configured threshold.
 

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -385,6 +385,7 @@ paths:
                       "name": "check1",
                       "startup": "enabled",
                       "status": "up",
+                      "successes": 2,
                       "failures": 1,
                       "threshold": 3,
                       "change-id": "1"
@@ -1702,7 +1703,10 @@ components:
         status:
           type: string
           description: Status of the check.
-          enum: [down, up]
+          enum: [inactive, down, up]
+        successes:
+          type: integer
+          description: Number of successes since check started or status transitioned from "down" to "up".
         failures:
           type: integer
           description: Number of consecutive failures.

--- a/internals/cli/cmd_check.go
+++ b/internals/cli/cmd_check.go
@@ -44,6 +44,7 @@ type checkInfo struct {
 	Level     string `yaml:"level,omitempty"`
 	Startup   string `yaml:"startup"`
 	Status    string `yaml:"status"`
+	Successes *int   `yaml:"successes,omitempty"`
 	Failures  int    `yaml:"failures"`
 	Threshold int    `yaml:"threshold"`
 	ChangeID  string `yaml:"change-id,omitempty"`
@@ -71,6 +72,7 @@ func checkInfoFromClient(check client.CheckInfo) checkInfo {
 		Level:     string(check.Level),
 		Startup:   string(check.Startup),
 		Status:    string(check.Status),
+		Successes: check.Successes,
 		Failures:  check.Failures,
 		Threshold: check.Threshold,
 		ChangeID:  check.ChangeID,

--- a/internals/cli/cmd_check_test.go
+++ b/internals/cli/cmd_check_test.go
@@ -33,7 +33,7 @@ func (s *PebbleSuite) TestCheck(c *C) {
 {
     "type": "sync",
     "status-code": 200,
-    "result": [{"name": "chk1", "startup": "enabled", "status": "up", "threshold": 3, "change-id": "1"}]
+    "result": [{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"}]
 }`)
 	})
 	rest, err := cli.ParserForTest().ParseArgs([]string{"check", "chk1"})
@@ -43,6 +43,7 @@ func (s *PebbleSuite) TestCheck(c *C) {
 name: chk1
 startup: enabled
 status: up
+successes: 5
 failures: 0
 threshold: 3
 change-id: "1"

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -92,7 +92,10 @@ func (cmd *cmdChecks) Execute(args []string) error {
 		}
 		successes := "?"
 		if check.Successes != nil {
-			successes = strconv.Itoa(*check.Successes)
+			successes = "-"
+			if check.Status != client.CheckStatusInactive {
+				successes = strconv.Itoa(*check.Successes)
+			}
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			check.Name, level, check.Startup, check.Status, successes, failures,

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/canonical/go-flags"
@@ -78,7 +79,7 @@ func (cmd *cmdChecks) Execute(args []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
-	fmt.Fprintln(w, "Check\tLevel\tStartup\tStatus\tFailures\tChange")
+	fmt.Fprintln(w, "Check\tLevel\tStartup\tStatus\tSuccesses\tFailures\tChange")
 
 	for _, check := range checks {
 		level := check.Level
@@ -89,8 +90,12 @@ func (cmd *cmdChecks) Execute(args []string) error {
 		if check.Status != client.CheckStatusInactive {
 			failures = fmt.Sprintf("%d/%d", check.Failures, check.Threshold)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			check.Name, level, check.Startup, check.Status, failures,
+		successes := "?"
+		if check.Successes != nil {
+			successes = strconv.Itoa(*check.Successes)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			check.Name, level, check.Startup, check.Status, successes, failures,
 			cmd.changeInfo(check))
 	}
 	return nil

--- a/internals/cli/cmd_checks_test.go
+++ b/internals/cli/cmd_checks_test.go
@@ -38,7 +38,7 @@ func (s *PebbleSuite) TestChecks(c *check.C) {
 		{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"},
 		{"name": "chk2", "startup": "enabled", "status": "down", "successes": 6, "failures": 1, "threshold": 1, "change-id": "2"},
 		{"name": "chk3", "startup": "enabled", "level": "alive", "status": "down", "successes": 7, "failures": 42, "threshold": 3, "change-id": "3"},
-		{"name": "chk4", "startup": "enabled", "status": "down", "successes": 8, "failures": 6, "threshold": 2, "change-id": "4"},
+		{"name": "chk4", "startup": "enabled", "status": "down", "successes": 0, "failures": 6, "threshold": 2, "change-id": "4"},
 		{"name": "chk5", "startup": "enabled", "status": "down", "failures": 3, "threshold": 2, "change-id": "5"},
 		{"name": "chk6", "startup": "disabled", "status": "inactive", "successes": 9, "failures": 0, "threshold": 3, "change-id": ""}
 	]
@@ -94,9 +94,9 @@ Check  Level  Startup   Status    Successes  Failures  Change
 chk1   -      enabled   up        5          0/3       1
 chk2   -      enabled   down      6          1/1       2 (second)
 chk3   alive  enabled   down      7          42/3      3 (cannot get change 3)
-chk4   -      enabled   down      8          6/2       4 (Get "http://localhost:8000/": dial tc... run "pebble tasks 4" for more)
+chk4   -      enabled   down      0          6/2       4 (Get "http://localhost:8000/": dial tc... run "pebble tasks 4" for more)
 chk5   -      enabled   down      ?          3/2       5 (error with some\nline breaks\nin it\n)
-chk6   -      disabled  inactive  9          -         -
+chk6   -      disabled  inactive  -          -         -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/internals/cli/cmd_checks_test.go
+++ b/internals/cli/cmd_checks_test.go
@@ -35,12 +35,12 @@ func (s *PebbleSuite) TestChecks(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "chk1", "startup": "enabled", "status": "up", "threshold": 3, "change-id": "1"},
-		{"name": "chk2", "startup": "enabled", "status": "down", "failures": 1, "threshold": 1, "change-id": "2"},
-		{"name": "chk3", "startup": "enabled", "level": "alive", "status": "down", "failures": 42, "threshold": 3, "change-id": "3"},
-		{"name": "chk4", "startup": "enabled", "status": "down", "failures": 6, "threshold": 2, "change-id": "4"},
+		{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"},
+		{"name": "chk2", "startup": "enabled", "status": "down", "successes": 6, "failures": 1, "threshold": 1, "change-id": "2"},
+		{"name": "chk3", "startup": "enabled", "level": "alive", "status": "down", "successes": 7, "failures": 42, "threshold": 3, "change-id": "3"},
+		{"name": "chk4", "startup": "enabled", "status": "down", "successes": 8, "failures": 6, "threshold": 2, "change-id": "4"},
 		{"name": "chk5", "startup": "enabled", "status": "down", "failures": 3, "threshold": 2, "change-id": "5"},
-		{"name": "chk6", "startup": "disabled", "status": "inactive", "failures": 0, "threshold": 3, "change-id": ""}
+		{"name": "chk6", "startup": "disabled", "status": "inactive", "successes": 9, "failures": 0, "threshold": 3, "change-id": ""}
 	]
 }`)
 		case "/v1/changes/2":
@@ -90,13 +90,13 @@ func (s *PebbleSuite) TestChecks(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Check  Level  Startup   Status    Failures  Change
-chk1   -      enabled   up        0/3       1
-chk2   -      enabled   down      1/1       2 (second)
-chk3   alive  enabled   down      42/3      3 (cannot get change 3)
-chk4   -      enabled   down      6/2       4 (Get "http://localhost:8000/": dial tc... run "pebble tasks 4" for more)
-chk5   -      enabled   down      3/2       5 (error with some\nline breaks\nin it\n)
-chk6   -      disabled  inactive  -         -
+Check  Level  Startup   Status    Successes  Failures  Change
+chk1   -      enabled   up        5          0/3       1
+chk2   -      enabled   down      6          1/1       2 (second)
+chk3   alive  enabled   down      7          42/3      3 (cannot get change 3)
+chk4   -      enabled   down      8          6/2       4 (Get "http://localhost:8000/": dial tc... run "pebble tasks 4" for more)
+chk5   -      enabled   down      ?          3/2       5 (error with some\nline breaks\nin it\n)
+chk6   -      disabled  inactive  9          -         -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -146,8 +146,8 @@ func (s *PebbleSuite) TestChecksFiltering(c *check.C) {
     "type": "sync",
     "status-code": 200,
     "result": [
-		{"name": "chk1", "startup": "enabled", "status": "up", "threshold": 3},
-		{"name": "chk3", "startup": "enabled", "level": "alive", "status": "down", "failures": 42, "threshold": 3}
+		{"name": "chk1", "startup": "enabled", "status": "up", "successes": 15, "threshold": 3},
+		{"name": "chk3", "startup": "enabled", "level": "alive", "status": "down", "successes": 16, "failures": 42, "threshold": 3}
 	]
 }`)
 	})
@@ -155,9 +155,9 @@ func (s *PebbleSuite) TestChecksFiltering(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-Check  Level  Startup  Status  Failures  Change
-chk1   -      enabled  up      0/3       -
-chk3   alive  enabled  down    42/3      -
+Check  Level  Startup  Status  Successes  Failures  Change
+chk1   -      enabled  up      15         0/3       -
+chk3   alive  enabled  down    16         42/3      -
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -30,6 +30,7 @@ type checkInfo struct {
 	Level     string `json:"level,omitempty"`
 	Startup   string `json:"startup"`
 	Status    string `json:"status"`
+	Successes int    `json:"successes"`
 	Failures  int    `json:"failures,omitempty"`
 	Threshold int    `json:"threshold"`
 	ChangeID  string `json:"change-id,omitempty"`
@@ -151,6 +152,7 @@ func checkInfoFromInternal(check *checkstate.CheckInfo) checkInfo {
 		Level:     string(check.Level),
 		Startup:   string(check.Startup),
 		Status:    string(check.Status),
+		Successes: check.Successes,
 		Failures:  check.Failures,
 		Threshold: check.Threshold,
 		ChangeID:  check.ChangeID,

--- a/internals/daemon/api_checks_test.go
+++ b/internals/daemon/api_checks_test.go
@@ -60,9 +60,9 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-			map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C1"},
-			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C2"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "successes": 0.0, "threshold": 3.0, "change-id": "C1"},
+			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "successes": 0.0, "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -79,8 +79,8 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C1"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "successes": 0.0, "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with names filter (comma-separated values)
@@ -88,8 +88,8 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C1"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "successes": 0.0, "threshold": 3.0, "change-id": "C1"},
 	})
 
 	// Request with level filter
@@ -97,7 +97,7 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk2", "startup": "enabled", "status": "up", "level": "alive", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
 	})
 
 	// Request with names and level filters
@@ -105,7 +105,7 @@ checks:
 	c.Check(rsp.Status, Equals, 200)
 	c.Check(rsp.Type, Equals, ResponseTypeSync)
 	c.Check(body["result"], DeepEquals, []any{
-		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+		map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
 	})
 }
 
@@ -192,9 +192,9 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
-			map[string]any{"name": "chk2", "startup": "disabled", "status": "inactive", "level": "alive", "threshold": 3.0, "change-id": ""},
-			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "threshold": 3.0, "change-id": "C2"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk2", "startup": "disabled", "status": "inactive", "level": "alive", "successes": 0.0, "threshold": 3.0, "change-id": ""},
+			map[string]any{"name": "chk3", "startup": "enabled", "status": "up", "successes": 0.0, "threshold": 3.0, "change-id": "C2"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -247,7 +247,7 @@ checks:
 		c.Check(rsp.Status, Equals, 200)
 		c.Check(rsp.Type, Equals, ResponseTypeSync)
 		expected := []any{
-			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "threshold": 3.0, "change-id": "C0"},
+			map[string]any{"name": "chk1", "startup": "enabled", "status": "up", "level": "ready", "successes": 0.0, "threshold": 3.0, "change-id": "C0"},
 		}
 		if reflect.DeepEqual(body["result"], expected) {
 			break
@@ -286,6 +286,7 @@ checks:
 		Level:     "ready",
 		Startup:   "enabled",
 		Status:    "up",
+		Successes: 1,
 		Failures:  0,
 		Threshold: 3,
 		ChangeID:  "C0",

--- a/internals/overlord/checkstate/manager.go
+++ b/internals/overlord/checkstate/manager.go
@@ -169,7 +169,7 @@ func (m *CheckManager) PlanChanged(newPlan *plan.Plan) {
 			} else {
 				// Check is new and should be inactive - no need to start it,
 				// but we need to add it to the list of existing checks.
-				m.updateCheckData(config, "", 0)
+				m.updateCheckData(config, "", 0, 0)
 			}
 		}
 	}
@@ -179,7 +179,7 @@ func (m *CheckManager) PlanChanged(newPlan *plan.Plan) {
 		if newOrModified[config.Name] {
 			merged := mergeServiceContext(newPlan, config)
 			changeID := performCheckChange(m.state, merged)
-			m.updateCheckData(config, changeID, 0)
+			m.updateCheckData(config, changeID, 0, 0)
 			shouldEnsure = true
 		}
 	}
@@ -197,8 +197,8 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 			break
 		}
 		config := m.state.Cached(performConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
-		changeID := recoverCheckChange(m.state, config, details.Failures)
-		m.updateCheckData(config, changeID, details.Failures)
+		changeID := recoverCheckChange(m.state, config, details.Successes, details.Failures)
+		m.updateCheckData(config, changeID, details.Successes, details.Failures)
 		shouldEnsure = true
 
 	case change.Kind() == recoverCheckKind && new == state.DoneStatus:
@@ -208,7 +208,7 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 		}
 		config := m.state.Cached(recoverConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
 		changeID := performCheckChange(m.state, config)
-		m.updateCheckData(config, changeID, 0)
+		m.updateCheckData(config, changeID, 0, 0)
 		shouldEnsure = true
 	}
 
@@ -323,17 +323,8 @@ func (m *CheckManager) Checks() ([]*CheckInfo, error) {
 	defer m.checksLock.Unlock()
 
 	infos := make([]*CheckInfo, 0, len(m.checks))
-	for _, checkData := range m.checks {
-		info := CheckInfo{
-			Name:      checkData.name,
-			Level:     checkData.level,
-			Startup:   checkData.startup,
-			Status:    checkData.status,
-			Failures:  checkData.failures,
-			Threshold: checkData.threshold,
-			ChangeID:  checkData.changeID,
-		}
-		infos = append(infos, &info)
+	for _, data := range m.checks {
+		infos = append(infos, checkDataToInfo(data))
 	}
 	sort.Slice(infos, func(i, j int) bool {
 		return infos[i].Name < infos[j].Name
@@ -353,7 +344,7 @@ func (m *CheckManager) ensureCheck(name string) *checkData {
 	return check
 }
 
-func (m *CheckManager) updateCheckData(config *plan.Check, changeID string, failures int) {
+func (m *CheckManager) updateCheckData(config *plan.Check, changeID string, successes, failures int) {
 	m.checksLock.Lock()
 	defer m.checksLock.Unlock()
 
@@ -372,25 +363,26 @@ func (m *CheckManager) updateCheckData(config *plan.Check, changeID string, fail
 	check.level = config.Level
 	check.startup = startup
 	check.status = status
+	check.successes = successes
 	check.failures = failures
 	check.threshold = config.Threshold
 	check.changeID = changeID
 }
 
-func (m *CheckManager) incSuccessCount(config *plan.Check) {
+func (m *CheckManager) incSuccessMetric(config *plan.Check) {
 	m.checksLock.Lock()
 	defer m.checksLock.Unlock()
 
 	check := m.ensureCheck(config.Name)
-	check.successCount += 1
+	check.successMetric += 1
 }
 
-func (m *CheckManager) incFailureCount(config *plan.Check) {
+func (m *CheckManager) incFailureMetric(config *plan.Check) {
 	m.checksLock.Lock()
 	defer m.checksLock.Unlock()
 
 	check := m.ensureCheck(config.Name)
-	check.failureCount += 1
+	check.failureMetric += 1
 }
 
 func (m *CheckManager) deleteCheckData(name string) {
@@ -406,6 +398,7 @@ type CheckInfo struct {
 	Level     plan.CheckLevel
 	Startup   plan.CheckStartup
 	Status    CheckStatus
+	Successes int
 	Failures  int
 	Threshold int
 	ChangeID  string
@@ -418,16 +411,17 @@ type refreshInfo struct {
 
 // checkData holds the metrics and other data for a single check.
 type checkData struct {
-	name         string
-	level        plan.CheckLevel
-	startup      plan.CheckStartup
-	status       CheckStatus
-	failures     int
-	threshold    int
-	changeID     string
-	successCount int64
-	failureCount int64
-	refresh      chan refreshInfo
+	name          string
+	level         plan.CheckLevel
+	startup       plan.CheckStartup
+	status        CheckStatus
+	successes     int
+	failures      int
+	threshold     int
+	changeID      string
+	successMetric int64
+	failureMetric int64
+	refresh       chan refreshInfo
 }
 
 type CheckStatus string
@@ -464,7 +458,7 @@ func (c *checkData) writeMetric(writer metrics.Writer) error {
 	err := writer.Write(metrics.Metric{
 		Name:       "pebble_check_success_count",
 		Type:       metrics.TypeCounterInt,
-		ValueInt64: c.successCount,
+		ValueInt64: c.successMetric,
 		Comment:    "Number of times the check has succeeded",
 		Labels:     []metrics.Label{metrics.NewLabel("check", c.name)},
 	})
@@ -475,7 +469,7 @@ func (c *checkData) writeMetric(writer metrics.Writer) error {
 	err = writer.Write(metrics.Metric{
 		Name:       "pebble_check_failure_count",
 		Type:       metrics.TypeCounterInt,
-		ValueInt64: c.failureCount,
+		ValueInt64: c.failureMetric,
 		Comment:    "Number of times the check has failed",
 		Labels:     []metrics.Label{metrics.NewLabel("check", c.name)},
 	})
@@ -555,7 +549,7 @@ func (m *CheckManager) StartChecks(checks []string) (started []string, err error
 			continue
 		}
 		changeID := performCheckChange(m.state, check)
-		m.updateCheckData(check, changeID, 0)
+		m.updateCheckData(check, changeID, 0, 0)
 		started = append(started, check.Name)
 	}
 
@@ -602,11 +596,11 @@ func (m *CheckManager) StopChecks(checks []string) (stopped []string, err error)
 			change.Abort()
 			stopped = append(stopped, check.Name)
 		}
-		// We pass in the current number of failures so that it remains the
+		// We pass in the current number of successes and failures so that they remain the
 		// same, so that people can inspect what the state of the check was when
 		// it was stopped. The status of the check will be "inactive", but the
 		// failure count combined with the threshold will give the full picture.
-		m.updateCheckData(check, "", checkData.failures)
+		m.updateCheckData(check, "", checkData.successes, checkData.failures)
 	}
 
 	return stopped, nil
@@ -638,7 +632,7 @@ func (m *CheckManager) Replan() {
 			continue
 		}
 		changeID := performCheckChange(m.state, check)
-		m.updateCheckData(check, changeID, 0)
+		m.updateCheckData(check, changeID, 0, 0)
 	}
 }
 
@@ -653,17 +647,8 @@ func (m *CheckManager) RefreshCheck(ctx context.Context, check *plan.Check) (*Ch
 	getCheckInfo := func() *CheckInfo {
 		m.checksLock.Lock()
 		defer m.checksLock.Unlock()
-		checkData := m.ensureCheck(check.Name)
-		info := CheckInfo{
-			Name:      checkData.name,
-			Level:     checkData.level,
-			Startup:   checkData.startup,
-			Status:    checkData.status,
-			Failures:  checkData.failures,
-			Threshold: checkData.threshold,
-			ChangeID:  checkData.changeID,
-		}
-		return &info
+		data := m.ensureCheck(check.Name)
+		return checkDataToInfo(data)
 	}
 
 	// If the check is stopped, run the check directly without using changes and tasks.
@@ -693,5 +678,18 @@ func (m *CheckManager) RefreshCheck(ctx context.Context, check *plan.Check) (*Ch
 		return getCheckInfo(), nil
 	case <-ctx.Done():
 		return getCheckInfo(), ctx.Err()
+	}
+}
+
+func checkDataToInfo(data *checkData) *CheckInfo {
+	return &CheckInfo{
+		Name:      data.name,
+		Level:     data.level,
+		Startup:   data.startup,
+		Status:    data.status,
+		Successes: data.successes,
+		Failures:  data.failures,
+		Threshold: data.threshold,
+		ChangeID:  data.changeID,
 	}
 }

--- a/internals/overlord/checkstate/manager.go
+++ b/internals/overlord/checkstate/manager.go
@@ -208,7 +208,7 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 		}
 		config := m.state.Cached(recoverConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
 		changeID := performCheckChange(m.state, config)
-		m.updateCheckData(config, changeID, 0, 0)
+		m.updateCheckData(config, changeID, details.Successes, details.Failures)
 		shouldEnsure = true
 	}
 

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -1252,6 +1252,7 @@ func (s *ManagerSuite) TestChecksSuccesses(c *C) {
 	err = os.WriteFile(testPath, nil, 0o644)
 	c.Assert(err, IsNil)
 	waitCheck(c, s.manager, "chk1", func(chk *checkstate.CheckInfo) bool {
+		c.Assert(chk.Successes, Not(Equals), 0)
 		return chk.Successes >= 2 && chk.Successes < numSuccesses
 	})
 }

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -1073,6 +1073,7 @@ func (s *ManagerSuite) TestRefreshCheck(c *C) {
 		Level:     "",
 		Startup:   "enabled",
 		Status:    "up",
+		Successes: 1,
 		Failures:  0,
 		Threshold: 3,
 		ChangeID:  originalChangeID,

--- a/internals/overlord/checkstate/request.go
+++ b/internals/overlord/checkstate/request.go
@@ -22,8 +22,9 @@ import (
 )
 
 type checkDetails struct {
-	Name     string `json:"name"`
-	Failures int    `json:"failures"`
+	Name      string `json:"name"`
+	Failures  int    `json:"failures"`
+	Successes int    `json:"successes"`
 	// Whether to proceed to next check type when change is ready
 	Proceed bool `json:"proceed,omitempty"`
 }
@@ -52,10 +53,14 @@ type recoverConfigKey struct {
 	changeID string
 }
 
-func recoverCheckChange(st *state.State, config *plan.Check, failures int) (changeID string) {
+func recoverCheckChange(st *state.State, config *plan.Check, successes, failures int) (changeID string) {
 	summary := fmt.Sprintf("Recover %s check %q", checkType(config), config.Name)
 	task := st.NewTask(recoverCheckKind, summary)
-	task.Set(checkDetailsAttr, &checkDetails{Name: config.Name, Failures: failures})
+	task.Set(checkDetailsAttr, &checkDetails{
+		Name:      config.Name,
+		Successes: successes,
+		Failures:  failures,
+	})
 
 	change := st.NewChangeWithNoticeData(recoverCheckKind, task.Summary(), map[string]string{
 		"check-name": config.Name,

--- a/internals/overlord/servstate/handlers.go
+++ b/internals/overlord/servstate/handlers.go
@@ -588,6 +588,9 @@ func (s *serviceData) exited(exitCode int) error {
 			s.transition(stateStopped)
 		}
 
+	case stateStopped:
+		// This can happen when we send SIGKILL after the doStart tomb is killed, ignore.
+
 	default:
 		return fmt.Errorf("internal error: exited invalid in state %q", s.state)
 	}


### PR DESCRIPTION
This adds a "Successes" column to the output of `pebble checks` (and field to the `pebble check` YAML), as well as a "successes" field in the `/v1/checks` API response.

"Successes" is the number of times this check has succeeded. It is reset when the check succeeds again after the check's failure threshold was reached. It will be zero if the check has never run, or has never run successfully. If successes==0 and failures==0, the caller knows the check has not yet been run.

The client field `CheckInfo.Successes` is typed as a pointer (`*int`) as it's being added in a much later version of Pebble -- this means clients will be able to tell the difference between `*Successes==0` and `Successes==nil` (nil meaning the field is not present in the API response because they're querying on older version of Pebble). In the `pebble checks` CLI output the column will show `?` if running against an older Pebble daemon. I figure we can do something similar on the Python side (`successes: int | None`). This does make it a bit more awkward to use, and I'm open to push-back on this choice if you have a better idea.

Example `pebble checks` output:

```
$ pebble checks
Check   Level  Startup   Status    Successes  Failures  Change
up      alive  enabled   up        5          0/1       10
```

Note that this PR is an alternative to the new status "unknown" reverted in https://github.com/canonical/pebble/pull/628.