### PR TITLE
docs: add a Sphinx reference point to the security doc

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -1,3 +1,5 @@
+(security)=
+
 # Security
 
 


### PR DESCRIPTION
This makes it possible to have an intersphinx link to the security content.