### PR TITLE
fix: don't writeback identity keys when PEBBLE_PERSIST=never

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -33,6 +33,7 @@ import (
 	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/overlord"
 	"github.com/canonical/pebble/internals/overlord/pairingstate"
+	"github.com/canonical/pebble/internals/overlord/tlsstate"
 	"github.com/canonical/pebble/internals/plan"
 	"github.com/canonical/pebble/internals/reaper"
 	"github.com/canonical/pebble/internals/systemd"
@@ -193,10 +194,13 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	plan.RegisterSectionExtension(workloads.WorkloadsField, &workloads.WorkloadsSectionExtension{})
 	plan.RegisterSectionExtension(pairingstate.PairingField, &pairingstate.SectionExtension{})
 
-	idPath := filepath.Join(rcmd.pebbleDir, "identity")
-	idSigner, err := idkey.Get(idPath)
-	if err != nil {
-		return err
+	var idSigner tlsstate.IDSigner
+	if rcmd.HTTPS != "" {
+		var err error
+		idPath := filepath.Join(rcmd.pebbleDir, "identity")
+		if idSigner, err = idkey.Get(idPath); err != nil {
+			return err
+		}
 	}
 
 	dopts := daemon.Options{

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -136,7 +136,8 @@ type Options struct {
 
 	// IDSigner is a private key representing the identity of a Pebble
 	// instance (machine, container or device), which implements the
-	// tlsstate.IDSigner interface (for digest signing).
+	// tlsstate.IDSigner interface (for digest signing). IDSigner is
+	// required if HTTPSAddress is set.
 	IDSigner tlsstate.IDSigner
 
 	// SocketPath is an optional path for the unix socket used for the client

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -1156,3 +1156,13 @@ func (ovs *overlordSuite) TestOverlordStopDoesNotHang(c *C) {
 	fo := overlord.Fake()
 	c.Assert(executesWithinTimeout(fo.Stop, timeout), Equals, true, Commentf("Overlord Stop() is hanging for fake overlord. Call lasted more than timeout: %s", timeout))
 }
+
+func (ovs *overlordSuite) TestNewNoTLSManagerWithoutIDSigner(c *C) {
+	opts := &overlord.Options{
+		PebbleDir: ovs.dir,
+		IDSigner:  nil, // No IDSigner means no TLSManager will be created.
+	}
+	o, err := overlord.New(opts)
+	c.Assert(err, IsNil)
+	c.Assert(o.TLSManager(), IsNil)
+}


### PR DESCRIPTION
Partially fixes, but not completely #801 by not writing to disk when `PEBBLE_PERSIST=never` is set.

Additionally, TLS manager is not created when no HTTPS endpoint is provided as an option on run.