### PR TITLE
feat: prune service logs and serviceData in service manager

### DIFF
--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -58,8 +58,8 @@ var (
 	// Hold no more than 1000 completed notices, even if they have not yet expired
 	pruneMaxNotices = 1000
 
-	// Hold	no more than 100 serviceData.
-	pruneMaxServiceData = 100
+	// Hold no more than 100 inactive services.
+	pruneMaxInactiveServices = 100
 )
 
 var pruneTickerC = func(t *time.Ticker) <-chan time.Time {
@@ -429,7 +429,7 @@ func (o *Overlord) Loop() {
 				st.Prune(o.startOfOperationTime, pruneWait, abortWait, pruneMaxChanges, pruneMaxNotices)
 				st.Unlock()
 				serviceMgr := o.ServiceManager()
-				serviceMgr.Prune(pruneWait, pruneMaxServiceData)
+				serviceMgr.Prune(pruneWait, pruneMaxInactiveServices)
 			}
 		}
 	})

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -58,8 +58,8 @@ var (
 	// Hold no more than 1000 completed notices, even if they have not yet expired
 	pruneMaxNotices = 1000
 
-	// Hold	no more than 1000 serviceData.
-	pruneMaxServiceData = 1000
+	// Hold	no more than 100 serviceData.
+	pruneMaxServiceData = 100
 )
 
 var pruneTickerC = func(t *time.Ticker) <-chan time.Time {

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -58,8 +58,7 @@ var (
 	// Hold no more than 1000 completed notices, even if they have not yet expired
 	pruneMaxNotices = 1000
 
-	// Hold	no more than 1000 serviceData,
-	// even if it means pruning in active services less than pruneWait.
+	// Hold	no more than 1000 serviceData.
 	pruneMaxServiceData = 1000
 )
 

--- a/internals/overlord/servstate/export_test.go
+++ b/internals/overlord/servstate/export_test.go
@@ -89,3 +89,14 @@ func FakeSetCmdCredential(f func(cmd *exec.Cmd, credential *syscall.Credential))
 		setCmdCredential = old
 	}
 }
+
+// FakeTimeNow fakes the system time for the TLS manager.
+func FakeTimeNow(t time.Time) (restore func()) {
+	old := timeNow
+	timeNow = func() time.Time {
+		return t
+	}
+	return func() {
+		timeNow = old
+	}
+}

--- a/internals/overlord/servstate/export_test.go
+++ b/internals/overlord/servstate/export_test.go
@@ -90,7 +90,7 @@ func FakeSetCmdCredential(f func(cmd *exec.Cmd, credential *syscall.Credential))
 	}
 }
 
-// FakeTimeNow fakes the system time for the TLS manager.
+// FakeTimeNow fakes the system time for the service manager for testing purposes.
 func FakeTimeNow(t time.Time) (restore func()) {
 	old := timeNow
 	timeNow = func() time.Time {

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -395,8 +395,8 @@ func (m *ServiceManager) Prune(pruneWait time.Duration, maxServiceData int) {
 				inactive = append(inactive, s)
 			}
 		}
-		sort.Slice(inactive, func(i, j int) bool {
-			return inactive[i].currentSince.Before(inactive[j].currentSince)
+		slices.SortFunc(inactive, func(a, b *serviceData) bool {
+			return a.currentSince.Compare(b.currentSince)
 		})
 		excess := len(m.services) - maxServiceData
 		toDelete := min(len(inactive), excess)

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -391,7 +391,7 @@ func (m *ServiceManager) Prune(pruneWait time.Duration, maxServiceData int) {
 	if len(m.services) > maxServiceData {
 		var inactive []*serviceData
 		for _, s := range m.services {
-			if s != nil && stateToStatus(s.state) == StatusInactive {
+			if stateToStatus(s.state) == StatusInactive {
 				inactive = append(inactive, s)
 			}
 		}

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -383,7 +383,7 @@ func (m *ServiceManager) Prune(pruneWait time.Duration, maxServiceData int) {
 	now := timeNow()
 	pruneLimit := now.Add(-pruneWait)
 	for name, s := range m.services {
-		if s != nil && stateToStatus(s.state) == StatusInactive && s.currentSince.Before(pruneLimit) {
+		if stateToStatus(s.state) == StatusInactive && s.currentSince.Before(pruneLimit) {
 			delete(m.services, name)
 		}
 	}

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -395,7 +396,7 @@ func (m *ServiceManager) Prune(pruneWait time.Duration, maxServiceData int) {
 				inactive = append(inactive, s)
 			}
 		}
-		slices.SortFunc(inactive, func(a, b *serviceData) bool {
+		slices.SortFunc(inactive, func(a *serviceData, b *serviceData) int {
 			return a.currentSince.Compare(b.currentSince)
 		})
 		excess := len(m.services) - maxServiceData

--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -374,7 +374,7 @@ func (m *ServiceManager) WriteMetrics(writer metrics.Writer) error {
 
 // Prune cleans up the in-memory serviceData:
 //   - It removes the serviceData if a service is inactive and its currentSince is older than pruneWait.
-//   - If the number of serviceData entries is still more than maxServiceData, remove inactive services'
+//   - If the number of inactive serviceData entries is still more than maxServiceData, remove inactive services'
 //     serviceData even if they are not older than pruneWait. Inactive services are sorted by currentSince,
 //     and remove the older ones first.
 func (m *ServiceManager) Prune(pruneWait time.Duration, maxServiceData int) {
@@ -399,9 +399,8 @@ func (m *ServiceManager) Prune(pruneWait time.Duration, maxServiceData int) {
 		slices.SortFunc(inactive, func(a *serviceData, b *serviceData) int {
 			return a.currentSince.Compare(b.currentSince)
 		})
-		excess := len(m.services) - maxServiceData
-		toDelete := min(len(inactive), excess)
-		for i := 0; i < toDelete; i++ {
+		excess := max(len(inactive)-maxServiceData, 0)
+		for i := range excess {
 			delete(m.services, inactive[i].config.Name)
 		}
 	}

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -2494,8 +2494,9 @@ func (s *S) TestPruneMaxServiceData(c *C) {
 	s.st.Unlock()
 
 	// Prune, without time mock and with a very long pruneWait so that all services are not old enough,
-	// but also set maxServiceData set to 2, meaning 3 service will be pruned to respect maxServiceData.
-	s.manager.Prune(7*24*time.Hour, 2)
+	// but also set maxServiceData set to 0, meaning all 3 inactive service will be pruned to respect
+	// maxServiceData.
+	s.manager.Prune(7*24*time.Hour, 0)
 
 	services, err := s.manager.Services([]string{"test3", "test4", "test5"})
 	c.Assert(err, IsNil)
@@ -2541,9 +2542,9 @@ func (s *S) TestPruneSortByCurrentSince(c *C) {
 	s.st.Unlock()
 
 	// Prune, with a very long pruneWait so that all services are not old enough,
-	// but also set maxServiceData set to 4, meaning one service will be pruned and
+	// but also set maxServiceData set to 2, meaning one service will be pruned and
 	// it should be test3 since it's the oldest inactive service.
-	s.manager.Prune(100*365*24*time.Hour, 4)
+	s.manager.Prune(100*365*24*time.Hour, 2)
 
 	services, err := s.manager.Services([]string{"test3"})
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Prune service logs and `serviceData` in the service manager.

- If a service is inactive, and its `currentSince` is older than `pruneWait`, it will be pruned.
- If the total number of entries of serviceData is still greater than `maxServiceData`, inactive services will be pruned even if they are _not_ older than `pruneWait` to keep the total number of serviceData entries under control. In this case, it's sorted by `currentSince` to ensure pruning older inactive services first.

Also added a few unit test cases to cover this feature. Test cases for the overlord are not updated because the outer prune loop is already tested; no integration test is added because the unit tests already cover all cases.

Fixes #539.