### PR TITLE
ci: configure dependabot to alert about security issues

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"  # This is hard-coded to the 1st of the month
+    labels:
+      - "dependencies"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0  # Security updates only
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adds a dependabot configuration similar to ones in other Charm Tech repositories.

* GitHub Actions are checked once per month.
* Go dependencies are checked daily, but only for security releases.
* Only the `dependencies` label is used, not the per-language ones.