### PR TITLE
fix: stop "exited" services to avoid spurious restarts

### DIFF
--- a/internals/overlord/servstate/manager.go
+++ b/internals/overlord/servstate/manager.go
@@ -434,15 +434,19 @@ func servicesToStop(m *ServiceManager) ([][]string, error) {
 	defer m.servicesLock.Unlock()
 	var result [][]string
 	for _, services := range stop {
-		var notStopped []string
+		var toStop []string
 		for _, name := range services {
 			s := m.services[name]
-			if s != nil && (s.state == stateStarting || s.state == stateRunning || s.state == stateBackoff) {
-				notStopped = append(notStopped, name)
+			if s == nil {
+				continue
+			}
+			switch s.state {
+			case stateStarting, stateRunning, stateBackoff, stateExited:
+				toStop = append(toStop, name)
 			}
 		}
-		if len(notStopped) > 0 {
-			result = append(result, notStopped)
+		if len(toStop) > 0 {
+			result = append(result, toStop)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
If a service is configured with "on-failure: shutdown" and it fails, Pebble will shut down, but then when Pebble runs again it'll try to redo that "start" task and immediately shut down again. The task is in status 3 (DoingStatus).

This change fixes that bug: it simply adds stateExited to the list of service states we stop when shutting down the daemon, and this cleans up those start tasks in DoingStatus (they'll now be ErrorStatus).

We previously tried to fix this a couple of other ways, but seems simplest and least invasive. See [comments from here down](https://github.com/canonical/pebble/pull/696#pullrequestreview-3250202365).

Fixes #527.