### PR TITLE
refactor: remove octal literals that should have been decimal; use :=

### DIFF
--- a/client/changes_test.go
+++ b/client/changes_test.go
@@ -48,12 +48,12 @@ func (cs *clientSuite) TestClientChange(c *check.C) {
 			Summary:   "...",
 			Status:    "Do",
 			Progress:  client.TaskProgress{Done: 0, Total: 1},
-			SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),
-			ReadyTime: time.Date(2016, 04, 21, 1, 2, 4, 0, time.UTC),
+			SpawnTime: time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC),
+			ReadyTime: time.Date(2016, 4, 21, 1, 2, 4, 0, time.UTC),
 		}},
 
-		SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),
-		ReadyTime: time.Date(2016, 04, 21, 1, 2, 4, 0, time.UTC),
+		SpawnTime: time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC),
+		ReadyTime: time.Date(2016, 4, 21, 1, 2, 4, 0, time.UTC),
 	})
 }
 
@@ -82,11 +82,11 @@ func (cs *clientSuite) TestClientWaitChange(c *check.C) {
 			Summary:   "...",
 			Status:    "Do",
 			Progress:  client.TaskProgress{Done: 0, Total: 1},
-			SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),
-			ReadyTime: time.Date(2016, 04, 21, 1, 2, 4, 0, time.UTC),
+			SpawnTime: time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC),
+			ReadyTime: time.Date(2016, 4, 21, 1, 2, 4, 0, time.UTC),
 		}},
-		SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),
-		ReadyTime: time.Date(2016, 04, 21, 1, 2, 4, 0, time.UTC),
+		SpawnTime: time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC),
+		ReadyTime: time.Date(2016, 4, 21, 1, 2, 4, 0, time.UTC),
 	})
 }
 
@@ -262,8 +262,8 @@ func (cs *clientSuite) TestClientAbort(c *check.C) {
 		Status:  "Hold",
 		Ready:   true,
 
-		SpawnTime: time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC),
-		ReadyTime: time.Date(2016, 04, 21, 1, 2, 4, 0, time.UTC),
+		SpawnTime: time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC),
+		ReadyTime: time.Date(2016, 4, 21, 1, 2, 4, 0, time.UTC),
 	})
 
 	body, err := io.ReadAll(cs.req.Body)

--- a/client/checks.go
+++ b/client/checks.go
@@ -195,7 +195,7 @@ type RefreshCheckResult struct {
 
 // RefreshCheck runs a specific health check immediately.
 func (client *Client) RefreshCheck(opts *RefreshCheckOptions) (*RefreshCheckResult, error) {
-	var payload = struct {
+	payload := struct {
 		Name string `json:"name"`
 	}{
 		Name: opts.Name,

--- a/client/notices.go
+++ b/client/notices.go
@@ -46,7 +46,7 @@ type NotifyOptions struct {
 // Notify records an occurrence of a notice with the specified options,
 // returning the notice ID.
 func (client *Client) Notify(opts *NotifyOptions) (string, error) {
-	var payload = struct {
+	payload := struct {
 		Action      string            `json:"action"`
 		Type        string            `json:"type"`
 		Key         string            `json:"key"`

--- a/client/plan.go
+++ b/client/plan.go
@@ -41,7 +41,7 @@ type AddLayerOptions struct {
 
 // AddLayer adds a layer to the plan's configuration layers.
 func (client *Client) AddLayer(opts *AddLayerOptions) error {
-	var payload = struct {
+	payload := struct {
 		Action  string `json:"action"`
 		Combine bool   `json:"combine"`
 		Inner   bool   `json:"inner"`

--- a/internals/cli/cmd_help.go
+++ b/internals/cli/cmd_help.go
@@ -152,7 +152,7 @@ func (cmd cmdHelp) Execute(args []string) error {
 		return nil
 	}
 
-	var subcmd = cmd.parser.Command
+	subcmd := cmd.parser.Command
 	for _, subname := range cmd.Positional.Subs {
 		subcmd = subcmd.Find(subname)
 		if subcmd == nil {

--- a/internals/daemon/api_changes_test.go
+++ b/internals/daemon/api_changes_test.go
@@ -46,7 +46,7 @@ func setupChanges(st *state.State) []string {
 }
 
 func (s *apiSuite) TestStateChangesDefaultToInProgress(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup
@@ -75,7 +75,7 @@ func (s *apiSuite) TestStateChangesDefaultToInProgress(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChangesInProgress(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup
@@ -104,7 +104,7 @@ func (s *apiSuite) TestStateChangesInProgress(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChangesAll(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup
@@ -133,7 +133,7 @@ func (s *apiSuite) TestStateChangesAll(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChangesReady(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup
@@ -161,7 +161,7 @@ func (s *apiSuite) TestStateChangesReady(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChangesForServiceName(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup
@@ -192,7 +192,7 @@ func (s *apiSuite) TestStateChangesForServiceName(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChange(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup
@@ -261,7 +261,7 @@ func (s *apiSuite) TestStateChange(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChangeAbort(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	soon := 0
@@ -334,7 +334,7 @@ func (s *apiSuite) TestStateChangeAbort(c *check.C) {
 }
 
 func (s *apiSuite) TestStateChangeAbortIsReady(c *check.C) {
-	restore := state.FakeTime(time.Date(2016, 04, 21, 1, 2, 3, 0, time.UTC))
+	restore := state.FakeTime(time.Date(2016, 4, 21, 1, 2, 3, 0, time.UTC))
 	defer restore()
 
 	// Setup

--- a/internals/daemon/api_plan_test.go
+++ b/internals/daemon/api_plan_test.go
@@ -35,7 +35,7 @@ services:
 `
 
 func (s *apiSuite) TestGetPlanErrors(c *C) {
-	var tests = []struct {
+	tests := []struct {
 		url     string
 		status  int
 		message string
@@ -99,7 +99,7 @@ func (s *apiSuite) planLayersHasLen(c *C, expectedLen int) {
 }
 
 func (s *apiSuite) TestLayersErrors(c *C) {
-	var tests = []struct {
+	tests := []struct {
 		payload string
 		status  int
 		message string

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -707,7 +707,7 @@ services:
 
 func (s *S) TestStartFastExitCommand(c *C) {
 	s.newServiceManager(c)
-	var layer = `
+	layer := `
 services:
     test4:
         override: replace
@@ -732,7 +732,7 @@ services:
 
 func (s *S) TestStartFastExitCommandOnFailureIgnore(c *C) {
 	s.newServiceManager(c)
-	var layer = `
+	layer := `
 services:
     test1:
         override: replace

--- a/internals/overlord/state/change.go
+++ b/internals/overlord/state/change.go
@@ -732,8 +732,8 @@ func taskEffectiveStatus(t *Task) Status {
 }
 
 func (c *Change) abortLanes(lanes []int, abortedLanes map[int]bool, seenTasks map[string]bool) {
-	var hasLive = make(map[int]bool)
-	var hasDead = make(map[int]bool)
+	hasLive := make(map[int]bool)
+	hasDead := make(map[int]bool)
 	var laneTasks []*Task
 NextChangeTask:
 	for _, tid := range c.taskIDs {

--- a/internals/overlord/state/change_test.go
+++ b/internals/overlord/state/change_test.go
@@ -755,7 +755,7 @@ func (ts *taskRunnerSuite) TestAbortLanes(c *C) {
 		c.Logf("Expected result: %s", test.result)
 
 		seen = make(map[string]bool)
-		var expected = strings.Fields(test.result)
+		expected := strings.Fields(test.result)
 		var obtained []string
 		for i := 0; i < len(expected); i++ {
 			item := expected[i]
@@ -969,7 +969,7 @@ func (ts *taskRunnerSuite) TestAbortUnreadyLanes(c *C) {
 		c.Logf("Expected result: %s", test.result)
 
 		seen = make(map[string]bool)
-		var expected = strings.Fields(test.result)
+		expected := strings.Fields(test.result)
 		var obtained []string
 		for i := 0; i < len(expected); i++ {
 			item := expected[i]

--- a/internals/timeutil/schedule.go
+++ b/internals/timeutil/schedule.go
@@ -608,7 +608,7 @@ func parseWeekday(s string) (week Week, err error) {
 		return week, fmt.Errorf("cannot parse %q: invalid format", s)
 	}
 
-	var day = s
+	day := s
 	var pos uint
 	if l == 4 {
 		day = s[0:3]


### PR DESCRIPTION
We've decided not to go ahead with gofumpt for now. However, this pulls in the two changes from that test PR (https://github.com/canonical/pebble/pull/723) that I think are obvious and worth pulling in regardless.

- time.Date(2016, 04, 21, ...) -> time.Date(2016, 4, 21, ...); these were always intended to be decimal, so fix that
- use "myvar := foo" instead of "var myvar = foo"; the short form is just good Go style