### PR TITLE
feat(cli): add structured output formats to `identity`

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -351,9 +351,12 @@ The `identity` command is used to show a single identity.
 pebble identity --help
 
 Usage:
-  pebble identity <name>
+  pebble identity [identity-OPTIONS] <name>
 
 The identity command shows details for a single identity in YAML format.
+
+[identity command options]
+      --format=[text|json|yaml]   Output format (default: text)
 ```
 <!-- END AUTOMATED OUTPUT FOR identity -->
 

--- a/internals/cli/cmd_identity.go
+++ b/internals/cli/cmd_identity.go
@@ -31,6 +31,7 @@ The identity command shows details for a single identity in YAML format.
 type cmdIdentity struct {
 	client *client.Client
 
+	formatMixin
 	Positional struct {
 		Name string `positional-arg-name:"<name>" required:"1"`
 	} `positional-args:"yes"`
@@ -41,6 +42,7 @@ func init() {
 		Name:        "identity",
 		Summary:     cmdIdentitySummary,
 		Description: cmdIdentityDescription,
+		ArgsHelp:    formatArgsHelp,
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdIdentity{client: opts.Client}
 		},
@@ -60,6 +62,15 @@ func (cmd *cmdIdentity) Execute(args []string) error {
 	if !ok {
 		return fmt.Errorf("cannot find identity %q", cmd.Positional.Name)
 	}
+
+	if cmd.Format == "text" {
+		return cmd.writeText(identity)
+	}
+
+	return cmd.formatNonText(identity)
+}
+
+func (cmd *cmdIdentity) writeText(identity *client.Identity) error {
 	data, err := yaml.Marshal(identity)
 	if err != nil {
 		return err

--- a/internals/cli/cmd_identity_test.go
+++ b/internals/cli/cmd_identity_test.go
@@ -50,6 +50,57 @@ local:
 	c.Check(s.Stderr(), Equals, "")
 }
 
+func (s *PebbleSuite) TestIdentityJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/identities")
+		c.Check(r.URL.Query(), DeepEquals, url.Values{})
+		fmt.Fprint(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": {
+				"bob": {"access": "read", "local": {"user-id": 42}}
+			}
+		}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"identity", "--format", "json", "bob"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `{"access":"read","local":{"user-id":42}}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestIdentityYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, Equals, "GET")
+		c.Check(r.URL.Path, Equals, "/v1/identities")
+		c.Check(r.URL.Query(), DeepEquals, url.Values{})
+		fmt.Fprint(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": {
+				"bob": {"access": "read", "local": {"user-id": 42}}
+			}
+		}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"identity", "--format", "yaml", "bob"})
+	c.Assert(err, IsNil)
+	c.Check(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `
+access: read
+local:
+    user-id: 42
+`[1:])
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestIdentityInvalidFormat(c *C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"identity", "--format", "foobar", "bob"})
+	c.Assert(err, ErrorMatches, "Invalid value.*for option.*--format.*")
+}
+
 func (s *PebbleSuite) TestIdentityNotFound(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, Equals, "GET")


### PR DESCRIPTION
adds `--format` flag to support structured output formats to the `identity` command.

Towards #824 