### PR TITLE
chore: add missing exec subcommand to enter supporting list

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -35,7 +35,7 @@ There are several ways to install Pebble. The easiest way to ensure that you get
 
 ### Basic identity type
 
-For the "basic" [identity](/reference/identities) type, Pebble uses Ulrich Drepper's [SHA-crypt algorithm](https://www.akkadia.org/drepper/SHA-crypt.txt) with SHA-512. Specifically, we use the third party Go library [github.com/GehirnInc/crypt](https://github.com/Gehirninc/crypt) for verifying the password hashes sent in a client's `Authorization` HTTP header.
+For the "basic" [identity](/reference/identities) type, Pebble uses Ulrich Drepper's SHA-crypt algorithm with SHA-512. Specifically, we use the third party Go library [github.com/GehirnInc/crypt](https://github.com/Gehirninc/crypt) for verifying the password hashes sent in a client's `Authorization` HTTP header.
 
 ### TLS
 

--- a/internals/cli/cmd_enter.go
+++ b/internals/cli/cmd_enter.go
@@ -38,6 +38,7 @@ These subcommands are currently supported:
   plan      (1)(2)
   services  (1)(2)
   ls        (1)(2)
+  exec      (1)
   start     (3)
   stop      (3)
 


### PR DESCRIPTION
This pull request adds the `exec` subcommand to the list of supported subcommands in the CLI documentation of `pebble help enter`.

Fixes #805 