### PR TITLE
fix: avoid error log when daemon retries "exec" tasks on startup

### DIFF
--- a/internals/overlord/cmdstate/handlers.go
+++ b/internals/overlord/cmdstate/handlers.go
@@ -76,7 +76,11 @@ func (m *CommandManager) doExec(task *state.Task, tomb *tomb.Tomb) error {
 	st.Unlock()
 	setup, ok := setupObj.(*execSetup)
 	if !ok || setup == nil {
-		return fmt.Errorf("internal error: cannot get exec setup object for task %q", task.ID())
+		// A previously-run task was in Doing status when the daemon was killed,
+		// and the state engine retries it when the daemon is next restarted.
+		// Just ignore so we don't retry exec tasks.
+		logger.Debugf("Cannot get exec setup object for task %q (retried after restart)", task.ID())
+		return nil
 	}
 
 	// Set up the object that will track the execution.


### PR DESCRIPTION
Exec tasks are not retryable (by design). However, if the Pebble daemon is hard-killed when an exec task is running, then when the daemon is restarted, the state engine tries to run that task (which was in Doing status) again, and returns an error from the task handler.

Simply log this at debug level instead of returning a task error, as it's not an error.

Before:

```
2025-10-20T22:29:41.286Z [pebble] Started daemon.
2025-10-20T22:29:41.287Z [pebble] Change 1 task (Execute command "sleep") failed: internal error: cannot get exec setup object for task "1"
2025-10-20T22:29:41.287Z [pebble] POST /v1/services 982.809µs 400 (http+unix)
2025-10-20T22:29:41.287Z [pebble] Cannot start default services: no default services
```

After:

```
2025-10-20T22:33:28.862Z [pebble] Started daemon.
2025-10-20T22:33:28.865Z [pebble] POST /v1/services 2.696031ms 400 (http+unix)
2025-10-20T22:33:28.866Z [pebble] Cannot start default services: no default services
```

To repro or test:

- Start `pebble run` in one terminal
- Run a long-running exec like `pebble exec sleep 1000` in another terminal
- `kill -9 <pebble_run_pid>`
- Restart `pebble run` and (before the fix) you'll see the error log on startup

Fixes #587