### PR TITLE
fix: websocket connection timeout

### DIFF
--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -482,7 +482,6 @@ func (s *execSuite) TestExecChangeReady(c *C) {
 	rsp.ServeHTTP(rec, req)
 
 	c.Check(rec.Code, Equals, 500)
-	fmt.Printf("Response body: %q\n", rec.Body.String())
 	c.Check(rec.Body.String(), Matches, `.*cannot connect to websocket.*something went wrong.*`)
 }
 

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -450,9 +450,6 @@ func (s *execSuite) TestExecChangeReady(c *C) {
 		Command: []string{"echo", "foo"},
 	})
 	c.Assert(httpResp.StatusCode, Equals, http.StatusAccepted)
-	body := new(bytes.Buffer)
-	err := json.NewEncoder(body).Encode(execResp)
-	c.Assert(err, IsNil)
 
 	changeID := execResp.Change
 	c.Assert(changeID, Not(Equals), "")
@@ -485,9 +482,8 @@ func (s *execSuite) TestExecChangeReady(c *C) {
 	rsp.ServeHTTP(rec, req)
 
 	c.Check(rec.Code, Equals, 500)
-	err = rsp.connect(req, rec, rsp.task, rsp.websocketID)
-	c.Assert(err, NotNil)
-	c.Check(err.Error(), Matches, `.*cannot perform the following tasks:\n.*something went wrong.*`)
+	fmt.Printf("Response body: %q\n", rec.Body.String())
+	c.Check(rec.Body.String(), Matches, `.*cannot connect to websocket.*something went wrong.*`)
 }
 
 type execResponse struct {

--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -117,7 +117,13 @@ func (m *CommandManager) doExec(task *state.Task, tomb *tomb.Tomb) error {
 
 	// Run the command! Killing the tomb will terminate the command.
 	ctx := tomb.Context(context.Background())
-	return e.do(ctx, task)
+	err := e.do(ctx, task)
+	if err != nil {
+		m.executionsCond.L.Lock()
+		m.errors[task.ID()] = err
+		m.executionsCond.L.Unlock()
+	}
+	return err
 }
 
 var websocketUpgrader = websocket.Upgrader{

--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -117,13 +117,7 @@ func (m *CommandManager) doExec(task *state.Task, tomb *tomb.Tomb) error {
 
 	// Run the command! Killing the tomb will terminate the command.
 	ctx := tomb.Context(context.Background())
-	err := e.do(ctx, task)
-	if err != nil {
-		m.executionsCond.L.Lock()
-		m.errors[task.ID()] = err
-		m.executionsCond.L.Unlock()
-	}
-	return err
+	return e.do(ctx, task)
 }
 
 var websocketUpgrader = websocket.Upgrader{

--- a/internals/overlord/cmdstate/manager.go
+++ b/internals/overlord/cmdstate/manager.go
@@ -87,6 +87,8 @@ func (m *CommandManager) Connect(r *http.Request, w http.ResponseWriter, task *s
 		return e.connect(r, w, websocketID)
 	case <-r.Context().Done():
 		return r.Context().Err()
+	// Change unexpectedly marked ready, probably due to the client not sending
+	// websocket requests in time.
 	case <-change.Ready():
 		st.Lock()
 		defer st.Unlock()


### PR DESCRIPTION
Fix `CommandManager.Connect` so that if the Pebble side has already timed out (an exec change fails before the execution object is created in the `CommandManager`), the server returns an error, causing the connection to the websocket URL to be timed out immediately.

Also, add a unit test to cover this scenario.

Closes https://github.com/canonical/pebble/issues/422.
