### PR TITLE
feat(cli): add structured output formats to notice commands

### DIFF
--- a/client/notices.go
+++ b/client/notices.go
@@ -151,7 +151,8 @@ type jsonNotice struct {
 	ExpireAfter string `json:"expire-after,omitempty"`
 }
 
-// MarshalJSON is needed because the default JSON marshaler encodes time.Duration fields (RepeatAfter, ExpireAfter) as nanoseconds.
+// MarshalJSON is needed because the default JSON marshaler encodes
+// time.Duration fields (RepeatAfter, ExpireAfter) as nanoseconds.
 func (n Notice) MarshalJSON() ([]byte, error) {
 	type rawNotice Notice
 	raw := struct {

--- a/client/notices.go
+++ b/client/notices.go
@@ -115,17 +115,17 @@ const (
 // and Key, the previous notice is updated appropriately instead of a new one
 // being created.
 type Notice struct {
-	ID            string            `json:"id"`
-	UserID        *uint32           `json:"user-id"`
-	Type          NoticeType        `json:"type"`
-	Key           string            `json:"key"`
-	FirstOccurred time.Time         `json:"first-occurred"`
-	LastOccurred  time.Time         `json:"last-occurred"`
-	LastRepeated  time.Time         `json:"last-repeated"`
-	Occurrences   int               `json:"occurrences"`
-	LastData      map[string]string `json:"last-data,omitempty"`
-	RepeatAfter   time.Duration     `json:"repeat-after,omitempty"`
-	ExpireAfter   time.Duration     `json:"expire-after,omitempty"`
+	ID            string            `json:"id" yaml:"id"`
+	UserID        *uint32           `json:"user-id" yaml:"user-id"`
+	Type          NoticeType        `json:"type" yaml:"type"`
+	Key           string            `json:"key" yaml:"key"`
+	FirstOccurred time.Time         `json:"first-occurred" yaml:"first-occurred"`
+	LastOccurred  time.Time         `json:"last-occurred" yaml:"last-occurred"`
+	LastRepeated  time.Time         `json:"last-repeated" yaml:"last-repeated"`
+	Occurrences   int               `json:"occurrences" yaml:"occurrences"`
+	LastData      map[string]string `json:"last-data,omitempty" yaml:"last-data,omitempty"`
+	RepeatAfter   time.Duration     `json:"repeat-after,omitempty" yaml:"repeat-after,omitempty"`
+	ExpireAfter   time.Duration     `json:"expire-after,omitempty" yaml:"expire-after,omitempty"`
 }
 
 type NoticeType string

--- a/client/notices.go
+++ b/client/notices.go
@@ -151,6 +151,23 @@ type jsonNotice struct {
 	ExpireAfter string `json:"expire-after,omitempty"`
 }
 
+// MarshalJSON is needed because the default JSON marshaler encodes time.Duration fields (RepeatAfter, ExpireAfter) as nanoseconds.
+func (n Notice) MarshalJSON() ([]byte, error) {
+	type rawNotice Notice
+	raw := struct {
+		rawNotice
+		RepeatAfter string `json:"repeat-after,omitempty"`
+		ExpireAfter string `json:"expire-after,omitempty"`
+	}{rawNotice: rawNotice(n)}
+	if n.RepeatAfter != 0 {
+		raw.RepeatAfter = n.RepeatAfter.String()
+	}
+	if n.ExpireAfter != 0 {
+		raw.ExpireAfter = n.ExpireAfter.String()
+	}
+	return json.Marshal(raw)
+}
+
 // This is used to ensure we send a well-formed notice ID in the URL path.
 // It's a little more permissive than the currently-valid notice IDs (which
 // are always integers), but it will allow older clients to talk to newer

--- a/client/notices_test.go
+++ b/client/notices_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/pebble/client"
 )
@@ -254,4 +255,51 @@ func (cs *clientSuite) TestNoticeMarshalJSON(c *C) {
 	data, err = json.Marshal(notice)
 	c.Assert(err, IsNil)
 	c.Check(string(data), Equals, `{"id":"123","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T15:43:00Z","last-occurred":"2023-09-05T17:43:00Z","last-repeated":"2023-09-05T16:43:00Z","occurrences":7}`)
+}
+
+func (cs *clientSuite) TestNoticeMarshalYAML(c *C) {
+	uid := uint32(1000)
+	notice := client.Notice{
+		ID:            "123",
+		UserID:        &uid,
+		Type:          client.CustomNotice,
+		Key:           "a.b/c",
+		FirstOccurred: time.Date(2023, 9, 5, 15, 43, 0, 0, time.UTC),
+		LastOccurred:  time.Date(2023, 9, 5, 17, 43, 0, 0, time.UTC),
+		LastRepeated:  time.Date(2023, 9, 5, 16, 43, 0, 0, time.UTC),
+		Occurrences:   7,
+		LastData:      map[string]string{"k": "v"},
+		RepeatAfter:   time.Hour,
+		ExpireAfter:   7 * 24 * time.Hour,
+	}
+	data, err := yaml.Marshal(notice)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, `id: "123"
+user-id: 1000
+type: custom
+key: a.b/c
+first-occurred: 2023-09-05T15:43:00Z
+last-occurred: 2023-09-05T17:43:00Z
+last-repeated: 2023-09-05T16:43:00Z
+occurrences: 7
+last-data:
+    k: v
+repeat-after: 1h0m0s
+expire-after: 168h0m0s
+`)
+
+	notice.RepeatAfter = 0
+	notice.ExpireAfter = 0
+	notice.LastData = nil
+	data, err = yaml.Marshal(notice)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, `id: "123"
+user-id: 1000
+type: custom
+key: a.b/c
+first-occurred: 2023-09-05T15:43:00Z
+last-occurred: 2023-09-05T17:43:00Z
+last-repeated: 2023-09-05T16:43:00Z
+occurrences: 7
+`)
 }

--- a/client/notices_test.go
+++ b/client/notices_test.go
@@ -228,3 +228,30 @@ func (cs *clientSuite) TestWaitNoticesTimeout(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(notices, HasLen, 0)
 }
+
+func (cs *clientSuite) TestNoticeMarshalJSON(c *C) {
+	uid := uint32(1000)
+	notice := client.Notice{
+		ID:            "123",
+		UserID:        &uid,
+		Type:          client.CustomNotice,
+		Key:           "a.b/c",
+		FirstOccurred: time.Date(2023, 9, 5, 15, 43, 0, 0, time.UTC),
+		LastOccurred:  time.Date(2023, 9, 5, 17, 43, 0, 0, time.UTC),
+		LastRepeated:  time.Date(2023, 9, 5, 16, 43, 0, 0, time.UTC),
+		Occurrences:   7,
+		LastData:      map[string]string{"k": "v"},
+		RepeatAfter:   time.Hour,
+		ExpireAfter:   7 * 24 * time.Hour,
+	}
+	data, err := json.Marshal(notice)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, `{"id":"123","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T15:43:00Z","last-occurred":"2023-09-05T17:43:00Z","last-repeated":"2023-09-05T16:43:00Z","occurrences":7,"last-data":{"k":"v"},"repeat-after":"1h0m0s","expire-after":"168h0m0s"}`)
+
+	notice.RepeatAfter = 0
+	notice.ExpireAfter = 0
+	notice.LastData = nil
+	data, err = json.Marshal(notice)
+	c.Assert(err, IsNil)
+	c.Check(string(data), Equals, `{"id":"123","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T15:43:00Z","last-occurred":"2023-09-05T17:43:00Z","last-repeated":"2023-09-05T16:43:00Z","occurrences":7}`)
+}

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -508,8 +508,9 @@ The notice command fetches a single notice, either by ID (1-arg variant), or
 by unique type and key combination (2-arg variant).
 
 [notice command options]
-      --uid=            Look up notice from user with this UID (admin only;
-                        2-arg variant only)
+      --format=[text|json|yaml]   Output format (default: text)
+      --uid=                      Look up notice from user with this UID (admin
+                                  only; 2-arg variant only)
 ```
 <!-- END AUTOMATED OUTPUT FOR notice -->
 
@@ -577,15 +578,21 @@ can use --users=all to view notice with any user ID, or --uid=UID to view
 another user's notices.
 
 [notices command options]
-      --abs-time    Display absolute times (in RFC 3339 format). Otherwise,
-                    display relative times up to 60 days, then YYYY-MM-DD.
-      --users=      The only valid value is 'all', which lists notices with any
-                    user ID (admin only; cannot be used with --uid)
-      --uid=        Only list notices with this user ID (admin only; cannot be
-                    used with --users)
-      --type=       Only list notices of this type (multiple allowed)
-      --key=        Only list notices with this key (multiple allowed)
-      --timeout=    Wait up to this duration for matching notices to arrive
+      --abs-time                  Display absolute times (in RFC 3339 format).
+                                  Otherwise, display relative times up to 60
+                                  days, then YYYY-MM-DD.
+      --format=[text|json|yaml]   Output format (default: text)
+      --users=                    The only valid value is 'all', which lists
+                                  notices with any user ID (admin only; cannot
+                                  be used with --uid)
+      --uid=                      Only list notices with this user ID (admin
+                                  only; cannot be used with --users)
+      --type=                     Only list notices of this type (multiple
+                                  allowed)
+      --key=                      Only list notices with this key (multiple
+                                  allowed)
+      --timeout=                  Wait up to this duration for matching notices
+                                  to arrive
 ```
 <!-- END AUTOMATED OUTPUT FOR notices -->
 
@@ -1308,6 +1315,7 @@ Warnings expire automatically, and once expired they are forgotten.
       --abs-time                      Display absolute times (in RFC 3339
                                       format). Otherwise, display relative
                                       times up to 60 days, then YYYY-MM-DD.
+      --format=[text|json|yaml]       Output format (default: text)
       --unicode=[auto|never|always]   Use a little bit of Unicode to improve
                                       legibility. (default: auto)
       --all                           Show all warnings

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1312,13 +1312,13 @@ listed again unless it happens again, _and_ a cooldown time has passed.
 Warnings expire automatically, and once expired they are forgotten.
 
 [warnings command options]
+      --all                           Show all warnings
       --abs-time                      Display absolute times (in RFC 3339
                                       format). Otherwise, display relative
                                       times up to 60 days, then YYYY-MM-DD.
       --format=[text|json|yaml]       Output format (default: text)
       --unicode=[auto|never|always]   Use a little bit of Unicode to improve
                                       legibility. (default: auto)
-      --all                           Show all warnings
-      --verbose                       Show more information
+      --verbose                       Show more information (text format only)
 ```
 <!-- END AUTOMATED OUTPUT FOR warnings -->

--- a/internals/cli/cmd_notice.go
+++ b/internals/cli/cmd_notice.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/canonical/go-flags"
 	"gopkg.in/yaml.v3"
@@ -33,6 +32,7 @@ by unique type and key combination (2-arg variant).
 type cmdNotice struct {
 	client *client.Client
 
+	formatMixin
 	UID *uint32 `long:"uid"`
 
 	Positional struct {
@@ -47,9 +47,9 @@ func init() {
 		Summary:     cmdNoticeSummary,
 		Description: cmdNoticeDescription,
 
-		ArgsHelp: map[string]string{
+		ArgsHelp: merge(formatArgsHelp, map[string]string{
 			"--uid": `Look up notice from user with this UID (admin only; 2-arg variant only)`,
-		},
+		}),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdNotice{client: opts.Client}
 		},
@@ -98,28 +98,18 @@ func (cmd *cmdNotice) Execute(args []string) error {
 		}
 	}
 
-	// Notice can be assigned directly to yamlNotice as only the tags are different.
-	yn := yamlNotice(*notice)
+	if cmd.Format == "text" {
+		return cmd.writeText(notice)
+	}
 
-	b, err := yaml.Marshal(yn)
+	return cmd.formatNonText(notice)
+}
+
+func (cmd *cmdNotice) writeText(notice *client.Notice) error {
+	b, err := yaml.Marshal(notice)
 	if err != nil {
 		return err
 	}
 	fmt.Fprint(Stdout, string(b)) // yaml.Marshal includes the trailing newline
 	return nil
-}
-
-// yamlNotice exists to add "yaml" tags to the Notice fields.
-type yamlNotice struct {
-	ID            string            `yaml:"id"`
-	UserID        *uint32           `yaml:"user-id"`
-	Type          client.NoticeType `yaml:"type"`
-	Key           string            `yaml:"key"`
-	FirstOccurred time.Time         `yaml:"first-occurred"`
-	LastOccurred  time.Time         `yaml:"last-occurred"`
-	LastRepeated  time.Time         `yaml:"last-repeated"`
-	Occurrences   int               `yaml:"occurrences"`
-	LastData      map[string]string `yaml:"last-data,omitempty"`
-	RepeatAfter   time.Duration     `yaml:"repeat-after,omitempty"`
-	ExpireAfter   time.Duration     `yaml:"expire-after,omitempty"`
 }

--- a/internals/cli/cmd_notice_test.go
+++ b/internals/cli/cmd_notice_test.go
@@ -83,7 +83,10 @@ func (s *PebbleSuite) TestNoticeJSON(c *C) {
 				"first-occurred": "2023-09-05T17:18:00Z",
 				"last-occurred": "2023-09-05T19:18:00Z",
 				"last-repeated": "2023-09-05T18:18:00Z",
-				"occurrences": 1
+				"occurrences": 1,
+				"last-data": {"k": "v"},
+				"repeat-after": "1h0m0s",
+				"expire-after": "168h0m0s"
 			}
 		}`)
 	})
@@ -91,7 +94,7 @@ func (s *PebbleSuite) TestNoticeJSON(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"notice", "--format", "json", "123"})
 	c.Assert(err, IsNil)
 	c.Check(rest, HasLen, 0)
-	c.Check(s.Stdout(), Equals, `{"id":"123","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":1}`+"\n")
+	c.Check(s.Stdout(), Equals, `{"id":"123","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":1,"last-data":{"k":"v"},"repeat-after":"1h0m0s","expire-after":"168h0m0s"}`+"\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 
@@ -110,7 +113,10 @@ func (s *PebbleSuite) TestNoticeYAML(c *C) {
 				"first-occurred": "2023-09-05T17:18:00Z",
 				"last-occurred": "2023-09-05T19:18:00Z",
 				"last-repeated": "2023-09-05T18:18:00Z",
-				"occurrences": 1
+				"occurrences": 1,
+				"last-data": {"k": "v"},
+				"repeat-after": "1h0m0s",
+				"expire-after": "168h0m0s"
 			}
 		}`)
 	})
@@ -127,6 +133,10 @@ first-occurred: 2023-09-05T17:18:00Z
 last-occurred: 2023-09-05T19:18:00Z
 last-repeated: 2023-09-05T18:18:00Z
 occurrences: 1
+last-data:
+    k: v
+repeat-after: 1h0m0s
+expire-after: 168h0m0s
 `[1:])
 	c.Check(s.Stderr(), Equals, "")
 }

--- a/internals/cli/cmd_notice_test.go
+++ b/internals/cli/cmd_notice_test.go
@@ -68,6 +68,74 @@ expire-after: 168h0m0s
 	c.Check(s.Stderr(), Equals, "")
 }
 
+func (s *PebbleSuite) TestNoticeJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/notices/123")
+		fmt.Fprint(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": {
+				"id": "123",
+				"user-id": 1000,
+				"type": "custom",
+				"key": "a.b/c",
+				"first-occurred": "2023-09-05T17:18:00Z",
+				"last-occurred": "2023-09-05T19:18:00Z",
+				"last-repeated": "2023-09-05T18:18:00Z",
+				"occurrences": 1
+			}
+		}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"notice", "--format", "json", "123"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `{"id":"123","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":1}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestNoticeYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/notices/123")
+		fmt.Fprint(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": {
+				"id": "123",
+				"user-id": 1000,
+				"type": "custom",
+				"key": "a.b/c",
+				"first-occurred": "2023-09-05T17:18:00Z",
+				"last-occurred": "2023-09-05T19:18:00Z",
+				"last-repeated": "2023-09-05T18:18:00Z",
+				"occurrences": 1
+			}
+		}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"notice", "--format", "yaml", "123"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `
+id: "123"
+user-id: 1000
+type: custom
+key: a.b/c
+first-occurred: 2023-09-05T17:18:00Z
+last-occurred: 2023-09-05T19:18:00Z
+last-repeated: 2023-09-05T18:18:00Z
+occurrences: 1
+`[1:])
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestNoticeInvalidFormat(c *C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"notice", "--format", "foobar", "123"})
+	c.Assert(err, ErrorMatches, "Invalid value.*for option.*--format.*")
+}
+
 func (s *PebbleSuite) TestNoticeIDNotFound(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")

--- a/internals/cli/cmd_notices.go
+++ b/internals/cli/cmd_notices.go
@@ -45,6 +45,7 @@ type cmdNotices struct {
 	socketPath string
 
 	timeMixin
+	formatMixin
 	Users   client.NoticesUsers `long:"users"`
 	UID     *uint32             `long:"uid"`
 	Type    []client.NoticeType `long:"type"`
@@ -57,7 +58,7 @@ func init() {
 		Name:        "notices",
 		Summary:     cmdNoticesSummary,
 		Description: cmdNoticesDescription,
-		ArgsHelp: merge(timeArgsHelp, map[string]string{
+		ArgsHelp: merge(timeArgsHelp, formatArgsHelp, map[string]string{
 			"--users":   "The only valid value is 'all', which lists notices with any user ID (admin only; cannot be used with --uid)",
 			"--uid":     "Only list notices with this user ID (admin only; cannot be used with --users)",
 			"--type":    "Only list notices of this type (multiple allowed)",
@@ -102,15 +103,29 @@ func (cmd *cmdNotices) Execute(args []string) error {
 		return err
 	}
 
-	if len(notices) == 0 {
-		if cmd.Timeout != 0 {
-			fmt.Fprintf(Stderr, "No matching notices after waiting %s.\n", cmd.Timeout)
-		} else {
-			fmt.Fprintln(Stderr, "No matching notices.")
+	if cmd.Format == "text" {
+		if len(notices) == 0 {
+			if cmd.Timeout != 0 {
+				fmt.Fprintf(Stderr, "No matching notices after waiting %s.\n", cmd.Timeout)
+			} else {
+				fmt.Fprintln(Stderr, "No matching notices.")
+			}
+			return nil
 		}
-		return nil
+		return cmd.writeText(notices, state)
 	}
 
+	if notices == nil {
+		notices = []*client.Notice{}
+	}
+	return cmd.formatNonText(noticesResult{Notices: notices})
+}
+
+type noticesResult struct {
+	Notices []*client.Notice `json:"notices" yaml:"notices"`
+}
+
+func (cmd *cmdNotices) writeText(notices []*client.Notice, state *cliState) error {
 	writer := tabWriter()
 	defer writer.Flush()
 
@@ -137,7 +152,7 @@ func (cmd *cmdNotices) Execute(args []string) error {
 	}
 
 	state.NoticesLastListed = notices[len(notices)-1].LastRepeated
-	err = saveCLIState(cmd.socketPath, state)
+	err := saveCLIState(cmd.socketPath, state)
 	if err != nil {
 		return fmt.Errorf("cannot save CLI state: %w", err)
 	}

--- a/internals/cli/cmd_notices.go
+++ b/internals/cli/cmd_notices.go
@@ -103,6 +103,13 @@ func (cmd *cmdNotices) Execute(args []string) error {
 		return err
 	}
 
+	if len(notices) > 0 {
+		state.NoticesLastListed = notices[len(notices)-1].LastRepeated
+		if err := saveCLIState(cmd.socketPath, state); err != nil {
+			return fmt.Errorf("cannot save CLI state: %w", err)
+		}
+	}
+
 	if cmd.Format == "text" {
 		if len(notices) == 0 {
 			if cmd.Timeout != 0 {
@@ -112,7 +119,7 @@ func (cmd *cmdNotices) Execute(args []string) error {
 			}
 			return nil
 		}
-		return cmd.writeText(notices, state)
+		return cmd.writeText(notices)
 	}
 
 	if notices == nil {
@@ -125,7 +132,7 @@ type noticesResult struct {
 	Notices []*client.Notice `json:"notices" yaml:"notices"`
 }
 
-func (cmd *cmdNotices) writeText(notices []*client.Notice, state *cliState) error {
+func (cmd *cmdNotices) writeText(notices []*client.Notice) error {
 	writer := tabWriter()
 	defer writer.Flush()
 
@@ -149,12 +156,6 @@ func (cmd *cmdNotices) writeText(notices []*client.Notice, state *cliState) erro
 			cmd.fmtTime(notice.FirstOccurred),
 			cmd.fmtTime(notice.LastRepeated),
 			notice.Occurrences)
-	}
-
-	state.NoticesLastListed = notices[len(notices)-1].LastRepeated
-	err := saveCLIState(cmd.socketPath, state)
-	if err != nil {
-		return fmt.Errorf("cannot save CLI state: %w", err)
 	}
 	return nil
 }

--- a/internals/cli/cmd_notices_test.go
+++ b/internals/cli/cmd_notices_test.go
@@ -315,7 +315,10 @@ func (s *PebbleSuite) TestNoticesJSON(c *C) {
 				"first-occurred": "2023-09-05T17:18:00Z",
 				"last-occurred": "2023-09-05T19:18:00Z",
 				"last-repeated": "2023-09-05T18:18:00Z",
-				"occurrences": 3
+				"occurrences": 3,
+				"last-data": {"k": "v"},
+				"repeat-after": "1h0m0s",
+				"expire-after": "168h0m0s"
 			}
 		]}`)
 	})
@@ -323,7 +326,7 @@ func (s *PebbleSuite) TestNoticesJSON(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "json"})
 	c.Assert(err, IsNil)
 	c.Check(rest, HasLen, 0)
-	c.Check(s.Stdout(), Equals, `{"notices":[{"id":"1","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":3}]}`+"\n")
+	c.Check(s.Stdout(), Equals, `{"notices":[{"id":"1","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":3,"last-data":{"k":"v"},"repeat-after":"1h0m0s","expire-after":"168h0m0s"}]}`+"\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 
@@ -343,7 +346,10 @@ func (s *PebbleSuite) TestNoticesYAML(c *C) {
 				"first-occurred": "2023-09-05T17:18:00Z",
 				"last-occurred": "2023-09-05T19:18:00Z",
 				"last-repeated": "2023-09-05T18:18:00Z",
-				"occurrences": 3
+				"occurrences": 3,
+				"last-data": {"k": "v"},
+				"repeat-after": "1h0m0s",
+				"expire-after": "168h0m0s"
 			}
 		]}`)
 	})
@@ -351,7 +357,21 @@ func (s *PebbleSuite) TestNoticesYAML(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "yaml"})
 	c.Assert(err, IsNil)
 	c.Check(rest, HasLen, 0)
-	c.Check(s.Stdout(), Matches, `(?s)notices:\n    - id: "1"\n.*`)
+	c.Check(s.Stdout(), Equals, `
+notices:
+    - id: "1"
+      user-id: 1000
+      type: custom
+      key: a.b/c
+      first-occurred: 2023-09-05T17:18:00Z
+      last-occurred: 2023-09-05T19:18:00Z
+      last-repeated: 2023-09-05T18:18:00Z
+      occurrences: 3
+      last-data:
+        k: v
+      repeat-after: 1h0m0s
+      expire-after: 168h0m0s
+`[1:])
 	c.Check(s.Stderr(), Equals, "")
 }
 

--- a/internals/cli/cmd_notices_test.go
+++ b/internals/cli/cmd_notices_test.go
@@ -328,6 +328,12 @@ func (s *PebbleSuite) TestNoticesJSON(c *C) {
 	c.Check(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `{"notices":[{"id":"1","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":3,"last-data":{"k":"v"},"repeat-after":"1h0m0s","expire-after":"168h0m0s"}]}`+"\n")
 	c.Check(s.Stderr(), Equals, "")
+
+	cliState := s.readNoticesCLIState(c)
+	c.Check(cliState, DeepEquals, map[string]any{
+		"notices-last-listed": "2023-09-05T18:18:00Z",
+		"notices-last-okayed": "0001-01-01T00:00:00Z",
+	})
 }
 
 func (s *PebbleSuite) TestNoticesYAML(c *C) {
@@ -373,6 +379,12 @@ notices:
       expire-after: 168h0m0s
 `[1:])
 	c.Check(s.Stderr(), Equals, "")
+
+	cliState := s.readNoticesCLIState(c)
+	c.Check(cliState, DeepEquals, map[string]any{
+		"notices-last-listed": "2023-09-05T18:18:00Z",
+		"notices-last-okayed": "0001-01-01T00:00:00Z",
+	})
 }
 
 func (s *PebbleSuite) TestNoNoticesJSON(c *C) {

--- a/internals/cli/cmd_notices_test.go
+++ b/internals/cli/cmd_notices_test.go
@@ -298,3 +298,92 @@ func (s *PebbleSuite) TestNoticesNoNoticesTimeout(c *C) {
 	_, err = os.Stat(s.cliStatePath)
 	c.Assert(errors.Is(err, fs.ErrNotExist), Equals, true)
 }
+
+func (s *PebbleSuite) TestNoticesJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/notices")
+		c.Check(r.URL.Query(), DeepEquals, url.Values{})
+		fmt.Fprint(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": [{
+				"id": "1",
+				"user-id": 1000,
+				"type": "custom",
+				"key": "a.b/c",
+				"first-occurred": "2023-09-05T17:18:00Z",
+				"last-occurred": "2023-09-05T19:18:00Z",
+				"last-repeated": "2023-09-05T18:18:00Z",
+				"occurrences": 3
+			}
+		]}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "json"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `{"notices":[{"id":"1","user-id":1000,"type":"custom","key":"a.b/c","first-occurred":"2023-09-05T17:18:00Z","last-occurred":"2023-09-05T19:18:00Z","last-repeated":"2023-09-05T18:18:00Z","occurrences":3}]}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestNoticesYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/notices")
+		c.Check(r.URL.Query(), DeepEquals, url.Values{})
+		fmt.Fprint(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": [{
+				"id": "1",
+				"user-id": 1000,
+				"type": "custom",
+				"key": "a.b/c",
+				"first-occurred": "2023-09-05T17:18:00Z",
+				"last-occurred": "2023-09-05T19:18:00Z",
+				"last-repeated": "2023-09-05T18:18:00Z",
+				"occurrences": 3
+			}
+		]}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "yaml"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Matches, `(?s)notices:\n    - id: "1"\n.*`)
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestNoNoticesJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/notices")
+		fmt.Fprint(w, `{"type": "sync", "status-code": 200, "result": []}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "json"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `{"notices":[]}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestNoNoticesYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/notices")
+		fmt.Fprint(w, `{"type": "sync", "status-code": 200, "result": []}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "yaml"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, "notices: []\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestNoticesInvalidFormat(c *C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"notices", "--format", "foobar"})
+	c.Assert(err, ErrorMatches, "Invalid value.*for option.*--format.*")
+}

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -44,10 +44,10 @@ type cmdWarnings struct {
 
 	socketPath string
 
+	All bool `long:"all"`
 	timeMixin
 	formatMixin
 	unicodeMixin
-	All     bool `long:"all"`
 	Verbose bool `long:"verbose"`
 }
 
@@ -58,7 +58,7 @@ func init() {
 		Description: cmdWarningsDescription,
 		ArgsHelp: merge(timeArgsHelp, formatArgsHelp, unicodeArgsHelp, map[string]string{
 			"--all":     "Show all warnings",
-			"--verbose": "Show more information",
+			"--verbose": "Show more information (text format only)",
 		}),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdWarnings{

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -45,6 +45,7 @@ type cmdWarnings struct {
 	socketPath string
 
 	timeMixin
+	formatMixin
 	unicodeMixin
 	All     bool `long:"all"`
 	Verbose bool `long:"verbose"`
@@ -55,7 +56,7 @@ func init() {
 		Name:        "warnings",
 		Summary:     cmdWarningsSummary,
 		Description: cmdWarningsDescription,
-		ArgsHelp: merge(timeArgsHelp, unicodeArgsHelp, map[string]string{
+		ArgsHelp: merge(timeArgsHelp, formatArgsHelp, unicodeArgsHelp, map[string]string{
 			"--all":     "Show all warnings",
 			"--verbose": "Show more information",
 		}),
@@ -90,15 +91,30 @@ func (cmd *cmdWarnings) Execute(args []string) error {
 	if err != nil {
 		return fmt.Errorf("cannot get notices: %w", err)
 	}
-	if len(warnings) == 0 {
-		if cmd.All || state.WarningsLastOkayed.IsZero() {
-			fmt.Fprintln(Stderr, "No warnings.")
-		} else {
-			fmt.Fprintln(Stderr, "No further warnings.")
+
+	if cmd.Format == "text" {
+		if len(warnings) == 0 {
+			if cmd.All || state.WarningsLastOkayed.IsZero() {
+				fmt.Fprintln(Stderr, "No warnings.")
+			} else {
+				fmt.Fprintln(Stderr, "No further warnings.")
+			}
+			return nil
 		}
-		return nil
+		return cmd.writeText(warnings, state)
 	}
 
+	if warnings == nil {
+		warnings = []*client.Notice{}
+	}
+	return cmd.formatNonText(warningsResult{Warnings: warnings})
+}
+
+type warningsResult struct {
+	Warnings []*client.Notice `json:"warnings" yaml:"warnings"`
+}
+
+func (cmd *cmdWarnings) writeText(warnings []*client.Notice, state *cliState) error {
 	termWidth, _ := termSize()
 	if termWidth > 100 {
 		// any wider than this and it gets hard to read
@@ -127,7 +143,7 @@ func (cmd *cmdWarnings) Execute(args []string) error {
 
 	if !cmd.All {
 		state.WarningsLastListed = warnings[len(warnings)-1].LastRepeated
-		err = saveCLIState(cmd.socketPath, state)
+		err := saveCLIState(cmd.socketPath, state)
 		if err != nil {
 			return fmt.Errorf("cannot save CLI state: %w", err)
 		}

--- a/internals/cli/cmd_warnings.go
+++ b/internals/cli/cmd_warnings.go
@@ -92,6 +92,13 @@ func (cmd *cmdWarnings) Execute(args []string) error {
 		return fmt.Errorf("cannot get notices: %w", err)
 	}
 
+	if !cmd.All && len(warnings) > 0 {
+		state.WarningsLastListed = warnings[len(warnings)-1].LastRepeated
+		if err := saveCLIState(cmd.socketPath, state); err != nil {
+			return fmt.Errorf("cannot save CLI state: %w", err)
+		}
+	}
+
 	if cmd.Format == "text" {
 		if len(warnings) == 0 {
 			if cmd.All || state.WarningsLastOkayed.IsZero() {
@@ -101,7 +108,7 @@ func (cmd *cmdWarnings) Execute(args []string) error {
 			}
 			return nil
 		}
-		return cmd.writeText(warnings, state)
+		return cmd.writeText(warnings)
 	}
 
 	if warnings == nil {
@@ -114,7 +121,7 @@ type warningsResult struct {
 	Warnings []*client.Notice `json:"warnings" yaml:"warnings"`
 }
 
-func (cmd *cmdWarnings) writeText(warnings []*client.Notice, state *cliState) error {
+func (cmd *cmdWarnings) writeText(warnings []*client.Notice) error {
 	termWidth, _ := termSize()
 	if termWidth > 100 {
 		// any wider than this and it gets hard to read
@@ -140,15 +147,6 @@ func (cmd *cmdWarnings) writeText(warnings []*client.Notice, state *cliState) er
 		writeWarning(w, warning.Key, termWidth)
 		w.Flush()
 	}
-
-	if !cmd.All {
-		state.WarningsLastListed = warnings[len(warnings)-1].LastRepeated
-		err := saveCLIState(cmd.socketPath, state)
-		if err != nil {
-			return fmt.Errorf("cannot save CLI state: %w", err)
-		}
-	}
-
 	return nil
 }
 

--- a/internals/cli/cmd_warnings_test.go
+++ b/internals/cli/cmd_warnings_test.go
@@ -233,6 +233,51 @@ func (s *warningSuite) TestCommandWithWarnings(c *check.C) {
 	c.Check(timesCalled, check.Equals, len(expectedWarnings))
 }
 
+func (s *warningSuite) TestWarningsJSON(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, testWarnings))
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "json"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Matches, `\{"warnings":\[.*\]\}\n`)
+}
+
+func (s *warningSuite) TestWarningsYAML(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, testWarnings))
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "yaml"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stdout(), check.Matches, `(?s)warnings:\n    - id: "1"\n.*`)
+}
+
+func (s *warningSuite) TestNoWarningsJSON(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, `{"type": "sync", "status-code": 200, "result": []}`))
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "json"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"warnings":[]}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *warningSuite) TestNoWarningsYAML(c *check.C) {
+	s.RedirectClientToTestServer(mkWarningsFakeHandler(c, `{"type": "sync", "status-code": 200, "result": []}`))
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "yaml"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, "warnings: []\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *warningSuite) TestWarningsInvalidFormat(c *check.C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "foobar"})
+	c.Assert(err, check.ErrorMatches, "Invalid value.*for option.*--format.*")
+}
+
 func (s *warningSuite) TestExtraArgs(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "extra", "args"})
 	c.Assert(err, check.Equals, cli.ErrExtraArgs)

--- a/internals/cli/cmd_warnings_test.go
+++ b/internals/cli/cmd_warnings_test.go
@@ -241,6 +241,12 @@ func (s *warningSuite) TestWarningsJSON(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Matches, `\{"warnings":\[.*\]\}\n`)
+
+	cliState := s.readWarningsCLIState(c)
+	c.Check(cliState, check.DeepEquals, map[string]any{
+		"warnings-last-listed": "2018-09-19T12:44:50.680362867Z",
+		"warnings-last-okayed": "0001-01-01T00:00:00Z",
+	})
 }
 
 func (s *warningSuite) TestWarningsYAML(c *check.C) {
@@ -251,6 +257,21 @@ func (s *warningSuite) TestWarningsYAML(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stderr(), check.Equals, "")
 	c.Check(s.Stdout(), check.Matches, `(?s)warnings:\n    - id: "1"\n.*`)
+
+	cliState := s.readWarningsCLIState(c)
+	c.Check(cliState, check.DeepEquals, map[string]any{
+		"warnings-last-listed": "2018-09-19T12:44:50.680362867Z",
+		"warnings-last-okayed": "0001-01-01T00:00:00Z",
+	})
+}
+
+func (s *warningSuite) readWarningsCLIState(c *check.C) map[string]any {
+	fullCLIState := s.readCLIState(c)
+	cliState := map[string]any{
+		"warnings-last-listed": fullCLIState["warnings-last-listed"],
+		"warnings-last-okayed": fullCLIState["warnings-last-okayed"],
+	}
+	return cliState
 }
 
 func (s *warningSuite) TestNoWarningsJSON(c *check.C) {

--- a/internals/cli/cmd_warnings_test.go
+++ b/internals/cli/cmd_warnings_test.go
@@ -239,8 +239,8 @@ func (s *warningSuite) TestWarningsJSON(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "json"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"warnings":[{"id":"1","user-id":null,"type":"warning","key":"hello world number one","first-occurred":"2018-09-19T12:41:18.505007495Z","last-occurred":"2018-09-19T12:41:18.505007495Z","last-repeated":"2018-09-19T12:41:18.505007495Z","occurrences":0,"repeat-after":"24h0m0s","expire-after":"672h0m0s"},{"id":"2","user-id":null,"type":"warning","key":"hello world number two","first-occurred":"2018-09-19T12:44:19.680362867Z","last-occurred":"2018-09-19T12:44:19.680362867Z","last-repeated":"2018-09-19T12:44:19.680362867Z","occurrences":0,"repeat-after":"24h0m0s","expire-after":"672h0m0s"},{"id":"3","user-id":null,"type":"warning","key":"hello world number three","first-occurred":"2018-09-19T12:44:30.680362867Z","last-occurred":"2018-09-19T12:44:30.680362867Z","last-repeated":"2018-09-19T12:44:50.680362867Z","occurrences":0,"repeat-after":"24h0m0s","expire-after":"672h0m0s"}]}`+"\n")
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(s.Stdout(), check.Matches, `\{"warnings":\[.*\]\}\n`)
 
 	cliState := s.readWarningsCLIState(c)
 	c.Check(cliState, check.DeepEquals, map[string]any{
@@ -255,8 +255,40 @@ func (s *warningSuite) TestWarningsYAML(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"warnings", "--format", "yaml"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+warnings:
+    - id: "1"
+      user-id: null
+      type: warning
+      key: hello world number one
+      first-occurred: 2018-09-19T12:41:18.505007495Z
+      last-occurred: 2018-09-19T12:41:18.505007495Z
+      last-repeated: 2018-09-19T12:41:18.505007495Z
+      occurrences: 0
+      repeat-after: 24h0m0s
+      expire-after: 672h0m0s
+    - id: "2"
+      user-id: null
+      type: warning
+      key: hello world number two
+      first-occurred: 2018-09-19T12:44:19.680362867Z
+      last-occurred: 2018-09-19T12:44:19.680362867Z
+      last-repeated: 2018-09-19T12:44:19.680362867Z
+      occurrences: 0
+      repeat-after: 24h0m0s
+      expire-after: 672h0m0s
+    - id: "3"
+      user-id: null
+      type: warning
+      key: hello world number three
+      first-occurred: 2018-09-19T12:44:30.680362867Z
+      last-occurred: 2018-09-19T12:44:30.680362867Z
+      last-repeated: 2018-09-19T12:44:50.680362867Z
+      occurrences: 0
+      repeat-after: 24h0m0s
+      expire-after: 672h0m0s
+`[1:])
 	c.Check(s.Stderr(), check.Equals, "")
-	c.Check(s.Stdout(), check.Matches, `(?s)warnings:\n    - id: "1"\n.*`)
 
 	cliState := s.readWarningsCLIState(c)
 	c.Check(cliState, check.DeepEquals, map[string]any{


### PR DESCRIPTION
adds `--format` flag to support structured output formats to `notices`, `notice`, and `warnings` commands.

Towards #824 