### PR TITLE
docs: update links to changes and tasks in service dependencies guide

### DIFF
--- a/docs/how-to/service-dependencies.md
+++ b/docs/how-to/service-dependencies.md
@@ -264,4 +264,3 @@ failed run.
 - [`pebble start`](#reference_pebble_start_command) command
 - [`pebble stop`](#reference_pebble_stop_command) command
 - [Layer specification](../reference/layer-specification.md)
-- [Changes and tasks](/reference/changes-and-tasks.md)

--- a/docs/how-to/service-dependencies.md
+++ b/docs/how-to/service-dependencies.md
@@ -255,7 +255,7 @@ database  enabled  inactive  -
 frontend  enabled  inactive  -
 ```
 
-You can use the [Changes and tasks] commands to get more details about the
+You can use the [`changes`](#reference_pebble_changes_command) and [`tasks`](#reference_pebble_tasks_command) commands to get more details about the
 failed run.
 
 ## See more


### PR DESCRIPTION
I noticed that the last sentence of [How to manage service dependencies](https://documentation.ubuntu.com/pebble/how-to/service-dependencies/) has this text:

```
You can use the [Changes and tasks] commands to get more details about the failed run.
```

This PR replaces "[Changes and tasks]" by links to the specific commands in the CLI reference.

At the bottom of the page, there's also a "see more" link to [Changes and tasks](https://documentation.ubuntu.com/pebble/reference/changes-and-tasks/), which essentially refers people to the CLI reference. With my change above, I don't think this "see more" link is needed any more, so I've removed it.

**[Preview doc build](https://canonical-ubuntu-documentation-library--641.com.readthedocs.build/pebble/how-to/service-dependencies/)**

---

Side note: I considered whether we even need to keep the [Changes and tasks](https://documentation.ubuntu.com/pebble/reference/changes-and-tasks/) page, since it's so short. But I actually like having it appear in the TOC, as changes and tasks are important concepts in Pebble. I think it helps with discoverability.