### PR TITLE
ci: fix the Trivy scan, and add Go standard library scanning

### DIFF
--- a/.github/trivy-comprehensive.yaml
+++ b/.github/trivy-comprehensive.yaml
@@ -1,5 +1,6 @@
-timeout: 20m
+timeout: 30m
 scan:
+  detection-priority: comprehensive
   # This does not impact the database, which is always downloaded, only extra
   # files, and all the Go checks work in offline mode.
   offline-scan: true

--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -2,3 +2,6 @@ timeout: 20m
 ignore-file: .github/.trivyignore
 scan:
   detection-priority: comprehensive
+  # This does not impact the database, which is always downloaded, only extra
+  # files, and all the Go checks work in offline mode.
+  offline-scan: true

--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -1,4 +1,2 @@
 timeout: 20m
-scan:
-  offline-scan: true
 ignore-file: .github/.trivyignore

--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -1,7 +1,7 @@
 timeout: 20m
-ignore-file: .github/.trivyignore
 scan:
   detection-priority: comprehensive
   # This does not impact the database, which is always downloaded, only extra
   # files, and all the Go checks work in offline mode.
   offline-scan: true
+ignore-file: .github/.trivyignore

--- a/.github/trivy.yaml
+++ b/.github/trivy.yaml
@@ -1,2 +1,4 @@
 timeout: 20m
 ignore-file: .github/.trivyignore
+scan:
+  detection-priority: comprehensive

--- a/.github/workflows/comprehensive-scanning.yml
+++ b/.github/workflows/comprehensive-scanning.yml
@@ -1,0 +1,28 @@
+name: Vulnerability scanning
+
+on:
+  schedule:
+    - cron: '28 6 25 * *'
+  workflow_dispatch:
+
+jobs:
+  scan:
+    name: Scan for fixable vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Github Trivy FS Action
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          exit-code: '1'
+          ignore-unfixed: true
+          trivy-config: .github/trivy-comprehensive.yaml
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          # TODO: Remove the whole "env" section when the issue below is resolved.
+          # Known issue: aquasecurity/trivy-action#389.
+          # Workaround: https://github.com/orgs/community/discussions/139074#discussioncomment-10808081.

--- a/.github/workflows/scanning.yml
+++ b/.github/workflows/scanning.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
+          exit-code: '1'
           trivy-config: .github/trivy.yaml
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db


### PR DESCRIPTION
In #817, it's mentioned that we're missing alerts about (theoretical and likely not impacting Pebble) CVEs in Go's standard library (we've also had this come up before with other reports).

When we were finding issues, we never did anything about it -- you would never know unless you actually looked at the raw output from the check. This PR changes the settings so that the check fails (Trivy exits with a failure code) if there are vulnerability findings.

The comprehensive detection priority option needs to be enabled [for Trivy to find issues that come from the Go standard library](https://trivy.dev/docs/latest/guide/coverage/language/golang/#gomod-stdlib). This is because it's not always the case that the Go version can be determined (but we can be sure that it will be in our case).

Turning on checks for standard library issues will result in more false positives being reported. As has been discussed many times (and is also called out in the Trivy doc linked above), the tool is crude and cannot tell whether the issue from the standard library (or any dependency) actually impacts how it is used in Pebble.

However, I think it's worth knowing about these anyway, because the team gets reports about the issues because the same sorts of scanning software are also being used in projects that make use of Pebble. We're actually better placed to decide on how urgent the fix is than someone downstream, and it looks better if we are aware of the issue. Knowing about it doesn't mean that we have to implement a fix (often just bumping the Go version) or do a release earlier than we would otherwise. So I would argue that despite additional noise, there is enough signal to make this worthwhile.

However, blocking PRs due to something outside of that PR's changes doesn't make sense. So this PR leaves the existing scanning (which excludes the Go standard library) in place (other than the exit code fix), and adds a separate scan that is done towards the end of the month, in time to decide how to handle any findings before the (presumed) release.