### PR TITLE
chore: bump Go to 1.24.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,23 +34,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # NOTE: The latest version of staticcheck was built with go1.24.1, but because of CVE-2025-22874,
-      # we have upgraded to Go 1.24.4. If we install staticcheck from binary, we will get an error
-      # "module requires at least go1.24.4, but Staticcheck was built with go1.24.1 (compile)".
-      # So, we use `go install` for staticcheck.
       - uses: actions/setup-go@v4
         with:
           go-mod-file: 'go.mod'
 
       - name: Install staticcheck
+        # Use @master because of staticcheck tool versioning issues, for example:
+        # "module requires at least go1.24.6, but Staticcheck was built with go1.24.5 (compile)"
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
-
-      # - name: Install staticcheck
-      #   run: |
-      #     wget -q https://github.com/dominikh/go-tools/releases/download/2025.1.1/staticcheck_linux_amd64.tar.gz
-      #     tar -xzf staticcheck_linux_amd64.tar.gz
-      #     cp staticcheck/staticcheck /usr/local/bin
+          go install honnef.co/go/tools/cmd/staticcheck@master
 
       - name: Run checks
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.24/stable
+      - go/1.24/candidate  # TODO(benhoyt): switch back to stable once 1.24.6 is promoted to stable (https://snapcraft.io/go)
     # The snap build relies on the cmd/version*.go files within the source path.
     # For proper versioning, run "go generate ./cmd/" before building the snap.
     # If doing a "snapcraft remote-build", ensure you've also run

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,7 +41,7 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.24/candidate  # TODO(benhoyt): switch back to stable once 1.24.6 is promoted to stable (https://snapcraft.io/go)
+      - go/1.24/stable
     # The snap build relies on the cmd/version*.go files within the source path.
     # For proper versioning, run "go generate ./cmd/" before building the snap.
     # If doing a "snapcraft remote-build", ensure you've also run


### PR DESCRIPTION
This pulls in small fixes and resolves one [CVE](https://www.cve.org/CVERecord?id=CVE-2025-47907). The CVE is not relevant to Pebble's use of Go, but using the newer Go means that automated scanning tools (like Trivy) that aren't able to determine that will be satisfied.

For the snap, 1.24.5 is currently in stable but 1.24.6 is in candidate, so it seems likely that we'd be in alignment by the time there's a next Pebble release.