### PR TITLE
feat(cli): add structured output formats to `changes` & `tasks`

### DIFF
--- a/client/changes.go
+++ b/client/changes.go
@@ -26,16 +26,16 @@ import (
 
 // Change is a modification to the system state.
 type Change struct {
-	ID      string  `json:"id"`
-	Kind    string  `json:"kind"`
-	Summary string  `json:"summary"`
-	Status  string  `json:"status"`
-	Tasks   []*Task `json:"tasks,omitempty"`
-	Ready   bool    `json:"ready"`
-	Err     string  `json:"err,omitempty"`
+	ID      string  `json:"id" yaml:"id"`
+	Kind    string  `json:"kind" yaml:"kind"`
+	Summary string  `json:"summary" yaml:"summary"`
+	Status  string  `json:"status" yaml:"status"`
+	Tasks   []*Task `json:"tasks,omitempty" yaml:"tasks,omitempty"`
+	Ready   bool    `json:"ready" yaml:"ready"`
+	Err     string  `json:"err,omitempty" yaml:"err,omitempty"`
 
-	SpawnTime time.Time `json:"spawn-time"`
-	ReadyTime time.Time `json:"ready-time"`
+	SpawnTime time.Time `json:"spawn-time" yaml:"spawn-time"`
+	ReadyTime time.Time `json:"ready-time,omitzero" yaml:"ready-time,omitempty"`
 
 	data map[string]*json.RawMessage
 }
@@ -54,17 +54,17 @@ func (c *Change) Get(key string, value any) error {
 
 // Task represents a single operation done to change the system's state.
 type Task struct {
-	ID       string       `json:"id"`
-	Kind     string       `json:"kind"`
-	Summary  string       `json:"summary"`
-	Status   string       `json:"status"`
-	Log      []string     `json:"log,omitempty"`
-	Progress TaskProgress `json:"progress"`
+	ID       string       `json:"id" yaml:"id"`
+	Kind     string       `json:"kind" yaml:"kind"`
+	Summary  string       `json:"summary" yaml:"summary"`
+	Status   string       `json:"status" yaml:"status"`
+	Log      []string     `json:"log,omitempty" yaml:"log,omitempty"`
+	Progress TaskProgress `json:"progress" yaml:"progress"`
 
-	SpawnTime time.Time `json:"spawn-time"`
-	ReadyTime time.Time `json:"ready-time"`
+	SpawnTime time.Time `json:"spawn-time" yaml:"spawn-time"`
+	ReadyTime time.Time `json:"ready-time,omitzero" yaml:"ready-time,omitempty"`
 
-	Data map[string]*json.RawMessage
+	Data map[string]*json.RawMessage `json:"data,omitempty" yaml:"data,omitempty"`
 }
 
 // Get unmarshals into value the kind-specific data with the provided key.
@@ -78,9 +78,9 @@ func (t *Task) Get(key string, value any) error {
 
 // TaskProgress represents the completion progress of a task.
 type TaskProgress struct {
-	Label string `json:"label"`
-	Done  int    `json:"done"`
-	Total int    `json:"total"`
+	Label string `json:"label" yaml:"label"`
+	Done  int    `json:"done" yaml:"done"`
+	Total int    `json:"total" yaml:"total"`
 }
 
 type changeAndData struct {

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -103,8 +103,10 @@ Usage:
 The changes command displays a summary of system changes performed recently.
 
 [changes command options]
-      --abs-time     Display absolute times (in RFC 3339 format). Otherwise,
-                     display relative times up to 60 days, then YYYY-MM-DD.
+      --abs-time                  Display absolute times (in RFC 3339 format).
+                                  Otherwise, display relative times up to 60
+                                  days, then YYYY-MM-DD.
+      --format=[text|json|yaml]   Output format (default: text)
 ```
 <!-- END AUTOMATED OUTPUT FOR changes -->
 
@@ -1199,17 +1201,20 @@ The tasks command displays a summary of tasks associated with an individual
 change that happened recently.
 
 [tasks command options]
-      --abs-time       Display absolute times (in RFC 3339 format). Otherwise,
-                       display relative times up to 60 days, then YYYY-MM-DD.
-      --last=          Select last change of given type (install, refresh,
-                       remove, try, auto-refresh, etc.). A question mark at the
-                       end of the type means to do nothing (instead of
-                       returning an error) if no change of the given type is
-                       found. Note the question mark could need protecting from
-                       the shell.
+      --abs-time                  Display absolute times (in RFC 3339 format).
+                                  Otherwise, display relative times up to 60
+                                  days, then YYYY-MM-DD.
+      --format=[text|json|yaml]   Output format (default: text)
+      --last=                     Select last change of given type (install,
+                                  refresh, remove, try, auto-refresh, etc.). A
+                                  question mark at the end of the type means to
+                                  do nothing (instead of returning an error) if
+                                  no change of the given type is found. Note
+                                  the question mark could need protecting from
+                                  the shell.
 
 [tasks command arguments]
-  <change-id>:         Change ID
+  <change-id>:                    Change ID
 ```
 <!-- END AUTOMATED OUTPUT FOR tasks -->
 

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -34,6 +34,7 @@ type cmdChanges struct {
 	client *client.Client
 
 	timeMixin
+	formatMixin
 	Positional struct {
 		Service string `positional-arg-name:"<service>"`
 	} `positional-args:"yes"`
@@ -49,6 +50,7 @@ type cmdTasks struct {
 	client *client.Client
 
 	timeMixin
+	formatMixin
 	changeIDMixin
 }
 
@@ -57,7 +59,7 @@ func init() {
 		Name:        "changes",
 		Summary:     cmdChangesSummary,
 		Description: cmdChangesDescription,
-		ArgsHelp:    timeArgsHelp,
+		ArgsHelp:    merge(timeArgsHelp, formatArgsHelp),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdChanges{client: opts.Client}
 		},
@@ -66,7 +68,7 @@ func init() {
 		Name:        "tasks",
 		Summary:     cmdTasksSummary,
 		Description: cmdTasksDescription,
-		ArgsHelp:    merge(changeIDMixinArgsHelp, timeArgsHelp),
+		ArgsHelp:    merge(changeIDMixinArgsHelp, timeArgsHelp, formatArgsHelp),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdTasks{client: opts.Client}
 		},
@@ -116,12 +118,26 @@ func (c *cmdChanges) Execute(args []string) error {
 		return err
 	}
 
-	if len(changes) == 0 {
-		return fmt.Errorf("no changes found")
-	}
-
 	sort.Sort(changesByTime(changes))
 
+	if c.Format == "text" {
+		if len(changes) == 0 {
+			return fmt.Errorf("no changes found")
+		}
+		return c.writeText(changes)
+	}
+
+	if changes == nil {
+		changes = []*client.Change{}
+	}
+	return c.formatNonText(changesResult{Changes: changes})
+}
+
+type changesResult struct {
+	Changes []*client.Change `json:"changes" yaml:"changes"`
+}
+
+func (c *cmdChanges) writeText(changes []*client.Change) error {
 	w := tabWriter()
 
 	fmt.Fprintf(w, "ID\tStatus\tSpawn\tReady\tSummary\n")
@@ -152,6 +168,10 @@ func (c *cmdTasks) Execute([]string) error {
 	return c.showChange(chid)
 }
 
+type taskResult struct {
+	Change *client.Change `json:"change" yaml:"change"`
+}
+
 func queryChange(cli *client.Client, chid string) (*client.Change, error) {
 	chg, err := cli.Change(chid)
 	if err != nil {
@@ -169,6 +189,14 @@ func (c *cmdTasks) showChange(chid string) error {
 		return err
 	}
 
+	if c.Format == "text" {
+		return c.writeText(chg)
+	}
+
+	return c.formatNonText(taskResult{Change: chg})
+}
+
+func (c *cmdTasks) writeText(chg *client.Change) error {
 	w := tabWriter()
 
 	fmt.Fprintf(w, "Status\tSpawn\tReady\tSummary\n")

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -190,14 +190,14 @@ func (c *cmdTasks) showChange(chid string) error {
 	}
 
 	tasks := chg.Tasks
-	if tasks == nil {
-		tasks = []*client.Task{}
-	}
 
 	if c.Format == "text" {
 		return c.writeText(tasks)
 	}
 
+	if tasks == nil {
+		tasks = []*client.Task{}
+	}
 	return c.formatNonText(taskResult{Tasks: tasks})
 }
 

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -169,7 +169,7 @@ func (c *cmdTasks) Execute([]string) error {
 }
 
 type taskResult struct {
-	Change *client.Change `json:"change" yaml:"change"`
+	Tasks []*client.Task `json:"tasks" yaml:"tasks"`
 }
 
 func queryChange(cli *client.Client, chid string) (*client.Change, error) {
@@ -189,18 +189,23 @@ func (c *cmdTasks) showChange(chid string) error {
 		return err
 	}
 
-	if c.Format == "text" {
-		return c.writeText(chg)
+	tasks := chg.Tasks
+	if tasks == nil {
+		tasks = []*client.Task{}
 	}
 
-	return c.formatNonText(taskResult{Change: chg})
+	if c.Format == "text" {
+		return c.writeText(tasks)
+	}
+
+	return c.formatNonText(taskResult{Tasks: tasks})
 }
 
-func (c *cmdTasks) writeText(chg *client.Change) error {
+func (c *cmdTasks) writeText(tasks []*client.Task) error {
 	w := tabWriter()
 
 	fmt.Fprintf(w, "Status\tSpawn\tReady\tSummary\n")
-	for _, t := range chg.Tasks {
+	for _, t := range tasks {
 		spawnTime := c.fmtTime(t.SpawnTime)
 		readyTime := c.fmtTime(t.ReadyTime)
 		if t.ReadyTime.IsZero() {
@@ -215,7 +220,7 @@ func (c *cmdTasks) writeText(chg *client.Change) error {
 
 	w.Flush()
 
-	for _, t := range chg.Tasks {
+	for _, t := range tasks {
 		if len(t.Log) == 0 {
 			continue
 		}

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -463,7 +463,7 @@ func (s *PebbleSuite) TestTasksJSON(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"tasks", "--format", "json", "42"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, `{"change":{"id":"uno","kind":"foo","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}}`+"\n")
+	c.Check(s.Stdout(), check.Equals, `{"tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}]}`+"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -478,23 +478,16 @@ func (s *PebbleSuite) TestTasksYAML(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-change:
-    id: uno
-    kind: foo
-    summary: '...'
-    status: Do
-    tasks:
-        - id: ""
-          kind: bar
-          summary: some summary
-          status: Do
-          progress:
-            label: ""
-            done: 0
-            total: 1
-          spawn-time: 2016-04-21T01:02:03Z
-    ready: false
-    spawn-time: 2016-04-21T01:02:03Z
+tasks:
+    - id: ""
+      kind: bar
+      summary: some summary
+      status: Do
+      progress:
+        label: ""
+        done: 0
+        total: 1
+      spawn-time: 2016-04-21T01:02:03Z
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -30,6 +30,69 @@ import (
 	"github.com/canonical/pebble/internals/cli"
 )
 
+var fakeChangeJSON = `{"type": "sync", "result": {
+  "id":   "uno",
+  "kind": "foo",
+  "summary": "...",
+  "status": "Do",
+  "ready": false,
+  "spawn-time": "2016-04-21T01:02:03Z",
+  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z"}]
+}}`
+
+var fakeChangesJSON = `{"type": "sync", "result": [
+  {
+    "id":   "four",
+    "kind": "install",
+    "summary": "...",
+    "status": "Do",
+    "ready": false,
+    "spawn-time": "2015-02-21T01:02:03Z",
+    "ready-time": "2015-02-21T01:02:04Z",
+    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z"}]
+  },
+  {
+    "id":   "one",
+    "kind": "remove",
+    "summary": "...",
+    "status": "Do",
+    "ready": false,
+    "spawn-time": "2016-03-21T01:02:03Z",
+    "ready-time": "2016-03-21T01:02:04Z",
+    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-03-21T01:02:03Z", "ready-time": "2016-03-21T01:02:04Z"}]
+  },
+  {
+    "id":   "two",
+    "kind": "install",
+    "summary": "...",
+    "status": "Do",
+    "ready": false,
+    "spawn-time": "2016-04-21T01:02:03Z",
+    "ready-time": "2016-04-21T01:02:04Z",
+    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
+  },
+  {
+    "id":   "three",
+    "kind": "install",
+    "summary": "...",
+    "status": "Do",
+    "ready": false,
+    "spawn-time": "2016-01-21T01:02:03Z",
+    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-01-21T01:02:03Z", "ready-time": "2016-01-21T01:02:04Z"}]
+  }
+]}`
+
+var fakeChangeInProgressJSON = `{"type": "sync", "result": {
+  "id":   "uno",
+  "kind": "foo",
+  "summary": "...",
+  "status": "Do",
+  "ready": false,
+  "spawn-time": "2016-04-21T01:02:03Z",
+  "ready-time": "2016-04-21T01:02:04Z",
+  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Doing", "progress": {"done": 50, "total": 100}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z", "log": ["a", "b", "c"]}]
+}}`
+
 func (s *PebbleSuite) TestChangesExtraArgs(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"changes", "extra", "args"})
 	c.Assert(err, check.Equals, cli.ErrExtraArgs)
@@ -101,6 +164,144 @@ two +Do +2016-04-21 +2016-04-2[12] +...
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
+func (s *PebbleSuite) TestChangesJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/changes")
+		c.Check(r.URL.Query(), check.DeepEquals, url.Values{"select": {"all"}})
+		fmt.Fprintln(w, fakeChangesJSON)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"changes", "--format", "json"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"changes":[{"id":"four","kind":"install","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2015-02-21T01:02:03Z","ready-time":"2015-02-21T01:02:04Z"}],"ready":false,"spawn-time":"2015-02-21T01:02:03Z","ready-time":"2015-02-21T01:02:04Z"},{"id":"three","kind":"install","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-01-21T01:02:03Z","ready-time":"2016-01-21T01:02:04Z"}],"ready":false,"spawn-time":"2016-01-21T01:02:03Z"},{"id":"one","kind":"remove","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-03-21T01:02:03Z","ready-time":"2016-03-21T01:02:04Z"}],"ready":false,"spawn-time":"2016-03-21T01:02:03Z","ready-time":"2016-03-21T01:02:04Z"},{"id":"two","kind":"install","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:04Z"}],"ready":false,"spawn-time":"2016-04-21T01:02:03Z","ready-time":"2016-04-21T01:02:04Z"}]}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestChangesYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/changes")
+		c.Check(r.URL.Query(), check.DeepEquals, url.Values{"select": {"all"}})
+		fmt.Fprintln(w, fakeChangesJSON)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"changes", "--format", "yaml"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+changes:
+    - id: four
+      kind: install
+      summary: '...'
+      status: Do
+      tasks:
+        - id: ""
+          kind: bar
+          summary: some summary
+          status: Do
+          progress:
+            label: ""
+            done: 0
+            total: 1
+          spawn-time: 2015-02-21T01:02:03Z
+          ready-time: 2015-02-21T01:02:04Z
+      ready: false
+      spawn-time: 2015-02-21T01:02:03Z
+      ready-time: 2015-02-21T01:02:04Z
+    - id: three
+      kind: install
+      summary: '...'
+      status: Do
+      tasks:
+        - id: ""
+          kind: bar
+          summary: some summary
+          status: Do
+          progress:
+            label: ""
+            done: 0
+            total: 1
+          spawn-time: 2016-01-21T01:02:03Z
+          ready-time: 2016-01-21T01:02:04Z
+      ready: false
+      spawn-time: 2016-01-21T01:02:03Z
+    - id: one
+      kind: remove
+      summary: '...'
+      status: Do
+      tasks:
+        - id: ""
+          kind: bar
+          summary: some summary
+          status: Do
+          progress:
+            label: ""
+            done: 0
+            total: 1
+          spawn-time: 2016-03-21T01:02:03Z
+          ready-time: 2016-03-21T01:02:04Z
+      ready: false
+      spawn-time: 2016-03-21T01:02:03Z
+      ready-time: 2016-03-21T01:02:04Z
+    - id: two
+      kind: install
+      summary: '...'
+      status: Do
+      tasks:
+        - id: ""
+          kind: bar
+          summary: some summary
+          status: Do
+          progress:
+            label: ""
+            done: 0
+            total: 1
+          spawn-time: 2016-04-21T01:02:03Z
+          ready-time: 2016-04-21T01:02:04Z
+      ready: false
+      spawn-time: 2016-04-21T01:02:03Z
+      ready-time: 2016-04-21T01:02:04Z
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestNoChangesJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/changes")
+		c.Check(r.URL.Query(), check.DeepEquals, url.Values{"select": {"all"}})
+		fmt.Fprintln(w, `{"type":"sync", "result": []}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"changes", "--format", "json"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"changes":[]}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestNoChangesYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/changes")
+		c.Check(r.URL.Query(), check.DeepEquals, url.Values{"select": {"all"}})
+		fmt.Fprintln(w, `{"type":"sync", "result": []}`)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"changes", "--format", "yaml"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, "changes: []\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestChangesInvalidFormat(c *check.C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"changes", "--format", "foobar"})
+	c.Assert(err, check.ErrorMatches, "Invalid value.*for option.*--format.*")
+}
+
 func (s *PebbleSuite) TestChangesUnknownMaintenance(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, check.Equals, "GET")
@@ -116,16 +317,6 @@ func (s *PebbleSuite) TestChangesUnknownMaintenance(c *check.C) {
 	c.Check(s.Stdout(), check.Matches, "")
 	c.Check(s.Stderr(), check.Equals, "")
 }
-
-var fakeChangeJSON = `{"type": "sync", "result": {
-  "id":   "uno",
-  "kind": "foo",
-  "summary": "...",
-  "status": "Do",
-  "ready": false,
-  "spawn-time": "2016-04-21T01:02:03Z",
-  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z"}]
-}}`
 
 func (s *PebbleSuite) TestChangeSimple(c *check.C) {
 	n := 0
@@ -195,48 +386,6 @@ func (s *PebbleSuite) TestChangeSimpleUnknownMaintenance(c *check.C) {
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
-var fakeChangesJSON = `{"type": "sync", "result": [
-  {
-    "id":   "four",
-    "kind": "install",
-    "summary": "...",
-    "status": "Do",
-    "ready": false,
-    "spawn-time": "2015-02-21T01:02:03Z",
-    "ready-time": "2015-02-21T01:02:04Z",
-    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2015-02-21T01:02:03Z", "ready-time": "2015-02-21T01:02:04Z"}]
-  },
-  {
-    "id":   "one",
-    "kind": "remove",
-    "summary": "...",
-    "status": "Do",
-    "ready": false,
-    "spawn-time": "2016-03-21T01:02:03Z",
-    "ready-time": "2016-03-21T01:02:04Z",
-    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-03-21T01:02:03Z", "ready-time": "2016-03-21T01:02:04Z"}]
-  },
-  {
-    "id":   "two",
-    "kind": "install",
-    "summary": "...",
-    "status": "Do",
-    "ready": false,
-    "spawn-time": "2016-04-21T01:02:03Z",
-    "ready-time": "2016-04-21T01:02:04Z",
-    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
-  },
-  {
-    "id":   "three",
-    "kind": "install",
-    "summary": "...",
-    "status": "Do",
-    "ready": false,
-    "spawn-time": "2016-01-21T01:02:03Z",
-    "tasks": [{"kind": "bar", "summary": "some summary", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-01-21T01:02:03Z", "ready-time": "2016-01-21T01:02:04Z"}]
-  }
-]}`
-
 func (s *PebbleSuite) TestTasksLast(c *check.C) {
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		c.Check(r.Method, check.Equals, "GET")
@@ -304,16 +453,56 @@ func (s *PebbleSuite) TestTasksSyntaxError(c *check.C) {
 	c.Assert(err, check.ErrorMatches, `please provide change ID or type with --last=<type>`)
 }
 
-var fakeChangeInProgressJSON = `{"type": "sync", "result": {
-  "id":   "uno",
-  "kind": "foo",
-  "summary": "...",
-  "status": "Do",
-  "ready": false,
-  "spawn-time": "2016-04-21T01:02:03Z",
-  "ready-time": "2016-04-21T01:02:04Z",
-  "tasks": [{"kind": "bar", "summary": "some summary", "status": "Doing", "progress": {"done": 50, "total": 100}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z", "log": ["a", "b", "c"]}]
-}}`
+func (s *PebbleSuite) TestTasksJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/changes/42")
+		fmt.Fprintln(w, fakeChangeJSON)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"tasks", "--format", "json", "42"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `{"change":{"id":"uno","kind":"foo","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestTasksYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		c.Check(r.Method, check.Equals, "GET")
+		c.Check(r.URL.Path, check.Equals, "/v1/changes/42")
+		fmt.Fprintln(w, fakeChangeJSON)
+	})
+
+	rest, err := cli.ParserForTest().ParseArgs([]string{"tasks", "--format", "yaml", "42"})
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
+	c.Check(s.Stdout(), check.Equals, `
+change:
+    id: uno
+    kind: foo
+    summary: '...'
+    status: Do
+    tasks:
+        - id: ""
+          kind: bar
+          summary: some summary
+          status: Do
+          progress:
+            label: ""
+            done: 0
+            total: 1
+          spawn-time: 2016-04-21T01:02:03Z
+    ready: false
+    spawn-time: 2016-04-21T01:02:03Z
+`[1:])
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestTasksInvalidFormat(c *check.C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"tasks", "--format", "foobar", "42"})
+	c.Assert(err, check.ErrorMatches, "Invalid value.*for option.*--format.*")
+}
 
 func (s *PebbleSuite) TestChangeProgress(c *check.C) {
 	n := 0


### PR DESCRIPTION
adds `--format` flag to support structured output formats to `changes` and `tasks` commands.

Example of `pebble changes` in YAML format:

```
$ pebble changes --format yaml
changes:
    - id: four
      kind: install
      summary: '...'
      status: Do
      tasks:
        - id: ""
          kind: bar
          summary: some summary
          status: Do
          progress:
            label: ""
            done: 0
            total: 1
          spawn-time: 2015-02-21T01:02:03Z
          ready-time: 2015-02-21T01:02:04Z
      ready: false
      spawn-time: 2015-02-21T01:02:03Z
      ready-time: 2015-02-21T01:02:04Z
    ...
```


Towards #824 