### PR TITLE
docs: update the release procedure to include FIPS builds

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -271,12 +271,14 @@ Recommended tone:
 
 To create a new tagged release, go to the [GitHub Releases page](https://github.com/canonical/pebble/releases) and:
 
-- Update `Version` in `cmd/version.go` to the version you're about to publish, for example `v1.9.0`. Push this to master (or open a PR to do so).
+- Update `Version` in `cmd/version.go` to the version you're about to publish, for example `v1.9.0`, open a pull request, have it reviewed and merged into the `master` branch.
+- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged.
 - Click ["Draft a new release"](https://github.com/canonical/pebble/releases/new).
-- Enter the version tag (eg: `v1.9.0`) and select "Create new tag: on publish".
+- Enter the version tag (for example `v1.9.0`) and select "Create new tag: on publish".
 - Enter a release title: include the version tag and a short summary of the release.
 - Write release notes: describe new features and bug fixes, and include a link to the full list of commits.
 - Click "Publish release".
+- Likewise, publish a FIPS release (for example `v1.9.0-fips`) targeting the tip of the `fips` branch.
 - Once the release GitHub Actions have finished, and the new [Snap](https://snapcraft.io/pebble) has been successfully built, update `Version` again to `v1.{next}.0-dev` (for example `v1.10.0-dev`).
 - Find the security scan artifact on the 'SBOM and secscan' run corresponding the pushing the release tag, and upload it to the [SSDLC Pebble folder in Drive](https://drive.google.com/drive/folders/11WR629JFPJ8IMPI0kcsNp_qdf39c6no3). Open the artifact and verify that the security scan has not found any vulnerabilities.
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -49,4 +49,4 @@ Our intention is that projects that build on Pebble can [override how TLS connec
 
 ### FIPS 140
 
-In the future we hope to have [FIPS 140](https://en.wikipedia.org/wiki/FIPS_140)-compliant builds of Pebble, but the official [`pebble` snap](https://snapcraft.io/pebble) is not yet FIPS 140-compliant.
+This project also distributes [FIPS 140](https://en.wikipedia.org/wiki/FIPS_140)-compliant builds of Pebble: the source code is in the `fips` branch and there's the `fips` track for the official [`pebble` snap](https://snapcraft.io/pebble). Refer to [HACKING.md](https://github.com/canonical/pebble/blob/fips/HACKING.md#fips-140-changes) in the `fips` branch for the list of limiations in the FIPS builds.


### PR DESCRIPTION
- note about the FIPS builds in the security doc
- extra steps in the release process to keep the FIPS branch in sync