### PR TITLE
ci: use a dedicated GitHub environment for the snap build

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   local-build:
     runs-on: ubuntu-latest
+    environment: snap-build
     # PRS usually come from forks, which are not allowed to access repo secrets.
     # So this job builds the snap locally, and not via LP.
     if: github.event_name == 'pull_request'

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -21,7 +21,6 @@ env:
 jobs:
   local-build:
     runs-on: ubuntu-latest
-    environment: snap-build
     # PRS usually come from forks, which are not allowed to access repo secrets.
     # So this job builds the snap locally, and not via LP.
     if: github.event_name == 'pull_request'
@@ -60,6 +59,7 @@ jobs:
 
   remote-build:
     runs-on: ubuntu-latest
+    environment: snap-build
     if: github.event_name != 'pull_request'
     strategy:
       fail-fast: true
@@ -149,6 +149,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    environment: snap-build
     needs: [test]
     if: github.event_name != 'pull_request' && needs.test.result == 'success' && always()
     strategy:
@@ -175,6 +176,7 @@ jobs:
 
   promote:
     runs-on: ubuntu-latest
+    environment: snap-build
     needs: [release]
     if: github.event_name == 'release' && needs.release.result == 'success' && always()
     strategy:


### PR DESCRIPTION
This PR sets the `snap` workflow to use a dedicated `snap-build` GitHub environment. Primarily, this lets us put the required secrets in that environment, so they are available to this workflow but not any others.

I have created the environment already, so everything should be good to go.