### PR TITLE
fix(cli): exit normally if "pebble changes" has no changes

### DIFF
--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -122,7 +122,8 @@ func (c *cmdChanges) Execute(args []string) error {
 
 	if c.Format == "text" {
 		if len(changes) == 0 {
-			return fmt.Errorf("no changes found")
+			fmt.Fprintln(Stderr, "no changes found")
+			return nil
 		}
 		return c.writeText(changes)
 	}

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -118,10 +118,10 @@ func (s *PebbleSuite) TestNoChanges(c *check.C) {
 	})
 
 	rest, err := cli.ParserForTest().ParseArgs([]string{"changes", "svc1"})
-	c.Assert(err, check.ErrorMatches, "no changes found")
-	c.Check(rest, check.HasLen, 1)
+	c.Assert(err, check.IsNil)
+	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "")
+	c.Check(s.Stderr(), check.Equals, "no changes found\n")
 }
 
 func (s *PebbleSuite) TestGetChangesFails(c *check.C) {


### PR DESCRIPTION
Updated as per https://github.com/canonical/snapd/pull/10245 to not return an error if no changes found. Now we return normally and just print an info message to `stderr`.

Resolves #846 