### PR TITLE
ci: bump the setup-go version and explicitly request Go 1.24 in the TIOBE workflow

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -5,14 +5,20 @@ on:
   schedule:
     - cron:  '0 7 1 * *'
 
+permissions: {}
+
 jobs:
   TICS:
     runs-on: [self-hosted, reactive, amd64, tiobe, noble]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
 
       - name: Install dependencies
         run: |
@@ -30,7 +36,7 @@ jobs:
           gocov-xml < coverage.json > .coverage/coverage.xml
 
       - name: TICS GitHub Action
-        uses: tiobe/tics-github-action@v3
+        uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # 3.4.0
         with:
           mode: qserver
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "github/*": ref-pin


### PR DESCRIPTION
#660 was meant to adjust the TIOBE workflow to run on self-hosted runners with no other changes, but that promise was unfortunately not fulfilled. The team suggests that bumping the setup-go action to v5 and explicitly specifying the version of Go to use may fix the failing job.

While making the adjustments, a drive-by of minor security improvements:
* Default permissions to none.
* Don't persist the git credentials when cloning.
* Pin the TIOBE action to a specific revision.
* Allow actions/ and github/ actions to be pinned to versions rather than revisions.