### PR TITLE
fix(overlord): initialize loopTomb when loop is started instead of on overlord creation

### DIFF
--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -141,7 +141,6 @@ func New(opts *Options) (*Overlord, error) {
 
 	o := &Overlord{
 		pebbleDir: opts.PebbleDir,
-		loopTomb:  new(tomb.Tomb),
 		inited:    true,
 		extension: opts.Extension,
 	}
@@ -475,6 +474,9 @@ func (o *Overlord) ensureBefore(d time.Duration) {
 // Loop runs a loop in a goroutine to ensure the current state regularly through StateEngine Ensure.
 func (o *Overlord) Loop() {
 	o.ensureTimerSetup()
+	if o.loopTomb == nil {
+		o.loopTomb = new(tomb.Tomb)
+	}
 	o.loopTomb.Go(func() error {
 		for {
 			// TODO: pass a proper context into Ensure
@@ -511,8 +513,11 @@ func (o *Overlord) CanStandby() bool {
 
 // Stop stops the ensure loop and the managers under the StateEngine.
 func (o *Overlord) Stop() error {
-	o.loopTomb.Kill(nil)
-	err := o.loopTomb.Wait()
+	var err error
+	if o.loopTomb != nil {
+		o.loopTomb.Kill(nil)
+		err = o.loopTomb.Wait()
+	}
 	o.stateEng.Stop()
 	return err
 }
@@ -681,8 +686,7 @@ func Fake() *Overlord {
 // testing.
 func FakeWithState(handleRestart func(restart.RestartType)) *Overlord {
 	o := &Overlord{
-		loopTomb: new(tomb.Tomb),
-		inited:   false,
+		inited: false,
 	}
 	s := state.New(fakeBackend{o: o})
 	o.stateEng = NewStateEngine(s)


### PR DESCRIPTION
Overlord `Stop` calls can hang forever if the loop is not started. Initializing a loopTomb without scheduling any routine on it causes the call to its `Wait` during overlord stop to hang forever.

This ports the fix in snapd introduced in this commit with an additional unit test: https://github.com/canonical/snapd/pull/11146/changes/4815875ea89eace1349d30fe863371e251e08ebd