### PR TITLE
ci: temporarily disable ppc64el and s390x snap builds

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -63,6 +63,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        # TODO: temporarily pause ppc64el and s390x builds while builders are broken
+        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
         arch: ["amd64", "arm64", "armhf", "riscv64"]
     steps:
       - name: Checkout Pebble repo
@@ -149,6 +151,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO: temporarily pause ppc64el and s390x builds while builders are broken
+        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
         arch: ["amd64", "arm64", "armhf", "riscv64"]
     steps:
       - uses: actions/download-artifact@v4
@@ -171,6 +175,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO: temporarily pause ppc64el and s390x builds while builders are broken
+        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
         arch: ["amd64", "arm64", "armhf", "riscv64"]
     env:
       TO_TRACK: latest


### PR DESCRIPTION
ppc64el and s390x remote build are broken in our infrastructure at the moment.
This PR disables these architectures for the time being.

ref: https://chat.canonical.com/canonical/pl/mg7gxzii5pydjjx3wjnutpqpne