### PR TITLE
chore: fix failed unit test

### DIFF
--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -482,7 +482,7 @@ func (s *execSuite) TestExecChangeReady(c *C) {
 	rsp.ServeHTTP(rec, req)
 
 	c.Check(rec.Code, Equals, 500)
-	c.Check(rec.Body.String(), Matches, `.*cannot connect to websocket.*something went wrong.*`)
+	c.Check(rec.Body.String(), Matches, `.*cannot perform the following tasks.*something went wrong.*`)
 }
 
 type execResponse struct {

--- a/internals/daemon/api_tasks.go
+++ b/internals/daemon/api_tasks.go
@@ -74,7 +74,7 @@ func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rsp.ServeHTTP(w, r)
 	} else if err != nil {
 		logger.Noticef("Websocket %s: cannot connect to %s websocket: %v", wr.task.ID(), wr.websocketID, err)
-		rsp := NotFound("%v", err)
+		rsp := InternalError("%v", err)
 		rsp.ServeHTTP(w, r)
 	}
 	// In the success case, Connect takes over the connection and upgrades to


### PR DESCRIPTION
Fix the newly added unit test `TestExecChangeReady`.

Since we merged the other PR that refactors the logging, the regex needs to be updated. Also, revert a change in `api_tasks.go`; it is supposed to be an internal error instead of not found. In the refactor PR, we should only change the format of the error, not the type.