### PR TITLE
chore: bump Go to the latest 1.24 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.24.6
+go 1.24.11
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5


### PR DESCRIPTION
Mostly [a bunch of security fixes](https://go.dev/doc/devel/release#go1.24.0).

I assume we'll want to move to 1.25 at some point, but this seems safe to do before a release this week.