### PR TITLE
fix(docs): offer only latest Loki link

### DIFF
--- a/docs/how-to/forward-logs-to-loki.md
+++ b/docs/how-to/forward-logs-to-loki.md
@@ -12,7 +12,7 @@ This guide demonstrates how to forward Pebble logs to the centralized logging sy
 
 For testing, the easiest way is to download the latest pre-built binary and run it locally:
 
-1. Find the latest release on the [Loki releases page](https://github.com/grafana/loki/releases/) and download the binary according to your operating system and architecture.
+1. Download the [latest Loki release](https://github.com/grafana/loki/releases/latest) binary according to your operating system and architecture.
 1. Download the sample local config: `wget https://raw.githubusercontent.com/grafana/loki/main/cmd/loki/loki-local-config.yaml`.
 1. Run Loki locally: `loki-linux-amd64 -config.file=loki-local-config.yaml`.
 


### PR DESCRIPTION
The Loki how-to instructs the user to download the sample local configuration from the repository ```main``` while pointing to the Loki releases page for downloading the binary. The issue is that the latest (matching the configuration) release is not always the top entry on the releases page, as multiple parallel versions are maintained.

The current state of using the configuration file with the top release entry is:
```
flotter@flotter-pc:~/pebble/loki$ ./loki-linux-amd64 -config.file=loki-local-config.yaml
failed parsing config: loki-local-config.yaml: yaml: unmarshal errors:
  line 30: field enable_multi_variant_queries not found in type validation.plain. Use `-config.expand-env=true` flag if you want to expand environment variables in your config file
```

Update the link to only point to the latest (highest versioned) release, which has a much better chance of matching the downloaded configuration file.