### PR TITLE
fix(checkstate): ensure the test check fails once only

### DIFF
--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -309,7 +309,7 @@ func (s *ManagerSuite) TestFailuresBelowThreshold(c *C) {
 				Timeout:   plan.OptionalDuration{Value: 100 * time.Millisecond},
 				Threshold: threshold,
 				Exec: &plan.ExecCheck{
-					Command: fmt.Sprintf(`/bin/sh -c '[ ! -f %s ]'`, testPath),
+					Command: fmt.Sprintf(`/bin/sh -c '[ ! -f %[1]s ] || { rm -f %[1]s; exit 1; }'`, testPath),
 				},
 			},
 		},
@@ -322,9 +322,6 @@ func (s *ManagerSuite) TestFailuresBelowThreshold(c *C) {
 	c.Assert(check.Status, Equals, checkstate.CheckStatusUp)
 	c.Assert(lastTaskLog(s.overlord.State(), check.ChangeID), Matches, ".* ERROR exit status 1")
 
-	// Should reset number of failures if command then succeeds
-	err = os.Remove(testPath)
-	c.Assert(err, IsNil)
 	check = waitCheck(c, s.manager, "chk1", func(check *checkstate.CheckInfo) bool {
 		return check.Failures == 0
 	})


### PR DESCRIPTION
Currently, if `os.Remove` takes longer than the configured timeout, we could hit the configured threshold on very slow disks. This change guarantees the first check removes the file ensuring at most one failure