### PR TITLE
chore: update TIOBE dependencies to support Go 1.24

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version-file: 'go.mod'
 
     - name: Run tests
       run: go test -count=1 -tags=integration ./tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    name: Install Go
+    name: Unit tests
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,19 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.22']
-
-    name: Go ${{ matrix.go }}
+    name: Install Go
     steps:
     - uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
 
     - name: Test and build
       run: |
@@ -39,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
 
     - name: Test
       run: |

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
           go install github.com/axw/gocov/gocov@v1.1.0
           go install github.com/AlekSi/gocov-xml@v1.1.0
 


### PR DESCRIPTION
Our TIOBE contact let us know that we need to update the staticcheck tool that the workflow uses, to support Go 1.24.

In order to have this work in CI, also bump the version of Go used in the unit and integration tests to 1.24, by pulling the version from `go.mod`. This removes the Go version matrix testing in the tests, but we only had a single version being tested, so the matrix wasn't really used.