### PR TITLE
docs: note about using a true merge commit for the master->fips merge

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -289,7 +289,7 @@ Follow these steps:
 
 ### FIPS release (fips branch)
 
-- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged.
+- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged. **Important:** merge using a true merge commit, rather than a squash-and-merge commit.
 - Open a second PR on the `fips` branch to bump the `Version` in `cmd/version.go` to the FIPS version, for example `v1.27.0-fips`, and have it reviewed and merged.
 - Publish a FIPS GitHub release (for example `v1.27.0-fips`) targeting the tip of the `fips` branch.
 - As with the main release, monitor the release [GitHub Actions](https://github.com/canonical/pebble/actions), check that the FIPS snap is uploaded, and promote it to stable.


### PR DESCRIPTION
To make it easier to merge changes into the `fips` branch, we should perform merges from master using actual merge commits. Note this in the release docs.

Fixes #795.
