### PR TITLE
docs: fix ResolutionTooDeep error building docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser~=4.0  # pin to 4.x due to ResolutionTooDeep issue
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
This should fix the error `pip._vendor.resolvelib.resolvers.ResolutionTooDeep: 200000` when building docs, due to an issue with myst-parser and dependency resolution.

See example run: https://github.com/canonical/pebble/actions/runs/21045537226/job/60518692360?pr=790