### PR TITLE
test: introduce helper osutil.isTestBinary to support use of dlv debug

### DIFF
--- a/internals/osutil/io.go
+++ b/internals/osutil/io.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/canonical/x-go/randutil"
 
@@ -41,7 +40,7 @@ const (
 // Allow disabling sync for testing. This brings massive improvements on
 // certain filesystems (like btrfs) and very much noticeable improvements in
 // all unit tests in general.
-var unsafeIO bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") && os.Getenv("UNSAFE_IO") == "1"
+var unsafeIO bool = IsTestBinary() && os.Getenv("UNSAFE_IO") == "1"
 
 // For testing
 var randomString = randutil.RandomString

--- a/internals/osutil/testhelper.go
+++ b/internals/osutil/testhelper.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package osutil
+
+import (
+	"os"
+	"regexp"
+)
+
+// Match binary names from both go test and dlv test.
+var goTestExeRe = regexp.MustCompile(`^.*/(.*go-build.*/.*\.test|debug\.test\d+)$`)
+
+// IsTestBinary checks whether the current process is a go test binary.
+func IsTestBinary() bool {
+	return len(os.Args) > 0 && goTestExeRe.MatchString(os.Args[0])
+}

--- a/internals/osutil/testhelper_test.go
+++ b/internals/osutil/testhelper_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2014-2015 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package osutil_test
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/osutil"
+)
+
+type testhelperSuite struct{}
+
+var _ = Suite(&testhelperSuite{})
+
+func mockOsArgs(args []string) (restore func()) {
+	old := os.Args
+	os.Args = args
+	return func() {
+		os.Args = old
+	}
+}
+
+func (s *testhelperSuite) TestIsTestBinary(c *C) {
+	// obvious case
+	c.Assert(osutil.IsTestBinary(), Equals, true)
+
+	defer mockOsArgs([]string{"foo", "bar", "baz"})()
+	c.Assert(osutil.IsTestBinary(), Equals, false)
+}
+
+func (s *testhelperSuite) TestBinaryNoRegressionWithValidApp(c *C) {
+	// Support go test binary
+	defer mockOsArgs([]string{"/go-build/some-snap.test", "bar", "baz"})()
+	c.Assert(osutil.IsTestBinary(), Equals, true)
+	// Support dlv test binary
+	defer mockOsArgs([]string{"/cwd/pebble/debug.test1234", "bar", "baz"})()
+	c.Assert(osutil.IsTestBinary(), Equals, true)
+}

--- a/internals/progress/progress.go
+++ b/internals/progress/progress.go
@@ -17,9 +17,10 @@ package progress
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"golang.org/x/term"
+
+	"github.com/canonical/pebble/internals/osutil"
 )
 
 // Meter is an interface to show progress to the user
@@ -77,7 +78,7 @@ func MockMeter(meter Meter) func() {
 	}
 }
 
-var inTesting bool = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test") || os.Getenv("SPREAD_SYSTEM") != ""
+var inTesting bool = osutil.IsTestBinary() || os.Getenv("SPREAD_SYSTEM") != ""
 
 // MakeProgressBar creates an appropriate progress.Meter for the environ in
 // which it is called:


### PR DESCRIPTION
Ensure a common test utility function is used which supports both
go test and dlv test binaries. Simplify existing conditionals in
progress.go and io.go.

This common functionality is also used in both snapd and tako.