### PR TITLE
chore(golangci-lint): update to latest

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -1,13 +1,17 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
+formatters:
   enable:
     - gci
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - Prefix(github.com/canonical/pebble)
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - Prefix(github.com/canonical/pebble)
+  exclusions:
+    generated: lax
 issues:
   # these values ensure that all issues will be surfaced
   max-issues-per-linter: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,11 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         id: lint
         with:
           version: latest
-          args: '-c .github/.golangci.yml --out-format=colored-line-number'
+          args: '-c .github/.golangci.yml --output.text.path --output.text.print-linter-name --output.text.print-issued-lines --output.text.colors'
           skip-cache: true
 
       - name: Print error message


### PR DESCRIPTION
The current golangci/golangci-lint-action@v3 version used on CI selects an old version of golangci-lint. The problem is that the configuration file in the project is not compatible with the current v2 releases of golangci-lint, which means I cannot run the proposed fix line locally (without downgrading).

Update CI and the configuration to v2 golangci-lint.