### PR TITLE
ci: use named artefacts per architecture

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -149,9 +149,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test]
-    # if: github.event_name != 'pull_request' && needs.test.result == 'success' && always()
-    # FIXME temp
-    if: needs.test.result == 'success' && always()
+    if: github.event_name != 'pull_request' && needs.test.result == 'success' && always()
     strategy:
       fail-fast: false
       matrix:
@@ -163,20 +161,13 @@ jobs:
         with:
           pattern: pebble-snap-${{ matrix.arch }}
 
-      - name: FIXME debug
-        run: |
-          ls -ld *snap
-          ls -l *snap
-
       - id: get-snap
         run: echo "filename=$(echo ${{ env.SNAP_NAME }}*${{ matrix.arch }}*.snap)" >> $GITHUB_OUTPUT
-
-      - run: ls FIXME-FAIL-HERE
 
       - name: Release ${{ steps.get-snap.outputs.filename }} to ${{ env.DEFAULT_TRACK }}/${{ env.DEFAULT_RISK }}
         uses: snapcore/action-publish@v1
         env:
-          SNAPCRAFT_STORE_CREDENTIALS: FIXME-FAIL-${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.get-snap.outputs.filename }}
           release: ${{ env.DEFAULT_TRACK }}/${{ env.DEFAULT_RISK }}


### PR DESCRIPTION
Since we've merged download-artefact version bump and I tried to fix the local build, the remote build began to fail, because when multiple artefacts are available, download would download all of them, but then unpack into a directory.

Set exact names on the artefacts, so that the test and release step download a single snap, for the specific architecture.