### PR TITLE
chore: add a test to prevent crypto being reintroduced in the fips branch

### DIFF
--- a/tests/dependencies_test.go
+++ b/tests/dependencies_test.go
@@ -19,7 +19,11 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 // packageInfo represents the relevant fields from `go list -json` output
 type packageInfo struct {


### PR DESCRIPTION
Adding a test that uses `go list -deps -json` to scan direct imports and 3rd party library imports and bails if someone accidentally merges in some code that uses cryptographic primitives.