### PR TITLE
feat(cli): add structured output formats to `ls`

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -454,10 +454,13 @@ pattern
 may be specified for the last path element.
 
 [ls command options]
-          --abs-time  Display absolute times (in RFC 3339 format). Otherwise,
-                      display relative times up to 60 days, then YYYY-MM-DD.
-      -d              List matching entries themselves, not directory contents
-      -l              Use a long listing format
+          --abs-time                Display absolute times (in RFC 3339
+                                    format). Otherwise, display relative times
+                                    up to 60 days, then YYYY-MM-DD.
+          --format=[text|json|yaml] Output format (default: text)
+      -d                            List matching entries themselves, not
+                                    directory contents
+      -l                            Use a long listing format
 ```
 <!-- END AUTOMATED OUTPUT FOR ls -->
 

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -17,8 +17,10 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
 	pathpkg "path"
 	"strings"
+	"time"
 
 	"github.com/canonical/go-flags"
 	"github.com/canonical/x-go/strutil/quantity"
@@ -36,6 +38,7 @@ type cmdLs struct {
 	client *client.Client
 
 	timeMixin
+	formatMixin
 	Directory  bool `short:"d"`
 	LongFormat bool `short:"l"`
 	Positional struct {
@@ -48,7 +51,7 @@ func init() {
 		Name:        "ls",
 		Summary:     cmdLsSummary,
 		Description: cmdLsDescription,
-		ArgsHelp: merge(timeArgsHelp, map[string]string{
+		ArgsHelp: merge(timeArgsHelp, formatArgsHelp, map[string]string{
 			"-d": "List matching entries themselves, not directory contents",
 			"-l": "Use a long listing format",
 		}),
@@ -56,6 +59,51 @@ func init() {
 			return &cmdLs{client: opts.Client}
 		},
 	})
+}
+
+type fileEntry struct {
+	Path         string `json:"path" yaml:"path"`
+	Name         string `json:"name" yaml:"name"`
+	Type         string `json:"type" yaml:"type"`
+	Size         *int64 `json:"size,omitempty" yaml:"size,omitempty"`
+	Permissions  string `json:"permissions" yaml:"permissions"`
+	LastModified string `json:"last-modified" yaml:"last-modified"`
+	UserID       *int   `json:"user-id" yaml:"user-id"`
+	User         string `json:"user" yaml:"user"`
+	GroupID      *int   `json:"group-id" yaml:"group-id"`
+	Group        string `json:"group" yaml:"group"`
+}
+
+type lsResult struct {
+	Files []fileEntry `json:"files" yaml:"files"`
+}
+
+func fileInfoToEntry(fi *client.FileInfo) fileEntry {
+	entry := fileEntry{
+		Path:         fi.Path(),
+		Name:         fi.Name(),
+		Permissions:  fmt.Sprintf("%03o", fi.Mode().Perm()),
+		LastModified: fi.ModTime().Format(time.RFC3339),
+		User:         fi.User(),
+		Group:        fi.Group(),
+	}
+	switch {
+	case fi.Mode().IsDir():
+		entry.Type = "directory"
+	case fi.Mode()&os.ModeSymlink != 0:
+		entry.Type = "symlink"
+	default:
+		entry.Type = "file"
+		size := fi.Size()
+		entry.Size = &size
+	}
+	if uid := fi.UserID(); uid != nil {
+		entry.UserID = uid
+	}
+	if gid := fi.GroupID(); gid != nil {
+		entry.GroupID = gid
+	}
+	return entry
 }
 
 func (cmd *cmdLs) Execute(args []string) error {
@@ -77,6 +125,18 @@ func (cmd *cmdLs) Execute(args []string) error {
 		return err
 	}
 
+	if cmd.Format == "text" {
+		return cmd.writeText(files)
+	}
+
+	entries := make([]fileEntry, len(files))
+	for i, fi := range files {
+		entries[i] = fileInfoToEntry(fi)
+	}
+	return cmd.formatNonText(lsResult{Files: entries})
+}
+
+func (cmd *cmdLs) writeText(files []*client.FileInfo) error {
 	w := tabWriter()
 	defer w.Flush()
 	for _, fi := range files {
@@ -92,7 +152,6 @@ func (cmd *cmdLs) Execute(args []string) error {
 			fmt.Fprintln(w, fi.Name())
 		}
 	}
-
 	return nil
 }
 

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -68,9 +68,9 @@ type fileEntry struct {
 	Size         *int64 `json:"size,omitempty" yaml:"size,omitempty"`
 	Permissions  string `json:"permissions" yaml:"permissions"`
 	LastModified string `json:"last-modified" yaml:"last-modified"`
-	UserID       *int   `json:"user-id" yaml:"user-id"`
+	UserID       *int   `json:"user-id,omitempty" yaml:"user-id,omitempty"`
 	User         string `json:"user" yaml:"user"`
-	GroupID      *int   `json:"group-id" yaml:"group-id"`
+	GroupID      *int   `json:"group-id,omitempty" yaml:"group-id,omitempty"`
 	Group        string `json:"group" yaml:"group"`
 }
 
@@ -78,30 +78,41 @@ type lsResult struct {
 	Files []fileEntry `json:"files" yaml:"files"`
 }
 
+func fileModeToType(mode os.FileMode) string {
+	switch {
+	case mode&os.ModeType == 0:
+		return "file"
+	case mode&os.ModeDir != 0:
+		return "directory"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	case mode&os.ModeNamedPipe != 0:
+		return "named-pipe"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	default:
+		return "unknown"
+	}
+}
+
 func fileInfoToEntry(fi *client.FileInfo) fileEntry {
+	mode := fi.Mode()
 	entry := fileEntry{
 		Path:         fi.Path(),
 		Name:         fi.Name(),
-		Permissions:  fmt.Sprintf("%03o", fi.Mode().Perm()),
+		Type:         fileModeToType(mode),
+		Permissions:  fmt.Sprintf("%03o", mode.Perm()),
 		LastModified: fi.ModTime().Format(time.RFC3339),
+		UserID:       fi.UserID(),
 		User:         fi.User(),
+		GroupID:      fi.GroupID(),
 		Group:        fi.Group(),
 	}
-	switch {
-	case fi.Mode().IsDir():
-		entry.Type = "directory"
-	case fi.Mode()&os.ModeSymlink != 0:
-		entry.Type = "symlink"
-	default:
-		entry.Type = "file"
+	if mode.IsRegular() {
 		size := fi.Size()
 		entry.Size = &size
-	}
-	if uid := fi.UserID(); uid != nil {
-		entry.UserID = uid
-	}
-	if gid := fi.GroupID(); gid != nil {
-		entry.GroupID = gid
 	}
 	return entry
 }
@@ -129,9 +140,9 @@ func (cmd *cmdLs) Execute(args []string) error {
 		return cmd.writeText(files)
 	}
 
-	entries := make([]fileEntry, len(files))
-	for i, fi := range files {
-		entries[i] = fileInfoToEntry(fi)
+	entries := make([]fileEntry, 0, len(files))
+	for _, fi := range files {
+		entries = append(entries, fileInfoToEntry(fi))
 	}
 	return cmd.formatNonText(lsResult{Files: entries})
 }

--- a/internals/cli/cmd_ls.go
+++ b/internals/cli/cmd_ls.go
@@ -69,9 +69,9 @@ type fileEntry struct {
 	Permissions  string `json:"permissions" yaml:"permissions"`
 	LastModified string `json:"last-modified" yaml:"last-modified"`
 	UserID       *int   `json:"user-id,omitempty" yaml:"user-id,omitempty"`
-	User         string `json:"user" yaml:"user"`
+	User         string `json:"user,omitempty" yaml:"user,omitempty"`
 	GroupID      *int   `json:"group-id,omitempty" yaml:"group-id,omitempty"`
-	Group        string `json:"group" yaml:"group"`
+	Group        string `json:"group,omitempty" yaml:"group,omitempty"`
 }
 
 type lsResult struct {

--- a/internals/cli/cmd_ls_test.go
+++ b/internals/cli/cmd_ls_test.go
@@ -184,7 +184,7 @@ func (s *PebbleSuite) TestLsJSON(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "json", "/"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
-	c.Check(s.Stdout(), Matches, `\{"files":\[.*\]\}\n`)
+	c.Check(s.Stdout(), Equals, `{"files":[{"path":"/foo","name":"foo","type":"directory","permissions":"777","last-modified":"2016-04-21T01:02:03Z","user-id":0,"user":"root","group-id":0,"group":"root"},{"path":"/bar","name":"bar","type":"file","size":1024,"permissions":"644","last-modified":"2021-04-21T01:02:03Z","user-id":600,"user":"toor","group-id":600,"group":"toor"}]}`+"\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 
@@ -212,7 +212,18 @@ func (s *PebbleSuite) TestLsYAML(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "yaml", "-d", "/"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
-	c.Check(s.Stdout(), Matches, `(?s)files:\n    - path: /\n.*`)
+	c.Check(s.Stdout(), Equals, `
+files:
+- path: /
+	name: /
+	type: directory
+	permissions: "777"
+	last-modified: "2016-04-21T01:02:03Z"
+	user-id: 0
+	user: root
+	group-id: 0
+	group: root
+`)
 	c.Check(s.Stderr(), Equals, "")
 }
 

--- a/internals/cli/cmd_ls_test.go
+++ b/internals/cli/cmd_ls_test.go
@@ -145,3 +145,106 @@ func (s *PebbleSuite) TestLsInvalidPattern(c *C) {
 	c.Check(s.Stdout(), Equals, "")
 	c.Check(s.Stderr(), Equals, "")
 }
+
+func (s *PebbleSuite) TestLsJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/v1/files")
+		c.Assert(r.URL.Query(), DeepEquals, url.Values{"action": {"list"}, "path": {"/"}})
+		fmt.Fprintln(w, `{
+	"type": "sync",
+	"result": [
+		{
+			"path": "/foo",
+			"name": "foo",
+			"type": "directory",
+			"permissions": "777",
+			"last-modified": "2016-04-21T01:02:03Z",
+			"user-id": 0,
+			"user": "root",
+			"group-id": 0,
+			"group": "root"
+		},
+		{
+			"path": "/bar",
+			"name": "bar",
+			"type": "file",
+			"permissions": "644",
+			"last-modified": "2021-04-21T01:02:03Z",
+			"user-id": 600,
+			"user": "toor",
+			"group-id": 600,
+			"group": "toor",
+			"size": 1024
+		}
+	]
+}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "json", "/"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Matches, `\{"files":\[.*\]\}\n`)
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestLsYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/v1/files")
+		c.Assert(r.URL.Query(), DeepEquals, url.Values{"action": {"list"}, "path": {"/"}, "itself": {"true"}})
+		fmt.Fprintln(w, `{
+	"type": "sync",
+	"result": [{
+		"path": "/",
+		"name": "/",
+		"type": "directory",
+		"permissions": "777",
+		"last-modified": "2016-04-21T01:02:03Z",
+		"user-id": 0,
+		"user": "root",
+		"group-id": 0,
+		"group": "root"
+	}]
+}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "yaml", "-d", "/"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Matches, `(?s)files:\n    - path: /\n.*`)
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestLsEmptyJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/v1/files")
+		fmt.Fprintln(w, `{"type":"sync","result":[]}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "json", "/empty"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, `{"files":[]}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestLsEmptyYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, Equals, "GET")
+		c.Assert(r.URL.Path, Equals, "/v1/files")
+		fmt.Fprintln(w, `{"type":"sync","result":[]}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "yaml", "/empty"})
+	c.Assert(err, IsNil)
+	c.Assert(rest, HasLen, 0)
+	c.Check(s.Stdout(), Equals, "files: []\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestLsInvalidFormat(c *C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "foobar", "/"})
+	c.Assert(err, ErrorMatches, "Invalid value.*for option.*--format.*")
+}

--- a/internals/cli/cmd_ls_test.go
+++ b/internals/cli/cmd_ls_test.go
@@ -176,6 +176,18 @@ func (s *PebbleSuite) TestLsJSON(c *C) {
 			"group-id": 600,
 			"group": "toor",
 			"size": 1024
+		},
+		{
+			"path": "/baz",
+			"name": "baz",
+			"type": "file",
+			"permissions": "600",
+			"last-modified": "2023-01-01T00:00:00Z",
+			"user-id": null,
+			"user": "",
+			"group-id": null,
+			"group": "",
+			"size": 0
 		}
 	]
 }`)
@@ -184,7 +196,7 @@ func (s *PebbleSuite) TestLsJSON(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"ls", "--format", "json", "/"})
 	c.Assert(err, IsNil)
 	c.Assert(rest, HasLen, 0)
-	c.Check(s.Stdout(), Equals, `{"files":[{"path":"/foo","name":"foo","type":"directory","permissions":"777","last-modified":"2016-04-21T01:02:03Z","user-id":0,"user":"root","group-id":0,"group":"root"},{"path":"/bar","name":"bar","type":"file","size":1024,"permissions":"644","last-modified":"2021-04-21T01:02:03Z","user-id":600,"user":"toor","group-id":600,"group":"toor"}]}`+"\n")
+	c.Check(s.Stdout(), Equals, `{"files":[{"path":"/foo","name":"foo","type":"directory","permissions":"777","last-modified":"2016-04-21T01:02:03Z","user-id":0,"user":"root","group-id":0,"group":"root"},{"path":"/bar","name":"bar","type":"file","size":1024,"permissions":"644","last-modified":"2021-04-21T01:02:03Z","user-id":600,"user":"toor","group-id":600,"group":"toor"},{"path":"/baz","name":"baz","type":"file","size":0,"permissions":"600","last-modified":"2023-01-01T00:00:00Z"}]}`+"\n")
 	c.Check(s.Stderr(), Equals, "")
 }
 

--- a/internals/cli/cmd_ls_test.go
+++ b/internals/cli/cmd_ls_test.go
@@ -214,16 +214,16 @@ func (s *PebbleSuite) TestLsYAML(c *C) {
 	c.Assert(rest, HasLen, 0)
 	c.Check(s.Stdout(), Equals, `
 files:
-- path: /
-	name: /
-	type: directory
-	permissions: "777"
-	last-modified: "2016-04-21T01:02:03Z"
-	user-id: 0
-	user: root
-	group-id: 0
-	group: root
-`)
+    - path: /
+      name: /
+      type: directory
+      permissions: "777"
+      last-modified: "2016-04-21T01:02:03Z"
+      user-id: 0
+      user: root
+      group-id: 0
+      group: root
+`[1:])
 	c.Check(s.Stderr(), Equals, "")
 }
 


### PR DESCRIPTION
adds `--format` flag to support structured output formats to the `ls` command.

Towards #824 