### PR TITLE
docs: remove reference to promtail release which no longer exists

### DIFF
--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -67,6 +67,3 @@ See the {external+rockcraft:doc}`Rockcraft documentation <index>` to learn more.
 
 - After capturing logs, you can [forward the logs to Loki](./forward-logs-to-loki).
 - [Log forwarding](../reference/log-forwarding.md) also supports the OpenTelemetry protocol (OTLP).
-- If `tail` is insufficient, consider using the
-  [Promtail binary](https://github.com/canonical/loki-k8s-operator/blob/main/.github/workflows/build-promtail-release.yaml)
-  instead.


### PR DESCRIPTION
This should fix broken docs CI.