### PR TITLE
refactor: avoid fmt.Sprintf in logging

### DIFF
--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -1818,12 +1818,12 @@ type fakeLogger struct {
 	noticeCh chan int
 }
 
-func (f *fakeLogger) Notice(msg string) {
-	f.msg = msg
+func (f *fakeLogger) Noticef(format string, v ...any) {
+	f.msg = fmt.Sprintf(format, v...)
 	f.noticeCh <- 1
 }
 
-func (f *fakeLogger) Debug(msg string) {}
+func (f *fakeLogger) Debugf(format string, v ...any) {}
 
 func (s *rebootSuite) TestSyscallRebootError(c *C) {
 	defer FakeSyscallSync(func() {})()

--- a/internals/logger/logger.go
+++ b/internals/logger/logger.go
@@ -57,9 +57,8 @@ var (
 func Panicf(format string, v ...any) {
 	loggerLock.Lock()
 	defer loggerLock.Unlock()
-	msg := fmt.Sprintf(format, v...)
-	logger.Noticef("PANIC %s", msg)
-	panic(msg)
+	logger.Noticef("PANIC "+format, v...)
+	panic(fmt.Sprintf(format, v...))
 }
 
 // Noticef notifies the user of something
@@ -118,7 +117,7 @@ func securityEvent(level string, event SecurityEvent, arg, description string) {
 		// Should never happen, and not much more we can do here.
 		return
 	}
-	logger.Noticef("%s", buf.String())
+	logger.Noticef("%s", buf.Bytes())
 }
 
 type SecurityEvent string

--- a/internals/logger/logger.go
+++ b/internals/logger/logger.go
@@ -198,7 +198,7 @@ func (l *defaultLogger) Noticef(format string, v ...any) {
 	l.buf = append(l.buf, ' ')
 	l.buf = append(l.buf, l.prefix...)
 	l.buf = fmt.Appendf(l.buf, format, v...)
-	if len(l.buf) == 0 || l.buf[len(l.buf)-1] != '\n' {
+	if l.buf[len(l.buf)-1] != '\n' {
 		l.buf = append(l.buf, '\n')
 	}
 	l.w.Write(l.buf)

--- a/internals/logger/logger_benchmark_test.go
+++ b/internals/logger/logger_benchmark_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package logger
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+// BenchmarkLoggerNoticef tests Noticef with string formatting.
+func BenchmarkLoggerNoticef(b *testing.B) {
+	logger := New(io.Discard, "Benchmark: ")
+	SetLogger(logger)
+
+	b.ResetTimer()
+	for b.Loop() {
+		Noticef("Formatted message with number: %d and string: %s", 42, "test")
+	}
+}
+
+// BenchmarkLoggerNoticefConcurrent tests concurrent logging performance.
+func BenchmarkLoggerNoticefConcurrent(b *testing.B) {
+	logger := New(io.Discard, "Benchmark: ")
+	SetLogger(logger)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Noticef("Concurrent message from goroutiner: %d and string: %s", 42, "test")
+		}
+	})
+}
+
+// BenchmarkLoggerNoticefStderr tests Noticef with real os.Stderr output.
+func BenchmarkLoggerNoticefStderr(b *testing.B) {
+	logger := New(os.Stderr, "Benchmark: ")
+	SetLogger(logger)
+
+	b.ResetTimer()
+	for b.Loop() {
+		Noticef("Formatted message with number: %d and string: %s", 42, "test")
+	}
+}
+
+// BenchmarkLoggerNoticefStderrConcurrent tests concurrent logging to os.Stderr.
+func BenchmarkLoggerNoticefStderrConcurrent(b *testing.B) {
+	logger := New(os.Stderr, "Benchmark: ")
+	SetLogger(logger)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Noticef("Concurrent message from goroutiner: %d and string: %s", 42, "test")
+		}
+	})
+}

--- a/internals/logger/logger_benchmark_test.go
+++ b/internals/logger/logger_benchmark_test.go
@@ -16,7 +16,6 @@ package logger
 
 import (
 	"io"
-	"os"
 	"testing"
 )
 
@@ -34,40 +33,6 @@ func BenchmarkLoggerNoticef(b *testing.B) {
 // BenchmarkLoggerNoticefConcurrent tests concurrent logging performance.
 func BenchmarkLoggerNoticefConcurrent(b *testing.B) {
 	logger := New(io.Discard, "Benchmark: ")
-	SetLogger(logger)
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			Noticef("Concurrent message from goroutiner: %d and string: %s", 42, "test")
-		}
-	})
-}
-
-// BenchmarkLoggerNoticefStderr tests Noticef with real os.Stderr output.
-// Run with: BENCH_STDERR=1 go test ./internals/logger -bench=BenchmarkLoggerNoticefStderr -v
-func BenchmarkLoggerNoticefStderr(b *testing.B) {
-	if os.Getenv("BENCH_STDERR") == "" {
-		b.SkipNow() // Silent skip - no message
-	}
-
-	logger := New(os.Stderr, "Benchmark: ")
-	SetLogger(logger)
-
-	b.ResetTimer()
-	for b.Loop() {
-		Noticef("Formatted message with number: %d and string: %s", 42, "test")
-	}
-}
-
-// BenchmarkLoggerNoticefStderrConcurrent tests concurrent logging to os.Stderr.
-// Run with: BENCH_STDERR=1 go test ./internals/logger -bench=BenchmarkLoggerNoticefStderrConcurrent -v
-func BenchmarkLoggerNoticefStderrConcurrent(b *testing.B) {
-	if os.Getenv("BENCH_STDERR") == "" {
-		b.Skip("Skipping stderr benchmark (set BENCH_STDERR=1 to enable)")
-	}
-
-	logger := New(os.Stderr, "Benchmark: ")
 	SetLogger(logger)
 
 	b.ResetTimer()

--- a/internals/logger/logger_benchmark_test.go
+++ b/internals/logger/logger_benchmark_test.go
@@ -45,7 +45,12 @@ func BenchmarkLoggerNoticefConcurrent(b *testing.B) {
 }
 
 // BenchmarkLoggerNoticefStderr tests Noticef with real os.Stderr output.
+// Run with: BENCH_STDERR=1 go test ./internals/logger -bench=BenchmarkLoggerNoticefStderr -v
 func BenchmarkLoggerNoticefStderr(b *testing.B) {
+	if os.Getenv("BENCH_STDERR") == "" {
+		b.SkipNow() // Silent skip - no message
+	}
+
 	logger := New(os.Stderr, "Benchmark: ")
 	SetLogger(logger)
 
@@ -56,7 +61,12 @@ func BenchmarkLoggerNoticefStderr(b *testing.B) {
 }
 
 // BenchmarkLoggerNoticefStderrConcurrent tests concurrent logging to os.Stderr.
+// Run with: BENCH_STDERR=1 go test ./internals/logger -bench=BenchmarkLoggerNoticefStderrConcurrent -v
 func BenchmarkLoggerNoticefStderrConcurrent(b *testing.B) {
+	if os.Getenv("BENCH_STDERR") == "" {
+		b.Skip("Skipping stderr benchmark (set BENCH_STDERR=1 to enable)")
+	}
+
 	logger := New(os.Stderr, "Benchmark: ")
 	SetLogger(logger)
 


### PR DESCRIPTION
Refactor logger to remove `fmt.Sprintf` for performance improvement.

Closes https://github.com/canonical/pebble/issues/679 (see more discussion and perf test here).

A few things worth mentioning:

1. The interface is a breaking change, but I think it doesn't break anything, it's only used by the default logger and a test logger.
2. I removed an unnecessary check `if len(l.buf) == 0` in `defaultLogger.Noticef()` because it will never be true at that point, since we've already appended at least the timestamp.
3. In the `New()` function, I initialized the buffer with an estimated capacity (`buf: make([]byte, 0, 256)`). In the original code, the buffer was not pre-initialized. I think my approach is a slight improvement because in this case, Go doesn't have to guess the initial capacity and reallocate later. Although 256 is also a guess, I think it is better than no allocation right? In perf test, the alloc numbers are the same, but with the preallocation, it's slightly faster, especially when the logs are long. So I'm including this change in this PR.
4. The test against `os.Stderr` is made optional by using an environment variable, because the output would pollute the bench test output, making it harder to see all the results.

There will be a follow-up PR that ports the `appendTimestamp` function from [this PR](https://github.com/canonical/pebble/pull/674/files) to the logger package.