### PR TITLE
feat(cli): add structured output formats to `check` & `checks`

### DIFF
--- a/client/checks.go
+++ b/client/checks.go
@@ -76,7 +76,7 @@ type CheckInfo struct {
 	Name string `json:"name" yaml:"name"`
 
 	// Level is this check's level, from the layer configuration.
-	Level CheckLevel `json:"level" yaml:"level"`
+	Level CheckLevel `json:"level,omitempty" yaml:"level,omitempty"`
 
 	// Startup is the startup mode for the check. If it is "enabled", the check
 	// will be started in a Pebble replan and when Pebble starts. If it is
@@ -95,7 +95,7 @@ type CheckInfo struct {
 	//
 	// This field will be nil if running against a version of the daemon
 	// before this field was added to the API.
-	Successes *int `json:"successes" yaml:"successes"`
+	Successes *int `json:"successes,omitempty" yaml:"successes,omitempty"`
 
 	// Failures is the number of times in a row this check has failed. It is
 	// reset to zero as soon as the check succeeds.
@@ -108,14 +108,14 @@ type CheckInfo struct {
 	// ChangeID is the ID of the change corresponding to this check operation.
 	// The change will be of kind "perform-check" if the check is up, or
 	// "recover-check" if it's down.
-	ChangeID string `json:"change-id" yaml:"change-id"`
+	ChangeID string `json:"change-id,omitempty" yaml:"change-id,omitempty"`
 
 	// PrevChangeID is the ID of the previous change. For a "recover-check"
 	// change, this is the "perform-check" change that was running before the
 	// check started failing. For a "perform-check" change, this is the
 	// "recover-check" change that was running before the check recovered, or
 	// empty if the check has never had to recover.
-	PrevChangeID string `json:"prev-change-id" yaml:"prev-change-id"`
+	PrevChangeID string `json:"prev-change-id,omitempty" yaml:"prev-change-id,omitempty"`
 }
 
 // Checks fetches information about specific health checks (or all of them),

--- a/client/checks.go
+++ b/client/checks.go
@@ -73,20 +73,20 @@ const (
 // CheckInfo holds status information for a single health check.
 type CheckInfo struct {
 	// Name is the name of this check, from the layer configuration.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Level is this check's level, from the layer configuration.
-	Level CheckLevel `json:"level"`
+	Level CheckLevel `json:"level" yaml:"level"`
 
 	// Startup is the startup mode for the check. If it is "enabled", the check
 	// will be started in a Pebble replan and when Pebble starts. If it is
 	// "disabled", it must be started manually.
-	Startup CheckStartup `json:"startup"`
+	Startup CheckStartup `json:"startup" yaml:"startup"`
 
 	// Status is the status of this check: "up" if healthy, "down" if the
 	// number of failures has reached the configured threshold, or "inactive" if
 	// the check is inactive.
-	Status CheckStatus `json:"status"`
+	Status CheckStatus `json:"status" yaml:"status"`
 
 	// Successes is the number of times this check has succeeded. It is reset
 	// when the check succeeds again after the check's failure threshold was
@@ -95,27 +95,27 @@ type CheckInfo struct {
 	//
 	// This field will be nil if running against a version of the daemon
 	// before this field was added to the API.
-	Successes *int `json:"successes"`
+	Successes *int `json:"successes" yaml:"successes"`
 
 	// Failures is the number of times in a row this check has failed. It is
 	// reset to zero as soon as the check succeeds.
-	Failures int `json:"failures"`
+	Failures int `json:"failures" yaml:"failures"`
 
 	// Threshold is this check's failure threshold, from the layer
 	// configuration.
-	Threshold int `json:"threshold"`
+	Threshold int `json:"threshold" yaml:"threshold"`
 
 	// ChangeID is the ID of the change corresponding to this check operation.
 	// The change will be of kind "perform-check" if the check is up, or
 	// "recover-check" if it's down.
-	ChangeID string `json:"change-id"`
+	ChangeID string `json:"change-id" yaml:"change-id"`
 
 	// PrevChangeID is the ID of the previous change. For a "recover-check"
 	// change, this is the "perform-check" change that was running before the
 	// check started failing. For a "perform-check" change, this is the
 	// "recover-check" change that was running before the check recovered, or
 	// empty if the check has never had to recover.
-	PrevChangeID string `json:"prev-change-id"`
+	PrevChangeID string `json:"prev-change-id" yaml:"prev-change-id"`
 }
 
 // Checks fetches information about specific health checks (or all of them),

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -137,7 +137,8 @@ Usage:
 The check command shows details for a single check in YAML format.
 
 [check command options]
-      --refresh    Run the check immediately
+      --format=[text|json|yaml]   Output format (default: text)
+      --refresh                   Run the check immediately
 ```
 <!-- END AUTOMATED OUTPUT FOR check -->
 
@@ -158,7 +159,8 @@ checks, optionally filtered by level and check names provided as positional
 arguments.
 
 [checks command options]
-      --level=[alive|ready]   Check level to filter for
+      --format=[text|json|yaml]   Output format (default: text)
+      --level=[alive|ready]       Check level to filter for
 ```
 <!-- END AUTOMATED OUTPUT FOR checks -->
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -134,7 +134,7 @@ pebble check --help
 Usage:
   pebble check [check-OPTIONS] <check>
 
-The check command shows details for a single check in YAML format.
+The check command shows details for a single check.
 
 [check command options]
       --format=[text|json|yaml]   Output format (default: text)

--- a/internals/cli/cmd_check.go
+++ b/internals/cli/cmd_check.go
@@ -32,6 +32,7 @@ The check command shows details for a single check in YAML format.
 type cmdCheck struct {
 	client *client.Client
 
+	formatMixin
 	Refresh bool `long:"refresh"`
 
 	Positional struct {
@@ -40,17 +41,17 @@ type cmdCheck struct {
 }
 
 type checkInfo struct {
-	Name         string `yaml:"name"`
-	Level        string `yaml:"level,omitempty"`
-	Startup      string `yaml:"startup"`
-	Status       string `yaml:"status"`
-	Successes    *int   `yaml:"successes,omitempty"`
-	Failures     int    `yaml:"failures"`
-	Threshold    int    `yaml:"threshold"`
-	ChangeID     string `yaml:"change-id,omitempty"`
-	PrevChangeID string `yaml:"prev-change-id,omitempty"`
-	Error        string `yaml:"error,omitempty"`
-	Logs         string `yaml:"logs,omitempty"`
+	Name         string `json:"name" yaml:"name"`
+	Level        string `json:"level,omitempty" yaml:"level,omitempty"`
+	Startup      string `json:"startup" yaml:"startup"`
+	Status       string `json:"status" yaml:"status"`
+	Successes    *int   `json:"successes,omitempty" yaml:"successes,omitempty"`
+	Failures     int    `json:"failures" yaml:"failures"`
+	Threshold    int    `json:"threshold" yaml:"threshold"`
+	ChangeID     string `json:"change-id,omitempty" yaml:"change-id,omitempty"`
+	PrevChangeID string `json:"prev-change-id,omitempty" yaml:"prev-change-id,omitempty"`
+	Error        string `json:"error,omitempty" yaml:"error,omitempty"`
+	Logs         string `json:"logs,omitempty" yaml:"logs,omitempty"`
 }
 
 func init() {
@@ -58,9 +59,9 @@ func init() {
 		Name:        "check",
 		Summary:     cmdCheckSummary,
 		Description: cmdCheckDescription,
-		ArgsHelp: map[string]string{
+		ArgsHelp: merge(formatArgsHelp, map[string]string{
 			"--refresh": "Run the check immediately",
-		},
+		}),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdCheck{client: opts.Client}
 		},
@@ -127,6 +128,15 @@ func (cmd *cmdCheck) Execute(args []string) error {
 			info.Logs = logs
 		}
 	}
+
+	if cmd.Format == "text" {
+		return cmd.writeText(info)
+	}
+
+	return cmd.formatNonText(info)
+}
+
+func (cmd *cmdCheck) writeText(info checkInfo) error {
 	data, err := yaml.Marshal(info)
 	if err != nil {
 		return err

--- a/internals/cli/cmd_check.go
+++ b/internals/cli/cmd_check.go
@@ -26,7 +26,7 @@ import (
 
 const cmdCheckSummary = "Query the details of a configured health check"
 const cmdCheckDescription = `
-The check command shows details for a single check in YAML format.
+The check command shows details for a single check.
 `
 
 type cmdCheck struct {
@@ -41,17 +41,10 @@ type cmdCheck struct {
 }
 
 type checkInfo struct {
-	Name         string `json:"name" yaml:"name"`
-	Level        string `json:"level,omitempty" yaml:"level,omitempty"`
-	Startup      string `json:"startup" yaml:"startup"`
-	Status       string `json:"status" yaml:"status"`
-	Successes    *int   `json:"successes,omitempty" yaml:"successes,omitempty"`
-	Failures     int    `json:"failures" yaml:"failures"`
-	Threshold    int    `json:"threshold" yaml:"threshold"`
-	ChangeID     string `json:"change-id,omitempty" yaml:"change-id,omitempty"`
-	PrevChangeID string `json:"prev-change-id,omitempty" yaml:"prev-change-id,omitempty"`
-	Error        string `json:"error,omitempty" yaml:"error,omitempty"`
-	Logs         string `json:"logs,omitempty" yaml:"logs,omitempty"`
+	client.CheckInfo `yaml:",inline"`
+
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+	Logs  string `json:"logs,omitempty" yaml:"logs,omitempty"`
 }
 
 func init() {
@@ -66,20 +59,6 @@ func init() {
 			return &cmdCheck{client: opts.Client}
 		},
 	})
-}
-
-func checkInfoFromClient(check client.CheckInfo) checkInfo {
-	return checkInfo{
-		Name:         check.Name,
-		Level:        string(check.Level),
-		Startup:      string(check.Startup),
-		Status:       string(check.Status),
-		Successes:    check.Successes,
-		Failures:     check.Failures,
-		Threshold:    check.Threshold,
-		ChangeID:     check.ChangeID,
-		PrevChangeID: check.PrevChangeID,
-	}
 }
 
 func (cmd *cmdCheck) Execute(args []string) error {
@@ -97,7 +76,7 @@ func (cmd *cmdCheck) Execute(args []string) error {
 			return err
 		}
 
-		info = checkInfoFromClient(res.Info)
+		info.CheckInfo = res.Info
 		info.Error = res.Error
 	} else {
 		opts := client.ChecksOptions{
@@ -110,7 +89,7 @@ func (cmd *cmdCheck) Execute(args []string) error {
 		if len(checks) == 0 {
 			return fmt.Errorf("cannot find check %q", cmd.Positional.Check)
 		}
-		info = checkInfoFromClient(*checks[0])
+		info.CheckInfo = *checks[0]
 	}
 
 	if info.Failures > 0 || info.Error != "" {

--- a/internals/cli/cmd_check_test.go
+++ b/internals/cli/cmd_check_test.go
@@ -218,6 +218,55 @@ func (s *PebbleSuite) TestCheckRefreshNotFound(c *C) {
 	c.Check(err, ErrorMatches, "cannot find check .*")
 }
 
+func (s *PebbleSuite) TestCheckJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/v1/checks")
+		c.Assert(r.URL.Query(), DeepEquals, url.Values{"names": {"chk1"}})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"}]
+}`)
+	})
+	rest, err := cli.ParserForTest().ParseArgs([]string{"check", "--format", "json", "chk1"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `{"name":"chk1","startup":"enabled","status":"up","successes":5,"failures":0,"threshold":3,"change-id":"1"}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestCheckYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/v1/checks")
+		c.Assert(r.URL.Query(), DeepEquals, url.Values{"names": {"chk1"}})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"}]
+}`)
+	})
+	rest, err := cli.ParserForTest().ParseArgs([]string{"check", "--format", "yaml", "chk1"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `
+name: chk1
+startup: enabled
+status: up
+successes: 5
+failures: 0
+threshold: 3
+change-id: "1"
+`[1:])
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestCheckInvalidFormat(c *C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"check", "--format", "foobar", "chk1"})
+	c.Assert(err, ErrorMatches, "Invalid value.*for option.*--format.*")
+}
+
 func (s *PebbleSuite) TestCheckPrevChangeLog(c *C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -34,6 +34,7 @@ arguments.
 type cmdChecks struct {
 	client *client.Client
 
+	formatMixin
 	//lint:ignore SA5008 "choice" tag is intentionally duplicated
 	Level      string `long:"level" choice:"alive" choice:"ready"`
 	Positional struct {
@@ -46,9 +47,9 @@ func init() {
 		Name:        "checks",
 		Summary:     cmdChecksSummary,
 		Description: cmdChecksDescription,
-		ArgsHelp: map[string]string{
+		ArgsHelp: merge(map[string]string{
 			"--level": "Check level to filter for",
-		},
+		}, formatArgsHelp),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdChecks{client: opts.Client}
 		},
@@ -68,15 +69,30 @@ func (cmd *cmdChecks) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(checks) == 0 {
-		if len(cmd.Positional.Checks) == 0 && cmd.Level == "" {
-			fmt.Fprintln(Stderr, "Plan has no health checks.")
-		} else {
-			fmt.Fprintln(Stderr, "No matching health checks.")
+
+	if cmd.Format == "text" {
+		if len(checks) == 0 {
+			if len(cmd.Positional.Checks) == 0 && cmd.Level == "" {
+				fmt.Fprintln(Stderr, "Plan has no health checks.")
+			} else {
+				fmt.Fprintln(Stderr, "No matching health checks.")
+			}
+			return nil
 		}
-		return nil
+		return cmd.writeText(checks)
 	}
 
+	if checks == nil {
+		checks = []*client.CheckInfo{}
+	}
+	return cmd.formatNonText(checksResult{Checks: checks})
+}
+
+type checksResult struct {
+	Checks []*client.CheckInfo `json:"checks" yaml:"checks"`
+}
+
+func (cmd *cmdChecks) writeText(checks []*client.CheckInfo) error {
 	w := tabWriter()
 	defer w.Flush()
 

--- a/internals/cli/cmd_checks.go
+++ b/internals/cli/cmd_checks.go
@@ -82,14 +82,15 @@ func (cmd *cmdChecks) Execute(args []string) error {
 		return cmd.writeText(checks)
 	}
 
-	if checks == nil {
-		checks = []*client.CheckInfo{}
+	checkMap := make(map[string]*client.CheckInfo, len(checks))
+	for _, check := range checks {
+		checkMap[check.Name] = check
 	}
-	return cmd.formatNonText(checksResult{Checks: checks})
+	return cmd.formatNonText(checksMap{Checks: checkMap})
 }
 
-type checksResult struct {
-	Checks []*client.CheckInfo `json:"checks" yaml:"checks"`
+type checksMap struct {
+	Checks map[string]*client.CheckInfo `json:"checks" yaml:"checks"`
 }
 
 func (cmd *cmdChecks) writeText(checks []*client.CheckInfo) error {

--- a/internals/cli/cmd_checks_test.go
+++ b/internals/cli/cmd_checks_test.go
@@ -246,3 +246,90 @@ chk1   -      enabled  down    0          3/3       2 (Get "http://localhost:800
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
+
+func (s *PebbleSuite) TestChecksJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/checks")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [
+		{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"},
+		{"name": "chk2", "startup": "enabled", "level": "alive", "status": "down", "failures": 1, "threshold": 1, "change-id": "2"}
+	]
+}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "json"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"checks":[{"name":"chk1","level":"","startup":"enabled","status":"up","successes":5,"failures":0,"threshold":3,"change-id":"1","prev-change-id":""},{"name":"chk2","level":"alive","startup":"enabled","status":"down","successes":null,"failures":1,"threshold":1,"change-id":"2","prev-change-id":""}]}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestChecksYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/checks")
+		c.Assert(r.URL.Query(), check.DeepEquals, url.Values{})
+		fmt.Fprint(w, `{
+    "type": "sync",
+    "status-code": 200,
+    "result": [
+		{"name": "chk1", "startup": "enabled", "status": "up", "successes": 5, "threshold": 3, "change-id": "1"}
+	]
+}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "yaml"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+checks:
+    - name: chk1
+      level: ""
+      startup: enabled
+      status: up
+      successes: 5
+      failures: 0
+      threshold: 3
+      change-id: "1"
+      prev-change-id: ""
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestNoChecksJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/checks")
+		fmt.Fprint(w, `{"type": "sync", "status-code": 200, "result": []}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "json"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"checks":[]}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestNoChecksYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, check.Equals, "GET")
+		c.Assert(r.URL.Path, check.Equals, "/v1/checks")
+		fmt.Fprint(w, `{"type": "sync", "status-code": 200, "result": []}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "yaml"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, "checks: []\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestChecksInvalidFormat(c *check.C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "foobar"})
+	c.Assert(err, check.ErrorMatches, "Invalid value.*for option.*--format.*")
+}

--- a/internals/cli/cmd_checks_test.go
+++ b/internals/cli/cmd_checks_test.go
@@ -265,7 +265,7 @@ func (s *PebbleSuite) TestChecksJSON(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "json"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, `{"checks":[{"name":"chk1","level":"","startup":"enabled","status":"up","successes":5,"failures":0,"threshold":3,"change-id":"1","prev-change-id":""},{"name":"chk2","level":"alive","startup":"enabled","status":"down","successes":null,"failures":1,"threshold":1,"change-id":"2","prev-change-id":""}]}`+"\n")
+	c.Check(s.Stdout(), check.Equals, `{"checks":{"chk1":{"name":"chk1","startup":"enabled","status":"up","successes":5,"failures":0,"threshold":3,"change-id":"1"},"chk2":{"name":"chk2","level":"alive","startup":"enabled","status":"down","failures":1,"threshold":1,"change-id":"2"}}}`+"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -288,15 +288,14 @@ func (s *PebbleSuite) TestChecksYAML(c *check.C) {
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
 checks:
-    - name: chk1
-      level: ""
-      startup: enabled
-      status: up
-      successes: 5
-      failures: 0
-      threshold: 3
-      change-id: "1"
-      prev-change-id: ""
+    chk1:
+        name: chk1
+        startup: enabled
+        status: up
+        successes: 5
+        failures: 0
+        threshold: 3
+        change-id: "1"
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }
@@ -311,7 +310,7 @@ func (s *PebbleSuite) TestNoChecksJSON(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "json"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, `{"checks":[]}`+"\n")
+	c.Check(s.Stdout(), check.Equals, `{"checks":{}}`+"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -325,7 +324,7 @@ func (s *PebbleSuite) TestNoChecksYAML(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"checks", "--format", "yaml"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, "checks: []\n")
+	c.Check(s.Stdout(), check.Equals, "checks: {}\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 


### PR DESCRIPTION
adds `--format` flag to support structured output formats to `checks` and `check` commands.

Towards #824 