### PR TITLE
ci: adjust TICS name

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           project: pebble
           installTics: true

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver
-          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           project: pebble
           installTics: true


### PR DESCRIPTION
As [announced in Mattermost](https://chat.canonical.com/canonical/pl/w76d5zmx4id7bxrwszsx5cxsme) and pointed out in [Jira](https://warthogs.atlassian.net/browse/TICSISSUES-96?focusedCommentId=823150&sourceType=mention), Go projects need to change the "name" passed to TICS from 'default' to 'GoProjects'.