### PR TITLE
chore: bump Go version to 1.26.2 to address govulncheck CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5


### PR DESCRIPTION
This addresses several CVEs raised by govulncheck due to the fact that we're still running CI with Go 1.26.1. The CVEs are fixed in Go 1.26.2.