### PR TITLE
chore: prepare a CI-changes-only v1.30.1 release

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -61,6 +61,7 @@ jobs:
 
   remote-build:
     runs-on: ubuntu-latest
+    environment: snap-build
     if: github.event_name != 'pull_request'
     strategy:
       fail-fast: true
@@ -156,6 +157,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    environment: snap-build
     needs: [test]
     if: github.event_name != 'pull_request' && needs.test.result == 'success' && always()
     strategy:
@@ -184,6 +186,7 @@ jobs:
 
   promote:
     runs-on: ubuntu-latest
+    environment: snap-build
     needs: [release]
     if: github.event_name == 'release' && needs.release.result == 'success' && always()
     strategy:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 //go:generate ./mkversion.sh
 
 // Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.30.0"
+var Version = "v1.30.1"
 
 func MockVersion(version string) (restore func()) {
 	old := Version


### PR DESCRIPTION
Prepare for a v1.30.1 release.

This release doesn't include any non-CI changes compared with v1.30.0. At the time 1.30 was released, our snap building functionality was broken while we were rotating credentials and adjusting the workflow to use a dedicated environment. That's working now, but re-running the 1.30 release action doesn't work because at that time the workflow didn't point to the environment where the secrets now are located.