### PR TITLE
test(testutil): remove test using reaper

### DIFF
--- a/internals/testutil/exec_test.go
+++ b/internals/testutil/exec_test.go
@@ -18,8 +18,6 @@ import (
 	"os/exec"
 
 	"gopkg.in/check.v1"
-
-	"github.com/canonical/pebble/internals/reaper"
 )
 
 type fakeCommandSuite struct{}
@@ -43,23 +41,6 @@ func (s *fakeCommandSuite) TestFakeCommand(c *check.C) {
 		{"cmd", "third-run", "--arg1", "arg2", ""},
 		{"cmd", "forth-run", "--arg1", "arg2", "", "a %s"},
 	})
-}
-
-func (s *fakeCommandSuite) TestFakeCommandWithReaper(c *check.C) {
-	err := reaper.Start()
-	c.Assert(err, check.IsNil)
-	defer func() {
-		err := reaper.Stop()
-		c.Assert(err, check.IsNil)
-	}()
-
-	fake := FakeCommand(c, "cmd", "true")
-	defer fake.Restore()
-
-	cmd := exec.Command("cmd", "")
-	out, err := reaper.CommandCombinedOutput(cmd)
-	c.Assert(err, check.IsNil)
-	c.Assert(string(out), check.Equals, "")
 }
 
 func (s *fakeCommandSuite) TestFakeCommandAlso(c *check.C) {


### PR DESCRIPTION
Remove redundant test case TestFakeCommandWithReaper. 

---

It appears there is some history with properly awaiting faked commands with the old shellcheck logic and using the reaper (see https://github.com/canonical/pebble/pull/247 and https://github.com/canonical/pebble/pull/281) but it appears this code has been removed. Looking at the rationale for removing shellcheck in https://github.com/canonical/pebble/pull/381, and not wanting  FakeCommand to be reaper aware, this test likely should have been removed at that time. Additionally, this code does not appear to test anything unique compared to the exec.Command.Run() style test as written.