### PR TITLE
ci: add more debugging when building Go snap to figure out version issue

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,9 @@ parts:
     # If doing a "snapcraft remote-build", ensure you've also run
     # "git add -f ./cmd/VERSION ./cmd/version_generated.go".
     override-build: |
+      which go
+      go version
+      snap info go
       CGO_ENABLED=0 go build -trimpath -ldflags=-w -ldflags=-s -o $CRAFT_PART_INSTALL/bin/pebble ./cmd/pebble
 
   pebble-release-data:


### PR DESCRIPTION
For some reason the latest/edge snap is being built with Go 1.24.4, but it should be using Go 1.24.11. Try to figure out why.