### PR TITLE
chore: merge master into fips branch for v1.29.0-fips release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,10 +39,9 @@ jobs:
           go-mod-file: 'go.mod'
 
       - name: Install staticcheck
-        # Use @master because of staticcheck tool versioning issues, for example:
-        # "module requires at least go1.24.6, but Staticcheck was built with go1.24.5 (compile)"
+        # Use @<commit> because latest master fails with "requires go >= 1.25.0"
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@master
+          go install honnef.co/go/tools/cmd/staticcheck@b8ec13ce4d00
 
       - name: Run checks
         run: |

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -36,7 +36,7 @@ jobs:
           gocov-xml < coverage.json > .coverage/coverage.xml
 
       - name: TICS GitHub Action
-        uses: tiobe/tics-github-action@768de18bedf164ee461bc9ef5e2f2fa1a20b122a  # 3.7.0
+        uses: tiobe/tics-github-action@faf5066082a31b2517574270b45e3df92aa39a35  # 3.7.1
         with:
           mode: qserver
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects

--- a/HACKING.md
+++ b/HACKING.md
@@ -301,7 +301,7 @@ Follow these steps:
 
 ### FIPS release (fips branch)
 
-- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged.
+- Open a pull request to merge the `master` branch into the `fips` branch, resolve any conflicts, and have it reviewed and merged. **Important:** merge using a true merge commit, rather than a squash-and-merge commit.
 - Open a second PR on the `fips` branch to bump the `Version` in `cmd/version.go` to the FIPS version, for example `v1.27.0-fips`, and have it reviewed and merged.
 - Publish a FIPS GitHub release (for example `v1.27.0-fips`) targeting the tip of the `fips` branch.
 - As with the main release, monitor the release [GitHub Actions](https://github.com/canonical/pebble/actions), check that the FIPS snap is uploaded, and promote it to stable.

--- a/client/checks.go
+++ b/client/checks.go
@@ -109,6 +109,13 @@ type CheckInfo struct {
 	// The change will be of kind "perform-check" if the check is up, or
 	// "recover-check" if it's down.
 	ChangeID string `json:"change-id"`
+
+	// PrevChangeID is the ID of the previous change. For a "recover-check"
+	// change, this is the "perform-check" change that was running before the
+	// check started failing. For a "perform-check" change, this is the
+	// "recover-check" change that was running before the check recovered, or
+	// empty if the check has never had to recover.
+	PrevChangeID string `json:"prev-change-id"`
 }
 
 // Checks fetches information about specific health checks (or all of them),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 //go:generate ./mkversion.sh
 
 // Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.28.0-fips"
+var Version = "v1.29.0-fips"
 
 func MockVersion(version string) (restore func()) {
 	old := Version

--- a/docs/explanation/api-and-clients.md
+++ b/docs/explanation/api-and-clients.md
@@ -10,7 +10,7 @@ The Go client is used primarily by the CLI, but is importable and can be used by
 
 We try to never change the underlying HTTP API in a backwards-incompatible way, however, in rare cases we may change the Go client in a backwards-incompatible way.
 
-There's also a {external+operator:ref}`Python client for the Pebble API <ops_pebble>` that's part of the Ops library used by Juju charms. For more information, see the [source code of the Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py) and {external+operator:ref}`Pebble in the context of Juju charms <run-workloads-with-a-charm-kubernetes>`.
+There's also a {external+operator:ref}`Python client for the Pebble API <ops_pebble>` that's part of the Ops library used by Juju charms. For more information, see the [source code of the Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py) and {external+operator:ref}`Pebble in the context of Juju charms <workload-containers>`.
 
 (api-access-levels)=
 ## API access levels

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,7 +67,7 @@ client.stop_services(["mysvc"])  # Python client also waits for change to finish
 For more information, see:
 
 - [Source code of the Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py)
-- {external+operator:ref}`Pebble in the context of Juju charms <run-workloads-with-a-charm-kubernetes>`
+- {external+operator:ref}`Pebble in the context of Juju charms <workload-containers>`
 
 ## Structure of the API
 

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -307,7 +307,8 @@ paths:
                       "name": "check1",
                       "status": "up",
                       "threshold": 3,
-                      "change-id": "37"
+                      "change-id": "37",
+                      "prev-change-id": "23"
                     }
                   ]
                 }
@@ -1716,6 +1717,9 @@ components:
         change-id:
           type: string
           description: ID of the change associated with the check.
+        prev-change-id:
+          type: string
+          description: ID of the previous change associated with the check.
     logs:
       type: object
       properties:

--- a/internals/cli/cmd_check.go
+++ b/internals/cli/cmd_check.go
@@ -40,16 +40,17 @@ type cmdCheck struct {
 }
 
 type checkInfo struct {
-	Name      string `yaml:"name"`
-	Level     string `yaml:"level,omitempty"`
-	Startup   string `yaml:"startup"`
-	Status    string `yaml:"status"`
-	Successes *int   `yaml:"successes,omitempty"`
-	Failures  int    `yaml:"failures"`
-	Threshold int    `yaml:"threshold"`
-	ChangeID  string `yaml:"change-id,omitempty"`
-	Error     string `yaml:"error,omitempty"`
-	Logs      string `yaml:"logs,omitempty"`
+	Name         string `yaml:"name"`
+	Level        string `yaml:"level,omitempty"`
+	Startup      string `yaml:"startup"`
+	Status       string `yaml:"status"`
+	Successes    *int   `yaml:"successes,omitempty"`
+	Failures     int    `yaml:"failures"`
+	Threshold    int    `yaml:"threshold"`
+	ChangeID     string `yaml:"change-id,omitempty"`
+	PrevChangeID string `yaml:"prev-change-id,omitempty"`
+	Error        string `yaml:"error,omitempty"`
+	Logs         string `yaml:"logs,omitempty"`
 }
 
 func init() {
@@ -68,14 +69,15 @@ func init() {
 
 func checkInfoFromClient(check client.CheckInfo) checkInfo {
 	return checkInfo{
-		Name:      check.Name,
-		Level:     string(check.Level),
-		Startup:   string(check.Startup),
-		Status:    string(check.Status),
-		Successes: check.Successes,
-		Failures:  check.Failures,
-		Threshold: check.Threshold,
-		ChangeID:  check.ChangeID,
+		Name:         check.Name,
+		Level:        string(check.Level),
+		Startup:      string(check.Startup),
+		Status:       string(check.Status),
+		Successes:    check.Successes,
+		Failures:     check.Failures,
+		Threshold:    check.Threshold,
+		ChangeID:     check.ChangeID,
+		PrevChangeID: check.PrevChangeID,
 	}
 }
 
@@ -115,6 +117,12 @@ func (cmd *cmdCheck) Execute(args []string) error {
 			logs, err := cmd.taskLogs(info.ChangeID)
 			if err != nil {
 				return fmt.Errorf("cannot get task logs for change %s: %w", info.ChangeID, err)
+			}
+			if logs == "" && info.PrevChangeID != "" {
+				logs, err = cmd.taskLogs(info.PrevChangeID)
+				if err != nil {
+					return fmt.Errorf("cannot get task logs for change %s: %w", info.PrevChangeID, err)
+				}
 			}
 			info.Logs = logs
 		}

--- a/internals/cli/cmd_checks_test.go
+++ b/internals/cli/cmd_checks_test.go
@@ -178,3 +178,71 @@ func (s *PebbleSuite) TestChecksFails(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Equals, "")
 }
+
+func (s *PebbleSuite) TestChecksPrevChangeLog(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		switch r.URL.Path {
+		case "/v1/checks":
+			fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [{"name": "chk1", "startup": "enabled", "status": "down", "successes": 0, "failures": 3, "threshold": 3, "change-id": "2", "prev-change-id": "1"}]
+}`)
+		case "/v1/changes/2":
+			fmt.Fprint(w, `{
+	"type": "sync",
+	"result": {"id": "2", "kind": "recover-check", "status": "Doing", "tasks": [{"kind": "recover-check", "status": "Doing", "log": []}]}
+}`)
+		case "/v1/changes/1":
+			fmt.Fprint(w, `{
+	"type": "sync",
+	"result": {"id": "1", "kind": "perform-check", "status": "Error", "tasks": [{"kind": "perform-check", "status": "Error", "log": ["2024-04-18T12:16:57Z ERROR connection refused"]}]}
+}`)
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	})
+	rest, err := cli.ParserForTest().ParseArgs([]string{"checks"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+Check  Level  Startup  Status  Successes  Failures  Change
+chk1   -      enabled  down    0          3/3       2 (connection refused)
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestChecksPrevChangeLogTruncated(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		switch r.URL.Path {
+		case "/v1/checks":
+			fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [{"name": "chk1", "startup": "enabled", "status": "down", "successes": 0, "failures": 3, "threshold": 3, "change-id": "2", "prev-change-id": "1"}]
+}`)
+		case "/v1/changes/2":
+			fmt.Fprint(w, `{
+	"type": "sync",
+	"result": {"id": "2", "kind": "recover-check", "status": "Doing", "tasks": [{"kind": "recover-check", "status": "Doing", "log": []}]}
+}`)
+		case "/v1/changes/1":
+			fmt.Fprint(w, `{
+	"type": "sync",
+	"result": {"id": "1", "kind": "perform-check", "status": "Error", "tasks": [{"kind": "perform-check", "status": "Error", "log": ["2024-04-18T12:16:57Z ERROR Get \"http://localhost:8000/\": dial tcp 127.0.0.1:8000: connect: connection refused"]}]}
+}`)
+		default:
+			c.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	})
+	rest, err := cli.ParserForTest().ParseArgs([]string{"checks"})
+	c.Assert(err, check.IsNil)
+	c.Assert(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+Check  Level  Startup  Status  Successes  Failures  Change
+chk1   -      enabled  down    0          3/3       2 (Get "http://localhost:8000/": dial tc... run "pebble tasks 1" for more)
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -28,14 +28,15 @@ import (
 )
 
 type checkInfo struct {
-	Name      string `json:"name"`
-	Level     string `json:"level,omitempty"`
-	Startup   string `json:"startup"`
-	Status    string `json:"status"`
-	Successes int    `json:"successes"`
-	Failures  int    `json:"failures,omitempty"`
-	Threshold int    `json:"threshold"`
-	ChangeID  string `json:"change-id,omitempty"`
+	Name         string `json:"name"`
+	Level        string `json:"level,omitempty"`
+	Startup      string `json:"startup"`
+	Status       string `json:"status"`
+	Successes    int    `json:"successes"`
+	Failures     int    `json:"failures,omitempty"`
+	Threshold    int    `json:"threshold"`
+	ChangeID     string `json:"change-id,omitempty"`
+	PrevChangeID string `json:"prev-change-id,omitempty"`
 }
 
 func v1GetChecks(c *Command, r *http.Request, _ *UserState) Response {
@@ -158,13 +159,14 @@ type responsePayload struct {
 
 func checkInfoFromInternal(check *checkstate.CheckInfo) checkInfo {
 	return checkInfo{
-		Name:      check.Name,
-		Level:     string(check.Level),
-		Startup:   string(check.Startup),
-		Status:    string(check.Status),
-		Successes: check.Successes,
-		Failures:  check.Failures,
-		Threshold: check.Threshold,
-		ChangeID:  check.ChangeID,
+		Name:         check.Name,
+		Level:        string(check.Level),
+		Startup:      string(check.Startup),
+		Status:       string(check.Status),
+		Successes:    check.Successes,
+		Failures:     check.Failures,
+		Threshold:    check.Threshold,
+		ChangeID:     check.ChangeID,
+		PrevChangeID: check.PrevChangeID,
 	}
 }

--- a/internals/daemon/api_checks_test.go
+++ b/internals/daemon/api_checks_test.go
@@ -145,7 +145,7 @@ func (s *apiSuite) getChecks(c *C, query string) (*resp, map[string]any) {
 	err = json.Unmarshal(rec.Body.Bytes(), &body)
 	c.Check(err, IsNil)
 
-	// Standardise the change-id fields before comparison as these can vary.
+	// Standardise the change-id and prev-change-id fields before comparison as these can vary.
 	if results, ok := body["result"].([]any); ok {
 		for i, result := range results {
 			resultMap := result.(map[string]any)
@@ -155,6 +155,8 @@ func (s *apiSuite) getChecks(c *C, query string) (*resp, map[string]any) {
 			} else {
 				resultMap["change-id"] = ""
 			}
+			// Remove prev-change-id for comparison (will be empty in most test scenarios).
+			delete(resultMap, "prev-change-id")
 		}
 	}
 
@@ -325,14 +327,15 @@ checks:
 	}
 
 	c.Check(info, DeepEquals, checkInfo{
-		Name:      "chk1",
-		Level:     "ready",
-		Startup:   "enabled",
-		Status:    "up",
-		Successes: 1,
-		Failures:  0,
-		Threshold: 3,
-		ChangeID:  "C0",
+		Name:         "chk1",
+		Level:        "ready",
+		Startup:      "enabled",
+		Status:       "up",
+		Successes:    1,
+		Failures:     0,
+		Threshold:    3,
+		ChangeID:     "C0",
+		PrevChangeID: "",
 	})
 	c.Check(rsp.Result.(refreshPayload).Error, Equals, "")
 }

--- a/internals/overlord/checkstate/handlers.go
+++ b/internals/overlord/checkstate/handlers.go
@@ -45,6 +45,7 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 	m.checksLock.Lock()
 	data := m.ensureCheck(config.Name)
 	refresh := data.refresh
+	prevChangeID := data.prevChangeID
 	m.checksLock.Unlock()
 
 	chk := newChecker(config)
@@ -60,7 +61,7 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 			// Record check failure and perform any action if the threshold
 			// is reached (for example, restarting a service).
 			details.Failures++
-			m.updateCheckData(config, changeID, details.Successes, details.Failures)
+			m.updateCheckData(config, changeID, prevChangeID, details.Successes, details.Failures)
 
 			m.state.Lock()
 			atThreshold := details.Failures >= config.Threshold
@@ -80,8 +81,10 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 				logger.Noticef("Check %q threshold %d hit, triggering action and recovering", config.Name, config.Threshold)
 				m.callFailureHandlers(config.Name)
 				// Returning the error means perform-check goes to Error status
-				// and logs the error to the task log.
-				return true, err
+				// and logs the error to the task log. We wrap the error to
+				// include details (such as stderr) since the task runner only
+				// logs err.Error().
+				return true, errors.New(errorDetails(err))
 			}
 			return false, err
 		}
@@ -91,14 +94,14 @@ func (m *CheckManager) doPerformCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		if details.Failures > 0 {
 			oldFailures := details.Failures
 			details.Failures = 0
-			m.updateCheckData(config, changeID, details.Successes, details.Failures)
+			m.updateCheckData(config, changeID, prevChangeID, details.Successes, details.Failures)
 
 			m.state.Lock()
 			task.Logf("succeeded after %s", pluralise(oldFailures, "failure", "failures"))
 			task.Set(checkDetailsAttr, &details)
 			m.state.Unlock()
 		} else {
-			m.updateCheckData(config, changeID, details.Successes, details.Failures)
+			m.updateCheckData(config, changeID, prevChangeID, details.Successes, details.Failures)
 
 			m.state.Lock()
 			task.Set(checkDetailsAttr, &details)
@@ -160,6 +163,7 @@ func (m *CheckManager) doRecoverCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 	m.checksLock.Lock()
 	data := m.ensureCheck(config.Name)
 	refresh := data.refresh
+	prevChangeID := data.prevChangeID
 	m.checksLock.Unlock()
 
 	chk := newChecker(config)
@@ -173,7 +177,7 @@ func (m *CheckManager) doRecoverCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		if err != nil {
 			m.incFailureMetric(config)
 			details.Failures++
-			m.updateCheckData(config, changeID, details.Successes, details.Failures)
+			m.updateCheckData(config, changeID, prevChangeID, details.Successes, details.Failures)
 
 			m.state.Lock()
 			task.Set(checkDetailsAttr, &details)
@@ -188,7 +192,7 @@ func (m *CheckManager) doRecoverCheck(task *state.Task, tomb *tombpkg.Tomb) erro
 		m.incSuccessMetric(config)
 		details.Successes = 1
 		details.Failures = 0
-		m.updateCheckData(config, changeID, details.Successes, details.Failures)
+		m.updateCheckData(config, changeID, prevChangeID, details.Successes, details.Failures)
 		details.Proceed = true
 		m.state.Lock()
 		task.Set(checkDetailsAttr, &details)

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -569,7 +569,8 @@ func waitChecks(c *C, mgr *checkstate.CheckManager, expected []*checkstate.Check
 		checks, err = mgr.Checks()
 		c.Assert(err, IsNil)
 		for _, check := range checks {
-			check.ChangeID = "" // clear change ID to avoid comparing it
+			check.ChangeID = ""     // clear change ID to avoid comparing it
+			check.PrevChangeID = "" // clear prev change ID to avoid comparing it
 		}
 		if len(checks) == 0 && len(expected) == 0 || reflect.DeepEqual(checks, expected) {
 			return
@@ -1249,4 +1250,43 @@ func (s *ManagerSuite) TestChecksSuccesses(c *C) {
 		c.Assert(chk.Successes, Not(Equals), 0)
 		return chk.Successes >= 2 && chk.Successes < numSuccesses
 	})
+}
+
+func (s *ManagerSuite) TestPrevChangeIDOnThreshold(c *C) {
+	testPath := c.MkDir() + "/test"
+	err := os.WriteFile(testPath, nil, 0o644)
+	c.Assert(err, IsNil)
+	s.manager.PlanChanged(&plan.Plan{
+		Checks: map[string]*plan.Check{
+			"chk1": {
+				Name:      "chk1",
+				Override:  "replace",
+				Period:    plan.OptionalDuration{Value: 20 * time.Millisecond},
+				Timeout:   plan.OptionalDuration{Value: 100 * time.Millisecond},
+				Threshold: 3,
+				Exec: &plan.ExecCheck{
+					Command: fmt.Sprintf(`/bin/sh -c '[ ! -f %s ]'`, testPath),
+				},
+			},
+		},
+	})
+
+	check := waitCheck(c, s.manager, "chk1", func(check *checkstate.CheckInfo) bool {
+		return check.Status == checkstate.CheckStatusUp && check.Failures >= 1
+	})
+	performChangeID := check.ChangeID
+	c.Assert(check.PrevChangeID, Equals, "")
+
+	check = waitCheck(c, s.manager, "chk1", func(check *checkstate.CheckInfo) bool {
+		return check.Status == checkstate.CheckStatusDown
+	})
+	c.Assert(check.PrevChangeID, Equals, performChangeID)
+	recoverChangeID := check.ChangeID
+
+	err = os.Remove(testPath)
+	c.Assert(err, IsNil)
+	check = waitCheck(c, s.manager, "chk1", func(check *checkstate.CheckInfo) bool {
+		return check.Status == checkstate.CheckStatusUp && check.ChangeID != recoverChangeID
+	})
+	c.Assert(check.PrevChangeID, Equals, recoverChangeID)
 }

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -255,7 +255,7 @@ func New(opts *Options) (*Overlord, error) {
 	// Load the plan from the Pebble layers directory (which may be missing
 	// or have no layers, resulting in an empty plan), and propagate PlanChanged
 	// notifications to all notification subscribers.
-	err = o.planMgr.Load()
+	err = o.planMgr.Load(nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load plan: %w", err)
 	}

--- a/internals/overlord/planstate/manager.go
+++ b/internals/overlord/planstate/manager.go
@@ -15,7 +15,6 @@
 package planstate
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -55,8 +54,8 @@ func NewManager(layersDir string) (*PlanManager, error) {
 // Load reads plan layers from the pebble directory, combines and validates the
 // final plan, and finally notifies registered managers of the plan update. In
 // the case of a non-existent layers directory, or no layers in the layers
-// directory, an empty plan is announced to change subscribers.
-func (m *PlanManager) Load() (err error) {
+// directory, the base plan (or an empty plan) is announced to change subscribers.
+func (m *PlanManager) Load(base *plan.Plan) (err error) {
 	m.planLock.Lock()
 
 	var p *plan.Plan
@@ -72,36 +71,8 @@ func (m *PlanManager) Load() (err error) {
 		return nil
 	}
 
-	p, err = plan.ReadDir(m.layersDir)
+	p, err = plan.ReadDir(m.layersDir, base)
 	if err != nil {
-		return err
-	}
-	m.plan = p
-	m.isLoaded = true
-	return nil
-}
-
-// Init loads the plan from an existing instance and announces to
-// change subscribers.
-func (m *PlanManager) Init(p *plan.Plan) (err error) {
-	m.planLock.Lock()
-
-	wasLoaded := m.isLoaded
-	defer func() {
-		m.planLock.Unlock()
-		if err == nil && !wasLoaded {
-			m.callChangeListeners(p)
-		}
-	}()
-
-	if m.isLoaded {
-		return nil
-	}
-	if p == nil {
-		return errors.New("cannot initialize plan manager with a nil plan")
-	}
-
-	if err := p.Validate(); err != nil {
 		return err
 	}
 	m.plan = p
@@ -294,6 +265,18 @@ func (m *PlanManager) updatePlanLayers(layers []*plan.Layer) (*plan.Plan, error)
 	if err != nil {
 		return nil, err
 	}
+
+	for name, oldSection := range m.plan.Sections {
+		if immutable, ok := oldSection.(plan.ImmutableSection); ok {
+			newSection := p.Sections[name]
+			if !immutable.Equal(newSection) {
+				return nil, &plan.FormatError{
+					Message: fmt.Sprintf("cannot change immutable section %q", name),
+				}
+			}
+		}
+	}
+
 	m.plan = p
 	return p, nil
 }

--- a/internals/plan/extensions_test.go
+++ b/internals/plan/extensions_test.go
@@ -399,7 +399,7 @@ nexttest:
 		}
 
 		// Load the plan layer from disk (parse, combine and validate).
-		p, err := plan.ReadDir(layersDir)
+		p, err := plan.ReadDir(layersDir, nil)
 		if testData.error != "" || err != nil {
 			// Expected error.
 			c.Assert(err, ErrorMatches, testData.error)

--- a/internals/workloads/workloads_test.go
+++ b/internals/workloads/workloads_test.go
@@ -271,7 +271,6 @@ func (s *workloadsSuite) TestWorkloadsSectionExtensionSchema(c *C) {
 			c.Assert(ws, DeepEquals, t.combinedSection)
 			c.Assert(layerYAML(c, combined), Equals, strings.TrimSpace(t.combinedYAML))
 		}
-
 	}
 }
 


### PR DESCRIPTION
This merges from master and bumps the version number to `v1.29.0-fips` (no conflicts apart from the version number).