### PR TITLE
test(checkstate): fix pluralise incompatible check

### DIFF
--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -329,7 +329,7 @@ func (s *ManagerSuite) TestFailuresBelowThreshold(c *C) {
 		return check.Failures == 0
 	})
 	c.Assert(check.Status, Equals, checkstate.CheckStatusUp)
-	c.Assert(lastTaskLog(s.overlord.State(), check.ChangeID), Matches, `.* INFO succeeded after \d+ failure`)
+	c.Assert(lastTaskLog(s.overlord.State(), check.ChangeID), Matches, `.* INFO succeeded after \d+ failure.*`)
 }
 
 func (s *ManagerSuite) TestPlanChangedSmarts(c *C) {


### PR DESCRIPTION
```sh
FAIL: manager_test.go:297: ManagerSuite.TestFailuresBelowThreshold

manager_test.go:332:
    c.Assert(lastTaskLog(s.overlord.State(), check.ChangeID), Matches, `.* INFO succeeded after \d+ failure`)
... value string = "2025-09-30T12:25:21Z INFO succeeded after 5 failures"
... regex string = ".* INFO succeeded after \\d+ failure"
```

Tweak the test to handle the plural version of the error string.