### PR TITLE
fix: check error log when failure is at threshold

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -26,13 +26,14 @@ import (
 
 // Change is a modification to the system state.
 type Change struct {
-	ID      string  `json:"id"`
-	Kind    string  `json:"kind"`
-	Summary string  `json:"summary"`
-	Status  string  `json:"status"`
-	Tasks   []*Task `json:"tasks,omitempty"`
-	Ready   bool    `json:"ready"`
-	Err     string  `json:"err,omitempty"`
+	ID                string  `json:"id"`
+	PrecedentChangeID string  `json:"precedent-change-id,omitempty"`
+	Kind              string  `json:"kind"`
+	Summary           string  `json:"summary"`
+	Status            string  `json:"status"`
+	Tasks             []*Task `json:"tasks,omitempty"`
+	Ready             bool    `json:"ready"`
+	Err               string  `json:"err,omitempty"`
 
 	SpawnTime time.Time `json:"spawn-time,omitempty"`
 	ReadyTime time.Time `json:"ready-time,omitempty"`

--- a/internals/cli/cmd_check.go
+++ b/internals/cli/cmd_check.go
@@ -135,6 +135,26 @@ func (cmd *cmdCheck) taskLogs(changeID string) (string, error) {
 	if len(change.Tasks) < 1 {
 		return "", nil
 	}
+
+	logs, err := cmd.getLogsFromChange(change)
+	if err != nil || logs != "" {
+		return logs, err
+	}
+
+	if change.PrecedentChangeID == "" {
+		return "", nil
+	}
+	precedentChange, err := cmd.client.Change(change.PrecedentChangeID)
+	if err != nil {
+		return "", err
+	}
+	if len(precedentChange.Tasks) < 1 {
+		return "", nil
+	}
+	return cmd.getLogsFromChange(precedentChange)
+}
+
+func (cmd *cmdCheck) getLogsFromChange(change *client.Change) (string, error) {
 	logs := change.Tasks[0].Log
 	if len(logs) < 1 {
 		return "", nil

--- a/internals/daemon/api_changes.go
+++ b/internals/daemon/api_changes.go
@@ -24,13 +24,14 @@ import (
 )
 
 type changeInfo struct {
-	ID      string      `json:"id"`
-	Kind    string      `json:"kind"`
-	Summary string      `json:"summary"`
-	Status  string      `json:"status"`
-	Tasks   []*taskInfo `json:"tasks,omitempty"`
-	Ready   bool        `json:"ready"`
-	Err     string      `json:"err,omitempty"`
+	ID                string      `json:"id"`
+	PrecedentChangeID string      `json:"precedent-change-id,omitempty"`
+	Kind              string      `json:"kind"`
+	Summary           string      `json:"summary"`
+	Status            string      `json:"status"`
+	Tasks             []*taskInfo `json:"tasks,omitempty"`
+	Ready             bool        `json:"ready"`
+	Err               string      `json:"err,omitempty"`
 
 	SpawnTime time.Time  `json:"spawn-time,omitempty"`
 	ReadyTime *time.Time `json:"ready-time,omitempty"`
@@ -61,11 +62,12 @@ type taskInfoProgress struct {
 func change2changeInfo(chg *state.Change) *changeInfo {
 	status := chg.Status()
 	chgInfo := &changeInfo{
-		ID:      chg.ID(),
-		Kind:    chg.Kind(),
-		Summary: chg.Summary(),
-		Status:  status.String(),
-		Ready:   status.Ready(),
+		ID:                chg.ID(),
+		PrecedentChangeID: chg.PrecedentChangeID(),
+		Kind:              chg.Kind(),
+		Summary:           chg.Summary(),
+		Status:            status.String(),
+		Ready:             status.Ready(),
 
 		SpawnTime: chg.SpawnTime(),
 	}

--- a/internals/overlord/checkstate/manager.go
+++ b/internals/overlord/checkstate/manager.go
@@ -178,7 +178,7 @@ func (m *CheckManager) PlanChanged(newPlan *plan.Plan) {
 	for _, config := range newPlan.Checks {
 		if newOrModified[config.Name] {
 			merged := mergeServiceContext(newPlan, config)
-			changeID := performCheckChange(m.state, merged)
+			changeID := performCheckChange(m.state, merged, "")
 			m.updateCheckData(config, changeID, 0, 0)
 			shouldEnsure = true
 		}
@@ -197,7 +197,7 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 			break
 		}
 		config := m.state.Cached(performConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
-		changeID := recoverCheckChange(m.state, config, details.Successes, details.Failures)
+		changeID := recoverCheckChange(m.state, config, change.ID(), details.Successes, details.Failures)
 		m.updateCheckData(config, changeID, details.Successes, details.Failures)
 		shouldEnsure = true
 
@@ -207,7 +207,7 @@ func (m *CheckManager) changeStatusChanged(change *state.Change, old, new state.
 			break
 		}
 		config := m.state.Cached(recoverConfigKey{change.ID()}).(*plan.Check) // panic if key not present (always should be)
-		changeID := performCheckChange(m.state, config)
+		changeID := performCheckChange(m.state, config, change.ID())
 		m.updateCheckData(config, changeID, details.Successes, details.Failures)
 		shouldEnsure = true
 	}
@@ -548,7 +548,7 @@ func (m *CheckManager) StartChecks(checks []string) (started []string, err error
 		if checkData.changeID != "" {
 			continue
 		}
-		changeID := performCheckChange(m.state, check)
+		changeID := performCheckChange(m.state, check, "")
 		m.updateCheckData(check, changeID, 0, 0)
 		started = append(started, check.Name)
 	}
@@ -631,7 +631,7 @@ func (m *CheckManager) Replan() {
 		if checkData.changeID != "" {
 			continue
 		}
-		changeID := performCheckChange(m.state, check)
+		changeID := performCheckChange(m.state, check, "")
 		m.updateCheckData(check, changeID, 0, 0)
 	}
 }

--- a/internals/overlord/checkstate/request.go
+++ b/internals/overlord/checkstate/request.go
@@ -33,12 +33,12 @@ type performConfigKey struct {
 	changeID string
 }
 
-func performCheckChange(st *state.State, config *plan.Check) (changeID string) {
+func performCheckChange(st *state.State, config *plan.Check, precedentChangeID string) (changeID string) {
 	summary := fmt.Sprintf("Perform %s check %q", checkType(config), config.Name)
 	task := st.NewTask(performCheckKind, summary)
 	task.Set(checkDetailsAttr, &checkDetails{Name: config.Name})
 
-	change := st.NewChangeWithNoticeData(performCheckKind, task.Summary(), map[string]string{
+	change := st.NewChangeWithNoticeData(performCheckKind, task.Summary(), precedentChangeID, map[string]string{
 		"check-name": config.Name,
 	})
 	change.Set(noPruneAttr, true)
@@ -53,7 +53,7 @@ type recoverConfigKey struct {
 	changeID string
 }
 
-func recoverCheckChange(st *state.State, config *plan.Check, successes, failures int) (changeID string) {
+func recoverCheckChange(st *state.State, config *plan.Check, precedentChangeID string, successes, failures int) (changeID string) {
 	summary := fmt.Sprintf("Recover %s check %q", checkType(config), config.Name)
 	task := st.NewTask(recoverCheckKind, summary)
 	task.Set(checkDetailsAttr, &checkDetails{
@@ -62,7 +62,7 @@ func recoverCheckChange(st *state.State, config *plan.Check, successes, failures
 		Failures:  failures,
 	})
 
-	change := st.NewChangeWithNoticeData(recoverCheckKind, task.Summary(), map[string]string{
+	change := st.NewChangeWithNoticeData(recoverCheckKind, task.Summary(), precedentChangeID, map[string]string{
 		"check-name": config.Name,
 	})
 	change.Set(noPruneAttr, true)

--- a/internals/overlord/state/change.go
+++ b/internals/overlord/state/change.go
@@ -135,6 +135,7 @@ const (
 type Change struct {
 	state                    *State
 	id                       string
+	precedentChangeID        string
 	kind                     string
 	summary                  string
 	status                   Status
@@ -246,6 +247,11 @@ func (c *Change) finishUnmarshal() {
 // ID returns the individual random key for the change.
 func (c *Change) ID() string {
 	return c.id
+}
+
+// PrecedentChangeID returns the precedent Change's ID for the change.
+func (c *Change) PrecedentChangeID() string {
+	return c.precedentChangeID
 }
 
 // Kind returns the nature of the change for managers to know how to handle it.

--- a/internals/overlord/state/change_test.go
+++ b/internals/overlord/state/change_test.go
@@ -56,7 +56,7 @@ func (cs *changeSuite) TestNewChangeWithExtraNoticeData(c *C) {
 	st.Lock()
 	defer st.Unlock()
 
-	st.NewChangeWithNoticeData("perform-check", "...", map[string]string{"check-name": "c"})
+	st.NewChangeWithNoticeData("perform-check", "...", "", map[string]string{"check-name": "c"})
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)

--- a/internals/overlord/state/state.go
+++ b/internals/overlord/state/state.go
@@ -391,15 +391,16 @@ func (s *State) Cache(key, value any) {
 
 // NewChange adds a new change to the state.
 func (s *State) NewChange(kind, summary string) *Change {
-	return s.NewChangeWithNoticeData(kind, summary, nil)
+	return s.NewChangeWithNoticeData(kind, summary, "", nil)
 }
 
 // NewChangeWithNoticeData adds a new change to the state, adding in any provided notice data.
-func (s *State) NewChangeWithNoticeData(kind, summary string, noticeData map[string]string) *Change {
+func (s *State) NewChangeWithNoticeData(kind, summary string, precedentChangeID string, noticeData map[string]string) *Change {
 	s.writing()
 	s.lastChangeId++
 	id := strconv.Itoa(s.lastChangeId)
 	chg := newChange(s, id, kind, summary)
+	chg.precedentChangeID = precedentChangeID
 	s.changes[id] = chg
 
 	// Set this before calling addNotice as that needs to use it.

--- a/internals/overlord/state/state_test.go
+++ b/internals/overlord/state/state_test.go
@@ -366,7 +366,7 @@ func (ss *stateSuite) TestNewChangeWithNoticeData(c *C) {
 	defer st.Unlock()
 
 	extraData := map[string]string{"foo": "bar"}
-	chg := st.NewChangeWithNoticeData("perform-check", "...", extraData)
+	chg := st.NewChangeWithNoticeData("perform-check", "...", "", extraData)
 
 	chgs := st.Changes()
 	c.Check(chgs, HasLen, 1)
@@ -383,7 +383,7 @@ func (ss *stateSuite) TestNewChangeWithNilNoticeData(c *C) {
 	defer st.Unlock()
 
 	st.NewChange("replan", "...")
-	st.NewChangeWithNoticeData("replan", "...", nil)
+	st.NewChangeWithNoticeData("replan", "...", "", nil)
 
 	for _, chg := range st.Changes() {
 		c.Assert(chg.Has("notice-data"), Equals, false)


### PR DESCRIPTION
Fix an issue where the error logs of a check can't be displayed properly when the check failures count is at the threshold.

Closes https://github.com/canonical/pebble/issues/634.