### PR TITLE
fix(servstate): prevent deadlock in TestStartFastExitCommand

### DIFF
--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -706,6 +706,9 @@ services:
 }
 
 func (s *S) TestStartFastExitCommand(c *C) {
+	restore := servstate.FakeOkayWait(2 * time.Second)
+	defer restore()
+
 	s.newServiceManager(c)
 	layer := `
 services:
@@ -719,12 +722,20 @@ services:
 	chg := s.startServices(c, [][]string{{"test4"}})
 
 	s.st.Lock()
-	c.Check(chg.Status(), Equals, state.ErrorStatus)
-	c.Check(chg.Err(), ErrorMatches, `(?s).*\n- Start service "test4" \(service start attempt: exited quickly with code 0, will restart\)`)
-	c.Check(chg.Tasks()[0].Log(), HasLen, 2)
-	c.Check(chg.Tasks()[0].Log()[0], Matches, `(?s).* INFO Most recent service output:\n    too-fast\n    second line`)
-	c.Check(chg.Tasks()[0].Log()[1], Matches, `.* ERROR service start attempt: exited quickly with code 0, will restart`)
+	status := chg.Status()
+	err := chg.Err()
+	tasks := chg.Tasks()
+	var logs []string
+	if len(tasks) > 0 {
+		logs = tasks[0].Log()
+	}
 	s.st.Unlock()
+
+	c.Check(status, Equals, state.ErrorStatus)
+	c.Check(err, ErrorMatches, `(?s).*\n- Start service "test4" \(service start attempt: exited quickly with code 0, will restart\)`)
+	c.Assert(logs, HasLen, 2)
+	c.Check(logs[0], Matches, `(?s).* INFO Most recent service output:\n    too-fast\n    second line`)
+	c.Check(logs[1], Matches, `.* ERROR service start attempt: exited quickly with code 0, will restart`)
 
 	svc := s.serviceByName(c, "test4")
 	c.Assert(svc.Current, Equals, servstate.StatusBackoff)


### PR DESCRIPTION
During a test run in CI/CD I noticed twice that this test panics and exits after 10 minutes:
```
2026-03-09T20:09:00.680Z [test] Service "test4" on-success action is "restart", waiting ~30s before restart (backoff 24)
panic: test timed out after 10m0s
	running tests:
		Test (10m0s)
```

It lasts 10 minutes since it goes into a deadlock and times out. Looking through the logs, the reason is a panic while accessing the logs in the code below, as we use `c.Check` which carries on when the check fails for the number of logs, then attempts to access a non-existing item panicing and causing go.check to recover the test and go into cleanup:
```
	c.Check(chg.Tasks()[0].Log(), HasLen, 2)
	c.Check(chg.Tasks()[0].Log()[0], Matches, `(?s).* INFO Most recent service output:\n    too-fast\n    second line`)
```
Since we already have the lock before we panic, when trying to clean up, we can not acquire the state lock, and we go into a deadlock, timing out after 10 minutes.

Switching the check to assert solves the deadlock; an additional change to read the logs and release the lock before we do the checks is also done to avoid deadlocking elsewhere.

It seems the test fail as the service is not starting within the configured "OkayWait" of 50 ms. Therefore, the timeout has also been increased to 2 seconds to avoid future failures altogether.