### PR TITLE
feat: add ability to get pebble plan using client

### DIFF
--- a/client/plan_test.go
+++ b/client/plan_test.go
@@ -92,3 +92,18 @@ services:
         command: cmd
 `[1:])
 }
+
+func (cs *clientSuite) TestPlan(c *check.C) {
+	cs.rsp = `{
+		"type": "sync",
+		"status-code": 200,
+		"result": "services:\n    foo:\n        override: replace\n        command: cmd\n"
+	}`
+	data, err := cs.cli.Plan()
+	c.Assert(err, check.IsNil)
+	c.Check(cs.req.Method, check.Equals, "GET")
+	c.Check(cs.req.URL.Path, check.Equals, "/v1/plan")
+	c.Check(cs.req.URL.Query(), check.DeepEquals, url.Values{"format": []string{"yaml"}})
+	c.Assert(data.Services["foo"].Override, check.Equals, "replace")
+	c.Assert(data.Services["foo"].Command, check.Equals, "cmd")
+}


### PR DESCRIPTION
# Description

When users want to retrieve the existing Pebble plan using the client, they needed to unmarshall the bytes that are returned by PlanBytes. This unmarshalling at the client usage level is unnecessary as the fields within the Pebble plan are always the same. Here we add the ability to fetch the Pebble plan struct through a new `Plan()` func, making it simpler for users to fetch the Pebble plans.

Fixes #635 

## New client usage

```go
package charm

import (
	"github.com/canonical/pebble/client"
)

func pebbleLayerCreated(pebbleClient *client.Client) bool {
	pebblePlan, err := pebbleClient.Plan()
	if err != nil {
		return false
	}

	service, exists := pebblePlan.Services["notary"]
	if !exists {
		return false
	}

	if service.Command != "notary --config "+ConfigPath {
		return false
	}

	return true
}
```