### PR TITLE
feat: add max start retries to service spec

### DIFF
--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -218,7 +218,7 @@ type Service struct {
 	OnSuccess       ServiceAction            `yaml:"on-success,omitempty"`
 	OnFailure       ServiceAction            `yaml:"on-failure,omitempty"`
 	OnCheckFailure  map[string]ServiceAction `yaml:"on-check-failure,omitempty"`
-	MaxStartRetries int64                    `yaml:"max-restarts,omitempty"`
+	MaxStartRetries int64                    `yaml:"max-start-retries,omitempty"`
 	BackoffDelay    OptionalDuration         `yaml:"backoff-delay,omitempty"`
 	BackoffFactor   OptionalFloat            `yaml:"backoff-factor,omitempty"`
 	BackoffLimit    OptionalDuration         `yaml:"backoff-limit,omitempty"`

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -215,13 +215,14 @@ type Service struct {
 	WorkingDir  string            `yaml:"working-dir,omitempty"`
 
 	// Auto-restart and backoff functionality
-	OnSuccess      ServiceAction            `yaml:"on-success,omitempty"`
-	OnFailure      ServiceAction            `yaml:"on-failure,omitempty"`
-	OnCheckFailure map[string]ServiceAction `yaml:"on-check-failure,omitempty"`
-	BackoffDelay   OptionalDuration         `yaml:"backoff-delay,omitempty"`
-	BackoffFactor  OptionalFloat            `yaml:"backoff-factor,omitempty"`
-	BackoffLimit   OptionalDuration         `yaml:"backoff-limit,omitempty"`
-	KillDelay      OptionalDuration         `yaml:"kill-delay,omitempty"`
+	OnSuccess       ServiceAction            `yaml:"on-success,omitempty"`
+	OnFailure       ServiceAction            `yaml:"on-failure,omitempty"`
+	OnCheckFailure  map[string]ServiceAction `yaml:"on-check-failure,omitempty"`
+	MaxStartRetries int64                    `yaml:"max-restarts,omitempty"`
+	BackoffDelay    OptionalDuration         `yaml:"backoff-delay,omitempty"`
+	BackoffFactor   OptionalFloat            `yaml:"backoff-factor,omitempty"`
+	BackoffLimit    OptionalDuration         `yaml:"backoff-limit,omitempty"`
+	KillDelay       OptionalDuration         `yaml:"kill-delay,omitempty"`
 }
 
 // Copy returns a deep copy of the service.
@@ -315,6 +316,9 @@ func (s *Service) Merge(other *Service) {
 	}
 	if other.BackoffLimit.IsSet {
 		s.BackoffLimit = other.BackoffLimit
+	}
+	if other.MaxStartRetries != 0 {
+		s.MaxStartRetries = other.MaxStartRetries
 	}
 }
 


### PR DESCRIPTION
Hi, I have been using pebble but sometimes would like to specify a maximum number of restart retries. Wondering if such a change would be considered -- opening this draft to just inquire on the possibility of adding this functionality.

# Description

Currently the behavior of pebble is to keep trying to restart a service while employing a back-off. I have a use case, and I think others may as well, where I'd like to let the service stop if it can't be started after a certain number of retries. At this point I may have some other action based on the service being inactive or a health-check failing. You can sort of mimic this by setting a really big backoff value, but that feels clunky as opposed to just being able to specify a limit when you want this behavior. This means adding `max-start-retries` to the service configuration. The expected behavior is that if the max retries is set to 3 then a failing service will be started the first time and then attempted to be started 3 additional times. This should not affect previous functionality as only a value greater than 0 for `max-start-retries` will enable this behavior, so previous service configurations should behave the same.

# New Usage in Service Configuration

```yaml
summary: Simple layer

description: |
    A simple layer.

services:
    http-server:
        override: replace
        summary: demo http server
        command: python3 -m http.server 8080
        startup: enabled
        max-start-retries: 3
```