### PR TITLE
chore: remove unsupported "syslog" type so it's validated earlier

### DIFF
--- a/internals/overlord/logstate/gatherer.go
+++ b/internals/overlord/logstate/gatherer.go
@@ -368,7 +368,6 @@ func newLogClient(target *plan.LogTarget) (logClient, error) {
 	switch target.Type {
 	case plan.LokiTarget:
 		return loki.NewClient(target), nil
-	//case plan.SyslogTarget: TODO
 	default:
 		return nil, fmt.Errorf("unknown type %q for log target %q", target.Type, target.Name)
 	}

--- a/internals/plan/plan.go
+++ b/internals/plan/plan.go
@@ -654,7 +654,6 @@ type LogTargetType string
 
 const (
 	LokiTarget     LogTargetType = "loki"
-	SyslogTarget   LogTargetType = "syslog"
 	UnsetLogTarget LogTargetType = ""
 )
 
@@ -981,14 +980,14 @@ func (layer *Layer) Validate() error {
 			}
 		}
 		switch target.Type {
-		case LokiTarget, SyslogTarget:
+		case LokiTarget:
 			// valid, continue
 		case UnsetLogTarget:
 			// will be checked when the layers are combined
 		default:
 			return &FormatError{
-				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q or %q`,
-					name, target.Type, LokiTarget, SyslogTarget),
+				Message: fmt.Sprintf(`log target %q has unsupported type %q, must be %q`,
+					name, target.Type, LokiTarget),
 			}
 		}
 	}
@@ -1056,12 +1055,12 @@ func (p *Plan) Validate() error {
 
 	for name, target := range p.LogTargets {
 		switch target.Type {
-		case LokiTarget, SyslogTarget:
+		case LokiTarget:
 			// valid, continue
 		case UnsetLogTarget:
 			return &FormatError{
-				Message: fmt.Sprintf(`plan must define "type" (%q or %q) for log target %q`,
-					LokiTarget, SyslogTarget, name),
+				Message: fmt.Sprintf(`plan must define "type" (%q) for log target %q`,
+					LokiTarget, name),
 			}
 		}
 

--- a/internals/plan/plan_test.go
+++ b/internals/plan/plan_test.go
@@ -974,11 +974,6 @@ var planTests = []planTest{{
 				location: http://10.1.77.196:3100/loki/api/v1/push
 				services: [all]
 				override: merge
-			tgt2:
-				type: syslog
-				location: udp://0.0.0.0:514
-				services: [svc2]
-				override: merge
 `},
 	result: &plan.Layer{
 		Services: map[string]*plan.Service{
@@ -1010,13 +1005,6 @@ var planTests = []planTest{{
 				Services: []string{"all"},
 				Override: plan.MergeOverride,
 			},
-			"tgt2": {
-				Name:     "tgt2",
-				Type:     plan.SyslogTarget,
-				Location: "udp://0.0.0.0:514",
-				Services: []string{"svc2"},
-				Override: plan.MergeOverride,
-			},
 		},
 		Sections: map[string]plan.Section{},
 	},
@@ -1040,11 +1028,6 @@ var planTests = []planTest{{
 				services: [all]
 				override: merge
 			tgt2:
-				type: syslog
-				location: udp://0.0.0.0:514
-				services: [svc2]
-				override: merge
-			tgt3:
 				type: loki
 				location: http://10.1.77.206:3100/loki/api/v1/push
 				services: [all]
@@ -1064,12 +1047,7 @@ var planTests = []planTest{{
 				services: [-all, svc1]
 				override: merge
 			tgt2:
-				type: syslog
-				location: udp://1.2.3.4:514
-				services: []
-				override: replace
-			tgt3:
-				type: syslog
+				type: loki
 				location: udp://0.0.0.0:514
 				services: [-svc1]
 				override: merge
@@ -1102,13 +1080,6 @@ var planTests = []planTest{{
 			},
 			"tgt2": {
 				Name:     "tgt2",
-				Type:     plan.SyslogTarget,
-				Location: "udp://0.0.0.0:514",
-				Services: []string{"svc2"},
-				Override: plan.MergeOverride,
-			},
-			"tgt3": {
-				Name:     "tgt3",
 				Type:     plan.LokiTarget,
 				Location: "http://10.1.77.206:3100/loki/api/v1/push",
 				Services: []string{"all"},
@@ -1141,14 +1112,7 @@ var planTests = []planTest{{
 			},
 			"tgt2": {
 				Name:     "tgt2",
-				Type:     plan.SyslogTarget,
-				Location: "udp://1.2.3.4:514",
-				Services: []string{},
-				Override: plan.ReplaceOverride,
-			},
-			"tgt3": {
-				Name:     "tgt3",
-				Type:     plan.SyslogTarget,
+				Type:     plan.LokiTarget,
 				Location: "udp://0.0.0.0:514",
 				Services: []string{"-svc1"},
 				Override: plan.MergeOverride,
@@ -1188,13 +1152,7 @@ var planTests = []planTest{{
 			},
 			"tgt2": {
 				Name:     "tgt2",
-				Type:     plan.SyslogTarget,
-				Location: "udp://1.2.3.4:514",
-				Override: plan.ReplaceOverride,
-			},
-			"tgt3": {
-				Name:     "tgt3",
-				Type:     plan.SyslogTarget,
+				Type:     plan.LokiTarget,
 				Location: "udp://0.0.0.0:514",
 				Services: []string{"all", "-svc1"},
 				Override: plan.MergeOverride,
@@ -1204,7 +1162,7 @@ var planTests = []planTest{{
 	},
 }, {
 	summary: "Log target requires type field",
-	error:   `plan must define "type" \("loki" or "syslog"\) for log target "tgt1"`,
+	error:   `plan must define "type" \("loki"\) for log target "tgt1"`,
 	input: []string{`
 		log-targets:
 			tgt1:
@@ -1222,7 +1180,7 @@ var planTests = []planTest{{
 				override: merge
 `}}, {
 	summary: "Unsupported log target type",
-	error:   `log target "tgt1" has unsupported type "foobar", must be "loki" or "syslog"`,
+	error:   `log target "tgt1" has unsupported type "foobar", must be "loki"`,
 	input: []string{`
 		log-targets:
 			tgt1:


### PR DESCRIPTION
This PR removes the `plan.SyslogTarget` constant, as its not supported. This has the effect of moving the validation earlier, when checking the plan, rather than later when setting up the log gatherer.

Before (with a log target of `type: syslog`):

```
$ go run ./cmd/pebble run
2025-07-28T22:18:37.200Z [pebble] Internal error: cannot create gatherer for target "tgt": cannot create log client: unknown type "syslog" for log target "tgt"
2025-07-28T22:18:37.201Z [pebble] Started daemon.
2025-07-28T22:18:37.204Z [pebble] POST /v1/services 1.534492ms 202 (http+unix)
2025-07-28T22:18:37.206Z [pebble] Service "test1" starting: /bin/sh -c "echo test; sleep 1000"
2025-07-28T22:18:38.211Z [pebble] GET /v1/changes/1/wait 1.005821051s 200 (http+unix)
2025-07-28T22:18:38.211Z [pebble] Started default services with change 1.
...
```

In other words, it starts up fine but just logs a warning. Whereas it should fail hard when loading the plan, like other validation errors.

After:

```go
$ go run ./cmd/pebble run
cannot run daemon: cannot load plan: log target "tgt" has unsupported type "syslog", must be "loki"
exit status 1
```

We can easily add the syslog type back when it's actually supported.