### PR TITLE
chore: temporarily disable snap builds in the fips branch

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -5,8 +5,9 @@ on:
     branches: [master]
   push:
     branches: [master]
-  release:
-    types: [published]
+  # dimaqq: temporarily disabled in order to create a fake "base" release
+  #release:
+    #types: [published]
 
 # We don't want this workflow to have multiple runs in parallel because
 # what could happen is that a slow-running and older execution will upload


### PR DESCRIPTION
Temporarily disable the snap builds in the FIPS branch.
This is done for two reasons:
- have a commit on the `fips` branch that's not on the `master` branch, so that this commit can be tagged via a dummy release, with the tag not being on the `master` branch
- prevent inadvertently pushing mainline builds into the `fips/` snap track before #734 is merged

https://warthogs.atlassian.net/browse/CHARMTECH-1042?atlOrigin=eyJpIjoiYmRkYjE3ZGVkOWIwNGJlNTkzMjcxZWUyNmExYTQ4ZjIiLCJwIjoiaiJ9