### PR TITLE
fix(cmdstate,wsutil): don't report websocket close errors

### DIFF
--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -475,10 +475,11 @@ func (e *execution) controlLoop(execID string, pidCh <-chan int, stop <-chan str
 		}
 
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
 				logger.Debugf("Exec %s: cannot get next websocket reader for PID %d: %v", execID, pid, err)
+			}
 
-				// If an abnormal closure occurred, kill the attached process.
+			if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
 				err := unix.Kill(pid, unix.SIGKILL)
 				if err != nil {
 					logger.Noticef("Exec %s: cannot send SIGKILL to pid %d: %v", execID, pid, err)
@@ -486,6 +487,7 @@ func (e *execution) controlLoop(execID string, pidCh <-chan int, stop <-chan str
 					logger.Debugf("Exec %s: sent SIGKILL to pid %d", execID, pid)
 				}
 			}
+
 			break
 		}
 

--- a/internals/wsutil/wsutil.go
+++ b/internals/wsutil/wsutil.go
@@ -75,12 +75,11 @@ func WebsocketSendStream(conn MessageWriter, r io.Reader, bufferSize int) chan b
 	return ch
 }
 
-func WebsocketRecvStream(w io.Writer, conn MessageReadWriter) chan bool {
+func WebsocketRecvStream(w io.Writer, conn MessageReader) chan bool {
 	ch := make(chan bool)
 
 	go func() {
 		recvLoop(w, conn)
-		sendEndCommand(conn)
 		close(ch)
 	}()
 

--- a/internals/wsutil/wsutil.go
+++ b/internals/wsutil/wsutil.go
@@ -88,7 +88,7 @@ func recvLoop(w io.Writer, conn MessageReader) {
 	for {
 		mt, r, err := conn.NextReader()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseAbnormalClosure) {
 				logger.Debugf("Cannot get next reader: %v", err)
 			}
 			return

--- a/internals/wsutil/wsutil.go
+++ b/internals/wsutil/wsutil.go
@@ -64,7 +64,7 @@ func WebsocketSendStream(conn MessageWriter, r io.Reader, bufferSize int) chan b
 				break
 			}
 		}
-		_ = conn.WriteMessage(websocket.TextMessage, endCommandJSON)
+		conn.WriteMessage(websocket.TextMessage, endCommandJSON)
 		close(ch) // NOTE(benhoyt): this was "ch <- true", but that can block
 	}(conn, r)
 


### PR DESCRIPTION
This issue is related to https://github.com/canonical/pebble/issues/586

When the websocket connection is closed from the client side, websocket close errors are sometimes incorrectly reported:

```
2025-03-12T06:27:37.428Z [pebble] DEBUG Exec 6: started mirroring websocket
2025-03-12T06:27:37.429Z [pebble] DEBUG Exec 6: control handler started for PID 260895
2025-03-12T06:27:37.431Z [pebble] DEBUG Reaper received SIGCHLD.
2025-03-12T06:27:37.431Z [pebble] DEBUG Reaped PID 260895 which exited with code 0.
2025-03-12T06:27:37.431Z [pebble] DEBUG Detected poll(POLLHUP) event: exiting.
>>>>> 2025-03-12T06:27:37.431Z [pebble] DEBUG Exec 6: cannot get next websocket reader for PID 260895: read unix /var/lib/pebble/default/.pebble.socket->@: use of closed network connection
2025-03-12T06:27:37.431Z [pebble] DEBUG Exec 6: control handler finished
2025-03-12T06:27:37.431Z [pebble] DEBUG Sending write barrier
2025-03-12T06:27:37.431Z [pebble] DEBUG Exec 6: finished mirroring websocket
2025-03-12T06:27:37.432Z [pebble] DEBUG Detected poll(POLLNVAL) event.
>>>>> 2025-03-12T06:27:37.432Z [pebble] DEBUG Cannot get next reader: websocket: close 1006 (abnormal closure): unexpected EOF
2025-03-12T06:27:37.440Z [pebble] DEBUG pid=260889;uid=0;socket=/var/lib/pebble/default/.pebble.socket; GET /v1/changes/6/wait 10.822537ms 200
2025-03-12T06:27:37.440Z [pebble] GET /v1/changes/6/wait 10.822537ms 200
```

This patch applies better error handling around connection closure so no bogus errors end up in the logs.