### PR TITLE
revert: return full change object for `tasks` cmd

### DIFF
--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -170,7 +170,7 @@ func (c *cmdTasks) Execute([]string) error {
 }
 
 type taskResult struct {
-	Tasks []*client.Task `json:"tasks" yaml:"tasks"`
+	Change *client.Change `json:"change" yaml:"change"`
 }
 
 func queryChange(cli *client.Client, chid string) (*client.Change, error) {
@@ -190,23 +190,18 @@ func (c *cmdTasks) showChange(chid string) error {
 		return err
 	}
 
-	tasks := chg.Tasks
-
 	if c.Format == "text" {
-		return c.writeText(tasks)
+		return c.writeText(chg)
 	}
 
-	if tasks == nil {
-		tasks = []*client.Task{}
-	}
-	return c.formatNonText(taskResult{Tasks: tasks})
+	return c.formatNonText(taskResult{Change: chg})
 }
 
-func (c *cmdTasks) writeText(tasks []*client.Task) error {
+func (c *cmdTasks) writeText(chg *client.Change) error {
 	w := tabWriter()
 
 	fmt.Fprintf(w, "Status\tSpawn\tReady\tSummary\n")
-	for _, t := range tasks {
+	for _, t := range chg.Tasks {
 		spawnTime := c.fmtTime(t.SpawnTime)
 		readyTime := c.fmtTime(t.ReadyTime)
 		if t.ReadyTime.IsZero() {
@@ -221,7 +216,7 @@ func (c *cmdTasks) writeText(tasks []*client.Task) error {
 
 	w.Flush()
 
-	for _, t := range tasks {
+	for _, t := range chg.Tasks {
 		if len(t.Log) == 0 {
 			continue
 		}

--- a/internals/cli/cmd_changes.go
+++ b/internals/cli/cmd_changes.go
@@ -169,10 +169,6 @@ func (c *cmdTasks) Execute([]string) error {
 	return c.showChange(chid)
 }
 
-type taskResult struct {
-	Change *client.Change `json:"change" yaml:"change"`
-}
-
 func queryChange(cli *client.Client, chid string) (*client.Change, error) {
 	chg, err := cli.Change(chid)
 	if err != nil {
@@ -194,7 +190,7 @@ func (c *cmdTasks) showChange(chid string) error {
 		return c.writeText(chg)
 	}
 
-	return c.formatNonText(taskResult{Change: chg})
+	return c.formatNonText(chg)
 }
 
 func (c *cmdTasks) writeText(chg *client.Change) error {

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -463,7 +463,7 @@ func (s *PebbleSuite) TestTasksJSON(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"tasks", "--format", "json", "42"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, `{"tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}]}`+"\n")
+	c.Check(s.Stdout(), check.Equals, `{"change":{"id":"uno","kind":"foo","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}}`+"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -478,16 +478,23 @@ func (s *PebbleSuite) TestTasksYAML(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-tasks:
-    - id: ""
-      kind: bar
-      summary: some summary
-      status: Do
-      progress:
-        label: ""
-        done: 0
-        total: 1
-      spawn-time: 2016-04-21T01:02:03Z
+change:
+    id: uno
+    kind: foo
+    summary: '...'
+    status: Do
+    tasks:
+        - id: ""
+          kind: bar
+          summary: some summary
+          status: Do
+          progress:
+            label: ""
+            done: 0
+            total: 1
+          spawn-time: 2016-04-21T01:02:03Z
+    ready: false
+    spawn-time: 2016-04-21T01:02:03Z
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }

--- a/internals/cli/cmd_changes_test.go
+++ b/internals/cli/cmd_changes_test.go
@@ -463,7 +463,7 @@ func (s *PebbleSuite) TestTasksJSON(c *check.C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"tasks", "--format", "json", "42"})
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, `{"change":{"id":"uno","kind":"foo","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}}`+"\n")
+	c.Check(s.Stdout(), check.Equals, `{"id":"uno","kind":"foo","summary":"...","status":"Do","tasks":[{"id":"","kind":"bar","summary":"some summary","status":"Do","progress":{"label":"","done":0,"total":1},"spawn-time":"2016-04-21T01:02:03Z"}],"ready":false,"spawn-time":"2016-04-21T01:02:03Z"}`+"\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 
@@ -478,23 +478,22 @@ func (s *PebbleSuite) TestTasksYAML(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Check(rest, check.HasLen, 0)
 	c.Check(s.Stdout(), check.Equals, `
-change:
-    id: uno
-    kind: foo
-    summary: '...'
-    status: Do
-    tasks:
-        - id: ""
-          kind: bar
-          summary: some summary
-          status: Do
-          progress:
-            label: ""
-            done: 0
-            total: 1
-          spawn-time: 2016-04-21T01:02:03Z
-    ready: false
-    spawn-time: 2016-04-21T01:02:03Z
+id: uno
+kind: foo
+summary: '...'
+status: Do
+tasks:
+    - id: ""
+      kind: bar
+      summary: some summary
+      status: Do
+      progress:
+        label: ""
+        done: 0
+        total: 1
+      spawn-time: 2016-04-21T01:02:03Z
+ready: false
+spawn-time: 2016-04-21T01:02:03Z
 `[1:])
 	c.Check(s.Stderr(), check.Equals, "")
 }


### PR DESCRIPTION
Roughly reverts https://github.com/canonical/pebble/pull/844/changes/9c7f7453360676b5b5114748ee96e7192abc337f as discussed in https://github.com/canonical/pebble/pull/844#pullrequestreview-4127211909.

Fixes #849 