### PR TITLE
feat!: require admin access for v1/plan

### DIFF
--- a/internals/daemon/api.go
+++ b/internals/daemon/api.go
@@ -61,7 +61,7 @@ var API = []*Command{{
 	POST:        v1PostService,
 }, {
 	Path:       "/v1/plan",
-	ReadAccess: UserAccess{},
+	ReadAccess: AdminAccess{},
 	GET:        v1GetPlan,
 }, {
 	Path:        "/v1/layers",


### PR DESCRIPTION
This is a breaking change that restricts the `/v1/plan` API endpoint to require admin access, for security hardening. In particular, environment variables may contain sensitive data (in the "12 factor" style, for example) and those are exposed in the plan, but should not be available to all Pebble users.

See [OP079](https://docs.google.com/document/d/1DIYLspDRkoIP6Qje009jYpnYHEZodtrDOq19MjY1A44/edit?usp=sharing) for more detail.