### PR TITLE
feat: use libcrypt when built with cgo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,42 +13,53 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.22', '1.23', '1.24']
+        go:
+          - name: '1.23'
+            version: '1.23'
+            channel: '1.23/stable'
+            CGO_ENABLED: 1
+          - name: '1.23-fips'
+            version: '1.23'
+            channel: '1.23-fips/stable'
+            CGO_ENABLED: 1
+          - name: '1.24'
+            version: '1.24'
+            channel: '1.24/stable'
+            CGO_ENABLED: 1
+          - name: '1.24-static'
+            version: '1.24'
+            channel: '1.24/stable'
+            CGO_ENABLED: 0
 
-    name: Go ${{ matrix.go }}
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: ${{ matrix.go }}
-
-    - name: Test and build
-      run: |
-        go build ./cmd/pebble
-        go test -race ./... -check.vv
-
-  build-fips:
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.23-fips/stable']
-
-    name: Go ${{ matrix.go }}
+    name: Go ${{ matrix.go.name }}
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
       run: |
-        sudo snap install go --channel=${{ matrix.go }} --classic
+        sudo snap install go --channel=${{ matrix.go.channel }} --classic
+        export GOTOOLCHAIN=local
+        go mod edit -go=${{ matrix.go.version }}
 
-    - name: Test and build
+    - name: Build
       run: |
+        export GOTOOLCHAIN=local
+        export CGO_ENABLED=${{ matrix.go.CGO_ENABLED }}
         go build ./cmd/pebble
+    
+    - name: Test
+      if: ${{ matrix.go.CGO_ENABLED == 1 }}
+      run: |
+        export GOTOOLCHAIN=local
+        export CGO_ENABLED=1
         go test -race ./... -check.vv
+        
+    - name: Test
+      if: ${{ matrix.go.CGO_ENABLED == 0 }}
+      run: |
+        export GOTOOLCHAIN=local
+        export CGO_ENABLED=0
+        go test ./... -check.vv
 
   root-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         go: ['1.22']
+        cgo: ['0', '1']
 
     name: Go ${{ matrix.go }}
     steps:
@@ -26,8 +27,8 @@ jobs:
 
     - name: Test and build
       run: |
-        go test -race ./... -check.vv
-        go build ./cmd/pebble
+        CGO_ENABLED=${{ matrix.cgo }} go test -race ./... -check.vv
+        CGO_ENABLED=${{ matrix.cgo }} go build ./cmd/pebble
 
   root-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,6 @@ jobs:
       run: |
         sudo snap install go --channel=${{ matrix.go.channel }} --classic
         export GOTOOLCHAIN=local
-        go mod edit -go=${{ matrix.go.version }}
 
     - name: Build
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.22']
-        cgo: ['0', '1']
+        go: ['1.22', '1.23', '1.24']
 
     name: Go ${{ matrix.go }}
     steps:
@@ -27,8 +26,29 @@ jobs:
 
     - name: Test and build
       run: |
-        CGO_ENABLED=${{ matrix.cgo }} go test -race ./... -check.vv
-        CGO_ENABLED=${{ matrix.cgo }} go build ./cmd/pebble
+        go build ./cmd/pebble
+        go test -race ./... -check.vv
+
+  build-fips:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.23-fips/stable']
+
+    name: Go ${{ matrix.go }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      run: |
+        sudo snap install go --channel=${{ matrix.go }} --classic
+
+    - name: Test and build
+      run: |
+        go build ./cmd/pebble
+        go test -race ./... -check.vv
 
   root-tests:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/canonical/pebble
 
-go 1.24.4
+go 1.23.0
+
+toolchain go1.23.10
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/internals/cryptutil/crypt.go
+++ b/internals/cryptutil/crypt.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cryptutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Verify returns a nil error if the provided salted hashed key was derived from
+// the provided key.
+// This library only support crypt using sha512. When compiled with CGO, libcrypt
+// is used.
+func Verify(hashedKey string, key string) error {
+	if !strings.HasPrefix(hashedKey, "$6$") {
+		return fmt.Errorf("unsupported key type")
+	}
+	return crypt6_verify(hashedKey, key)
+}

--- a/internals/cryptutil/crypt_cgo.go
+++ b/internals/cryptutil/crypt_cgo.go
@@ -31,6 +31,7 @@ package cryptutil
 import "C"
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"runtime"
@@ -49,7 +50,7 @@ func crypt6_verify(hashedKey string, key string) error {
 	defer runtime.UnlockOSThread()
 	lastSep := strings.LastIndex(hashedKey, "$")
 	if lastSep < 0 {
-		return errors.New("illformed key hash")
+		return errors.New("ill-formed key hash")
 	}
 	salt := hashedKey[:lastSep]
 	csalt := C.CString(salt)
@@ -65,8 +66,8 @@ func crypt6_verify(hashedKey string, key string) error {
 	if err != nil {
 		return fmt.Errorf("unable to verify passwd: %w", err)
 	}
-	resultHashedKey := C.GoString(chashedkey)
-	if resultHashedKey == hashedKey {
+	resHashedKey := C.GoString(chashedkey)
+	if subtle.ConstantTimeCompare([]byte(resHashedKey), []byte(hashedKey)) == 1 {
 		return nil
 	}
 	return errors.New("unable to verify passwd")

--- a/internals/cryptutil/crypt_cgo.go
+++ b/internals/cryptutil/crypt_cgo.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build cgo && linux
+
+package cryptutil
+
+//#cgo pkg-config: libcrypt
+//#include <crypt.h>
+//#include <string.h>
+//#include <malloc.h>
+//struct crypt_data *alloc_cryptdata() {
+//  struct crypt_data *d = malloc(sizeof(struct crypt_data));
+//  if(d == 0) {
+//    return 0;
+//  }
+//  memset(d, 0, sizeof(struct crypt_data));
+//  return d;
+//}
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"unsafe"
+)
+
+var (
+	cryptNotCalled atomic.Bool
+)
+
+func crypt6_verify(hashedKey string, key string) error {
+	cryptNotCalled.Store(false)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	lastSep := strings.LastIndex(hashedKey, "$")
+	if lastSep < 0 {
+		return errors.New("illformed key hash")
+	}
+	salt := hashedKey[:lastSep]
+	csalt := C.CString(salt)
+	defer C.free(unsafe.Pointer(csalt))
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	ccrypt_data := C.alloc_cryptdata()
+	if ccrypt_data == nil {
+		panic("cannot alloc crypt_data")
+	}
+	defer C.free(unsafe.Pointer(ccrypt_data))
+	chashedkey, err := C.crypt_r(ckey, csalt, ccrypt_data)
+	if err != nil {
+		return fmt.Errorf("unable to verify passwd: %w", err)
+	}
+	resultHashedKey := C.GoString(chashedkey)
+	if resultHashedKey == hashedKey {
+		return nil
+	}
+	return errors.New("unable to verify passwd")
+}

--- a/internals/cryptutil/crypt_cgo_test.go
+++ b/internals/cryptutil/crypt_cgo_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build cgo && linux
+
+package cryptutil
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+func (s *cryptSuite) TestLibcryptVersionCalled(c *C) {
+	cryptNotCalled.Store(true)
+	err := Verify(
+		"$6$PyHGCImoZPK/0kyz$L8H4NZq1TfrbSHDDdeSIFYXNMqIZrEqcRty2jU2IXDk5pbzJKwUNPrk/SoVdgeRi9PBT4AqpX3QMQPbguhBNu1",
+		"a",
+	)
+	c.Assert(err, IsNil)
+	c.Assert(cryptNotCalled.Load(), Equals, false)
+}

--- a/internals/cryptutil/crypt_other.go
+++ b/internals/cryptutil/crypt_other.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !(cgo && linux)
+
+package cryptutil
+
+import "github.com/GehirnInc/crypt/sha512_crypt"
+
+func crypt6_verify(hashedKey string, key string) error {
+	crypt := sha512_crypt.New()
+	return crypt.Verify(hashedKey, []byte(key))
+}

--- a/internals/cryptutil/crypt_test.go
+++ b/internals/cryptutil/crypt_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cryptutil
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type cryptSuite struct{}
+
+var _ = Suite(&cryptSuite{})
+
+func (s *cryptSuite) TestVerifyPasswd6(c *C) {
+	err := Verify(
+		"$6$PyHGCImoZPK/0kyz$L8H4NZq1TfrbSHDDdeSIFYXNMqIZrEqcRty2jU2IXDk5pbzJKwUNPrk/SoVdgeRi9PBT4AqpX3QMQPbguhBNu1",
+		"a",
+	)
+	c.Assert(err, IsNil)
+}
+
+func (s *cryptSuite) TestVerifyPasswd6FailsWithBadKey(c *C) {
+	err := Verify(
+		"$6$PyHGCImoZPK/0kyz$L8H4NZq1TfrbSHDDdeSIFYXNMqIZrEqcRty2jU2IXDk5pbzJKwUNPrk/SoVdgeRi9PBT4AqpX3QMQPbguhBNu1",
+		"b",
+	)
+	c.Assert(err, NotNil)
+}
+
+func (s *cryptSuite) TestVerifyPasswd6WithRounds(c *C) {
+	err := Verify(
+		"$6$rounds=1000$PyHGCImoZPK/0kyz$nuqrhBzhXojF6/SjS6vBn1OThCl5U8dIhYA4EVtkzVDiFdrCjRTt7YM9bAm8tsQyN8ywWZPq1qYNJDcnF0MCZ/",
+		"a",
+	)
+	c.Assert(err, IsNil)
+}
+
+func (s *cryptSuite) TestVerifyPasswd6WithIllformedSalt(c *C) {
+	err := Verify(
+		"$6$rounds=1000$PyHGCImoZPK/0kyznuqrhBzhXojF6/SjS6vBn1OThCl5U8dIhYA4EVtkzVDiFdrCjRTt7YM9bAm8tsQyN8ywWZPq1qYNJDcnF0MCZ/",
+		"a",
+	)
+	c.Assert(err, NotNil)
+}
+
+func (s *cryptSuite) TestVerifyPasswd5Unsupported(c *C) {
+	err := Verify(
+		"$5$ClNNHz7FMy8Wzf7.$Ca85oYLoUPTM1jjKyQCnS1eq/DCY4IQ.WIRqqgwE9a4",
+		"a",
+	)
+	c.Assert(err, ErrorMatches, `unsupported key type`)
+}
+
+func (s *cryptSuite) TestVerifyPasswd1Unsupported(c *C) {
+	err := Verify(
+		"$1$MgYHak8b$HJxCvRizgEnBZDyaHFmh//",
+		"a",
+	)
+	c.Assert(err, ErrorMatches, `unsupported key type`)
+}
+
+func (s *cryptSuite) TestVerifyPasswdApr1Unsupported(c *C) {
+	err := Verify(
+		"$apr1$0z.oA5jA$6v/W4LrAb95IipZY.SueG0",
+		"a",
+	)
+	c.Assert(err, ErrorMatches, `unsupported key type`)
+}
+
+func (s *cryptSuite) TestVerifyPasswdAixMD5Unsupported(c *C) {
+	err := Verify(
+		"0AsejNrv$.XgG72eDqFhZzpp7K66uX1",
+		"a",
+	)
+	c.Assert(err, ErrorMatches, `unsupported key type`)
+}

--- a/internals/cryptutil/package_test.go
+++ b/internals/cryptutil/package_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package cryptutil
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up check.v1 into the "go test" runner
+func Test(t *testing.T) {
+	TestingT(t)
+}

--- a/internals/overlord/state/identities.go
+++ b/internals/overlord/state/identities.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/GehirnInc/crypt/sha512_crypt"
+	"github.com/canonical/pebble/internals/cryptutil"
 )
 
 // Identity holds the configuration of a single identity.
@@ -335,13 +335,11 @@ func (s *State) IdentityFromInputs(userID *uint32, username, password string) *I
 		// Prioritize username/password if either is provided, because they come from HTTP
 		// Authorization header, a per-request, client controlled property. If set
 		// by the client, it's intentional, so it should have a higher priority.
-		passwordBytes := []byte(password)
 		for _, identity := range s.identities {
 			if identity.Basic == nil || identity.Name != username {
 				continue
 			}
-			crypt := sha512_crypt.New()
-			err := crypt.Verify(identity.Basic.Password, passwordBytes)
+			err := cryptutil.Verify(identity.Basic.Password, password)
 			if err == nil {
 				return identity
 			}


### PR DESCRIPTION
This is an attempt to use the system provided libcrypt (or libxcrypt) to
verify passwords instead of a pure-go implementation. This enables a
FIPS aware libcrypt to ensure FIPS compliance.