### PR TITLE
perf: improve performance of serializing log timestamps

### DIFF
--- a/internals/servicelog/formatter.go
+++ b/internals/servicelog/formatter.go
@@ -108,7 +108,7 @@ func appendTimestamp(b []byte, t time.Time) []byte {
 	b[19] = '.'
 
 	// Write milliseconds (3 digits)
-	b[20] = byte('0' + millisecond/100%10)
+	b[20] = byte('0' + millisecond/100) // millisecond is at most 999, so no need for %10 here
 	b[21] = byte('0' + millisecond/10%10)
 	b[22] = byte('0' + millisecond%10)
 	b[23] = 'Z'

--- a/internals/servicelog/formatter.go
+++ b/internals/servicelog/formatter.go
@@ -55,6 +55,10 @@ func NewFormatWriter(dest io.Writer, serviceName string) io.Writer {
 	}
 }
 
+func appendTimestamp(buf []byte, t time.Time) []byte {
+	return t.UTC().AppendFormat(buf, outputTimeFormat)
+}
+
 func (f *formatter) Write(p []byte) (nn int, ee error) {
 	f.mut.Lock()
 	defer f.mut.Unlock()
@@ -62,7 +66,7 @@ func (f *formatter) Write(p []byte) (nn int, ee error) {
 	for len(p) > 0 {
 		if f.writeTimestamp {
 			f.writeTimestamp = false
-			f.timestampBuffer = time.Now().UTC().AppendFormat(f.timestampBuffer[:0], outputTimeFormat)
+			f.timestampBuffer = appendTimestamp(f.timestampBuffer[:0], time.Now())
 			f.timestampBuffer = append(f.timestampBuffer, " ["...)
 			f.timestampBuffer = append(f.timestampBuffer, f.serviceName...)
 			f.timestampBuffer = append(f.timestampBuffer, "] "...)

--- a/internals/servicelog/formatter_benchmark_test.go
+++ b/internals/servicelog/formatter_benchmark_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package servicelog
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkAppendTimestamp(b *testing.B) {
+	t := time.Now()
+	buf := make([]byte, 0, 64)
+
+	for i := 0; i < b.N; i++ {
+		buf = appendTimestamp(buf[:0], t)
+	}
+
+	_ = buf // ensure buf is not optimized away
+}

--- a/internals/servicelog/formatter_benchmark_test.go
+++ b/internals/servicelog/formatter_benchmark_test.go
@@ -19,6 +19,17 @@ import (
 	"time"
 )
 
+func BenchmarkAppendFormat(b *testing.B) {
+	t := time.Now()
+	buf := make([]byte, 0, 64)
+
+	for i := 0; i < b.N; i++ {
+		buf = t.UTC().AppendFormat(buf[:0], "2006-01-02T15:04:05.000Z")
+	}
+
+	_ = buf // ensure buf is not optimized away
+}
+
 func BenchmarkAppendTimestamp(b *testing.B) {
 	t := time.Now()
 	buf := make([]byte, 0, 64)


### PR DESCRIPTION
Because the timestamp format used is not exactly RFC3339, the Go
standard library falls back to generic formatting code that analyzes the
format on every append, this causes a lot of unnecessary work. Using a
specialized formatter specifically for the format, a ~72% improvement
is achieved.

```
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/canonical/pebble/internals/servicelog
cpu: Apple M1 Max
                   │   old.txt    │               new.txt               │
                   │    sec/op    │   sec/op     vs base                │
AppendTimestamp-10   120.55n ± 0%   33.27n ± 1%  -72.41% (p=0.000 n=10)
```

After this, the only improvement that could still be made is assuming that it's always UTC, which we already know, profililing data shows that could at most improve another ~12% (`time.(*Location).get`).

https://pprof.me/da1dac7424551de8264abc96c430f319/?profileType=profile%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds%3Adelta&color_by=filename&dashboard_items=flamegraph%2Ctable&table_columns=color%2Cflat%2CflatPercentage%2Ccumulative%2Cname