### PR TITLE
docs: improve the release steps, separate out FIPS steps

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -269,17 +269,27 @@ Recommended tone:
 
 ## Creating a release
 
-To create a new tagged release, go to the [GitHub Releases page](https://github.com/canonical/pebble/releases) and:
+When releasing, you need to release the `master` branch and the `fips` branch.
 
-- Update `Version` in `cmd/version.go` to the version you're about to publish, for example `v1.9.0`, open a pull request, have it reviewed and merged into the `master` branch.
-- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged.
-- Click ["Draft a new release"](https://github.com/canonical/pebble/releases/new).
-- Enter the version tag (for example `v1.9.0`) and select "Create new tag: on publish".
+Binaries will be created and uploaded automatically to this release by the [binaries.yml](https://github.com/canonical/pebble/blob/master/.github/workflows/binaries.yml) GitHub Action. In addition, a new Snap version is built and uploaded to the [Snap Store](https://snapcraft.io/pebble) (but promotion to `stable` is a manual step).
+
+Follow these steps:
+
+### Main release (master branch)
+
+- Update `Version` in `cmd/version.go` to the version you're about to publish, for example `v1.27.0`, open a pull request, have it reviewed and merged into the `master` branch.
+- [Draft a new GitHub release](https://github.com/canonical/pebble/releases/new).
+- Enter the version tag (for example `v1.27.0`) and select "Create new tag: on publish".
 - Enter a release title: include the version tag and a short summary of the release.
 - Write release notes: describe new features and bug fixes, and include a link to the full list of commits.
 - Click "Publish release".
-- Likewise, publish a FIPS release (for example `v1.9.0-fips`) targeting the tip of the `fips` branch.
-- Once the release GitHub Actions have finished, and the new [Snap](https://snapcraft.io/pebble) has been successfully built, update `Version` again to `v1.{next}.0-dev` (for example `v1.10.0-dev`).
-- Find the security scan artifact on the 'SBOM and secscan' run corresponding the pushing the release tag, and upload it to the [SSDLC Pebble folder in Drive](https://drive.google.com/drive/folders/11WR629JFPJ8IMPI0kcsNp_qdf39c6no3). Open the artifact and verify that the security scan has not found any vulnerabilities.
+- Monitor the release [GitHub Actions](https://github.com/canonical/pebble/actions) and check that the [snap](https://snapcraft.io/pebble) is uploaded correctly.
+- If you're confident it's a compatible release, [promote the `candidate` snap to `stable`](https://snapcraft.io/pebble/releases).
+- Find the security scan artifact on the corresponding [SBOM and secscan](https://github.com/canonical/pebble/actions/workflows/sbom-secscan.yaml) run, and upload it to the [SSDLC Pebble folder in Drive](https://drive.google.com/drive/folders/11WR629JFPJ8IMPI0kcsNp_qdf39c6no3). Open the artifact and verify that the security scan has not found any vulnerabilities.
 
-Binaries will be created and uploaded automatically to this release by the [binaries.yml](https://github.com/canonical/pebble/blob/master/.github/workflows/binaries.yml) GitHub Actions job. In addition, a new Snap version is built and uploaded to the [Snap Store](https://snapcraft.io/pebble).
+### FIPS release (fips branch)
+
+- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged.
+- Open a second PR on the `fips` branch to bump the `Version` in `cmd/version.go` to the FIPS version, for example `v1.27.0-fips`, and have it reviewed and merged.
+- Publish a FIPS GitHub release (for example `v1.27.0-fips`) targeting the tip of the `fips` branch.
+- As with the main release, monitor the release [GitHub Actions](https://github.com/canonical/pebble/actions), check that the FIPS snap is uploaded, and promote it to stable.


### PR DESCRIPTION
This clarifies a few things in the release steps, and (I think) makes it cleaner by separating out the FIPS steps.