### PR TITLE
Revert "ci: upload failed snapcraft build logs (#736)"

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -102,7 +102,6 @@ jobs:
             ~/.cache/snapcraft/log/
             ~/.local/state/snapcraft/log/
             ${{ env.SNAP_NAME }}_*.txt
-            snapcraft-${{ env.SNAP_NAME }}-*.txt
 
       - name: Attach ${{ steps.build-snap.outputs.snap }} to GH workflow execution
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This reverts commit abe2132f20582096b781776e8ecc8cdac6098061.

The target filename looks like `snapcraft-pebble-b993bb89325d7459b9f296a16df051f2_s390x_2025-12-04T04:41:14.txt` and GHA artefacts can't have colons in their names.