### PR TITLE
fix: avoid connection leak when the client disconnects or times out

### DIFF
--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -103,6 +103,11 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 	st.Lock()
 	defer st.Unlock()
 
+	// Check if the request context has been cancelled (e.g., client timeout/disconnect)
+	if r.Context().Err() != nil {
+		return InternalError("request cancelled: %v", r.Context().Err())
+	}
+
 	var taskSet *state.TaskSet
 	var lanes [][]string
 	var services []string


### PR DESCRIPTION
If the remote side has disconnected (timed out, for example) when processing a potentially long-running connection (the various ones served by POST) then immediately exit with an error.

Fixes #784.