### PR TITLE
ci: upload failed snapcraft build logs

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -102,6 +102,7 @@ jobs:
             ~/.cache/snapcraft/log/
             ~/.local/state/snapcraft/log/
             ${{ env.SNAP_NAME }}_*.txt
+            snapcraft-${{ env.SNAP_NAME }}-*.txt
 
       - name: Attach ${{ steps.build-snap.outputs.snap }} to GH workflow execution
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
When the remote build fails, this log file is not pushed to github

```log
025-12-03 05:57:45.458 Build completed.
Log files: snapcraft-pebble-c1af907944ce9386fa3cf069eee5c5b3_ppc64el_2025-12-03T05:57:44.txt
Artifacts:
2025-12-03 05:57:45.458 Cleaning up
```

hopefully, with the extra info, we'd know better what went wrong.