### PR TITLE
ci: fix issues with linting and docs build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,10 +39,9 @@ jobs:
           go-mod-file: 'go.mod'
 
       - name: Install staticcheck
-        # Use @master because of staticcheck tool versioning issues, for example:
-        # "module requires at least go1.24.6, but Staticcheck was built with go1.24.5 (compile)"
+        # Use @<commit> because latest master fails with "requires go >= 1.25.0"
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@master
+          go install honnef.co/go/tools/cmd/staticcheck@b8ec13ce4d00
 
       - name: Run checks
         run: |

--- a/docs/explanation/api-and-clients.md
+++ b/docs/explanation/api-and-clients.md
@@ -10,7 +10,7 @@ The Go client is used primarily by the CLI, but is importable and can be used by
 
 We try to never change the underlying HTTP API in a backwards-incompatible way, however, in rare cases we may change the Go client in a backwards-incompatible way.
 
-There's also a {external+operator:ref}`Python client for the Pebble API <ops_pebble>` that's part of the Ops library used by Juju charms. For more information, see the [source code of the Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py) and {external+operator:ref}`Pebble in the context of Juju charms <run-workloads-with-a-charm-kubernetes>`.
+There's also a {external+operator:ref}`Python client for the Pebble API <ops_pebble>` that's part of the Ops library used by Juju charms. For more information, see the [source code of the Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py) and {external+operator:ref}`Pebble in the context of Juju charms <workload-containers>`.
 
 (api-access-levels)=
 ## API access levels

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,7 +67,7 @@ client.stop_services(["mysvc"])  # Python client also waits for change to finish
 For more information, see:
 
 - [Source code of the Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py)
-- {external+operator:ref}`Pebble in the context of Juju charms <run-workloads-with-a-charm-kubernetes>`
+- {external+operator:ref}`Pebble in the context of Juju charms <workload-containers>`
 
 ## Structure of the API
 


### PR DESCRIPTION
This PR fixes a couple of recent issues with CI:

- fix linting: pin staticcheck to previous version (newest doesn't run on Go 1.24)
- fix docs build: fix doc cross-site links since the workload-k8s page was moved

[Lint error logs](https://github.com/canonical/pebble/actions/runs/22047558495/job/63699089957)

[Docs build error logs](https://app.readthedocs.com/projects/canonical-pebble/builds/3752647/):

```
/home/docs/checkouts/readthedocs.org/user_builds/canonical-pebble/checkouts/684/docs/explanation/api-and-clients.md:13: WARNING: external std:ref reference target not found: run-workloads-with-a-charm-kubernetes
/home/docs/checkouts/readthedocs.org/user_builds/canonical-pebble/checkouts/684/docs/reference/api.md:70: WARNING: external std:ref reference target not found: run-workloads-with-a-charm-kubernetes
```