### PR TITLE
chore: merge master info the fips branch

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -63,7 +63,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        # TODO: temporarily pause ppc64el and s390x builds while builders are broken
+        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        arch: ["amd64", "arm64", "armhf", "riscv64"]
     steps:
       - name: Checkout Pebble repo
         uses: actions/checkout@v4
@@ -149,7 +151,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        # TODO: temporarily pause ppc64el and s390x builds while builders are broken
+        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        arch: ["amd64", "arm64", "armhf", "riscv64"]
     steps:
       - uses: actions/download-artifact@v4
 
@@ -171,7 +175,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        # TODO: temporarily pause ppc64el and s390x builds while builders are broken
+        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        arch: ["amd64", "arm64", "armhf", "riscv64"]
     env:
       TO_TRACK: fips
       TO_RISK: candidate


### PR DESCRIPTION
Specifically the temporary exclusion of ppc64el and s390x snap architectures