### PR TITLE
docs: replace redirecting links with the new locations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,8 @@ Pebble releases are tracked in GitHub. To get notified when there's a new releas
 
 Pebble is free software and released under [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).
 
-The Pebble project is sponsored by [Canonical Ltd](https://www.canonical.com).
+The Pebble project is sponsored by [Canonical Ltd](https://canonical.com).
 
-- [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
+- [Code of conduct](https://ubuntu.com/community/docs/ethos/code-of-conduct)
 - [Contribute to the project](https://github.com/canonical/pebble?tab=readme-ov-file#contributing)
 - [Development](https://github.com/canonical/pebble/blob/master/HACKING.md): information on how to run and hack on the Pebble codebase during development

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -34,4 +34,4 @@ For `pebble enter exec`, the `--verbose` flag is currently disallowed. However, 
 
 ## XDG_CONFIG_HOME
 
-The [XDG configuration directory](https://specifications.freedesktop.org/basedir-spec/latest/#basics). Certain Pebble CLI commands create or use data files in `$XDG_CONFIG_HOME/pebble`. Defaults to `$HOME/.config` if not specified.
+The [XDG configuration directory](https://specifications.freedesktop.org/basedir/latest/#basics). Certain Pebble CLI commands create or use data files in `$XDG_CONFIG_HOME/pebble`. Defaults to `$HOME/.config` if not specified.


### PR DESCRIPTION
Fixes #735.

This keeps two Sphinx redirect warnings intentionally:

* `…/issues/new`
  This is the correct entry point for users to file issues. The redirect to the GitHub login page is expected behavior for unauthenticated users, so the warning is harmless.

* `…/release/latest`
  This is preferable to hard-coding a specific tagged release (e.g., `…/releases/tag/v3.6.2`) and ensures the documentation always points to the latest available release.

All other reported warnings have been resolved.
