### PR TITLE
fix: avoid second copy when combining layers

### DIFF
--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -740,12 +740,10 @@ func CombineLayers(layers ...*Layer) (*Layer, error) {
 			switch service.Override {
 			case MergeOverride:
 				if old, ok := combined.Services[name]; ok {
-					copied := old.Copy()
-					copied.Merge(service)
-					combined.Services[name] = copied
-					break
+					old.Merge(service)
+				} else {
+					combined.Services[name] = service.Copy()
 				}
-				fallthrough
 			case ReplaceOverride:
 				combined.Services[name] = service.Copy()
 			case UnknownOverride:

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -1540,6 +1540,69 @@ services:
 	c.Assert(ok, Equals, true, Commentf("error must be *plan.FormatError, not %T", err))
 }
 
+func (s *S) TestCombineLayersOverrideMerge(c *C) {
+	layer1, err := plan.ParseLayer(1, "label1", []byte(`
+services:
+    srv1:
+        override: merge
+        command: cmd
+        before:
+            - srv2
+        after:
+            - srv3
+        requires:
+            - srv2
+            - srv3
+    srv2:
+        override: replace
+        command: cmd
+    srv3:
+        override: replace
+        command: cmd
+`))
+	c.Assert(err, IsNil)
+
+	layer2, err := plan.ParseLayer(2, "label2", []byte(`
+services:
+    srv1:
+        summary: new summary
+        override: merge
+        command: cmd
+        before:
+            - srv4
+        after:
+            - srv5
+        requires:
+            - srv4
+            - srv5
+    srv4:
+        override: replace
+        command: cmd
+    srv5:
+        override: replace
+        command: cmd
+`))
+	c.Assert(err, IsNil)
+
+	combined, err := plan.CombineLayers(layer1, layer2)
+	c.Assert(err, IsNil)
+	c.Assert(combined.Services["srv1"].Summary, Equals, "new summary")
+	c.Assert(combined.Services["srv1"].Before, DeepEquals, []string{"srv2", "srv4"})
+	c.Assert(combined.Services["srv1"].After, DeepEquals, []string{"srv3", "srv5"})
+	c.Assert(combined.Services["srv1"].Requires, DeepEquals, []string{"srv2", "srv3", "srv4", "srv5"})
+
+	layers := []*plan.Layer{layer1, layer2}
+	p := &plan.Plan{
+		Layers:     layers,
+		Services:   combined.Services,
+		Checks:     combined.Checks,
+		LogTargets: combined.LogTargets,
+		Sections:   combined.Sections,
+	}
+	err = p.Validate()
+	c.Assert(err, IsNil)
+}
+
 func (s *S) TestMissingOverride(c *C) {
 	layer1, err := plan.ParseLayer(1, "label1", []byte("{}"))
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Avoid a second copy of services when combining layers, also add a unit test to cover `override: merge`.

Closes https://github.com/canonical/pebble/issues/499.

See more discussion [here](https://github.com/canonical/pebble/issues/499#issuecomment-2354083170).