### PR TITLE
chore(glangci-lint): pin github workflow for v8 to specific SHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8
         id: lint
         with:
           version: latest


### PR DESCRIPTION
Security policy guidelines will recommend that github workflows pin to known SHA instead of tags to reduce attack surface area for Github marketplace workflows. As tags have been overwritten in some exploits.