### PR TITLE
chore: merge master into fips branch in preparation for 1.30.1

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -61,6 +61,7 @@ jobs:
 
   remote-build:
     runs-on: ubuntu-latest
+    environment: snap-build
     if: github.event_name != 'pull_request'
     strategy:
       fail-fast: true
@@ -156,6 +157,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    environment: snap-build
     needs: [test]
     if: github.event_name != 'pull_request' && needs.test.result == 'success' && always()
     strategy:
@@ -184,6 +186,7 @@ jobs:
 
   promote:
     runs-on: ubuntu-latest
+    environment: snap-build
     needs: [release]
     if: github.event_name == 'release' && needs.release.result == 'success' && always()
     strategy:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 //go:generate ./mkversion.sh
 
 // Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.30.0-fips"
+var Version = "v1.30.1-fips"
 
 func MockVersion(version string) (restore func()) {
 	old := Version

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 //go:generate ./mkversion.sh
 
 // Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.30.0"
+var Version = "v1.30.1"
 
 func MockVersion(version string) (restore func()) {
 	old := Version


### PR DESCRIPTION
Just a merge from master, only conflict the version string. This only brings in the build environment change, and bumps the version string.