### PR TITLE
chore(daemon): rename InternalError to ServerError

### DIFF
--- a/internals/daemon/api_changes.go
+++ b/internals/daemon/api_changes.go
@@ -202,14 +202,14 @@ func v1GetChangeWait(c *Command, r *http.Request, _ *UserState) Response {
 		case <-timer.C:
 			return GatewayTimeout("timed out waiting for change after %s", timeout)
 		case <-r.Context().Done():
-			return InternalError("request cancelled")
+			return ServerError("request cancelled")
 		}
 	} else {
 		// No timeout, wait indefinitely for change to be ready.
 		select {
 		case <-change.Ready():
 		case <-r.Context().Done():
-			return InternalError("request cancelled")
+			return ServerError("request cancelled")
 		}
 	}
 

--- a/internals/daemon/api_checks.go
+++ b/internals/daemon/api_checks.go
@@ -53,7 +53,7 @@ func v1GetChecks(c *Command, r *http.Request, _ *UserState) Response {
 	checkMgr := c.d.overlord.CheckManager()
 	checks, err := checkMgr.Checks()
 	if err != nil {
-		return InternalError("%v", err)
+		return ServerError("%v", err)
 	}
 
 	infos := []checkInfo{} // if no checks, return [] instead of null
@@ -104,7 +104,7 @@ func v1PostChecks(c *Command, r *http.Request, user *UserState) Response {
 		if _, ok := err.(*checkstate.ChecksNotFound); ok {
 			return BadRequest("cannot %s checks: %v", payload.Action, err)
 		} else {
-			return InternalError("cannot %s checks: %v", payload.Action, err)
+			return ServerError("cannot %s checks: %v", payload.Action, err)
 		}
 	}
 

--- a/internals/daemon/api_exec.go
+++ b/internals/daemon/api_exec.go
@@ -104,7 +104,7 @@ func v1PostExec(c *Command, req *http.Request, user *UserState) Response {
 	}
 	task, metadata, err := cmdstate.Exec(st, args)
 	if err != nil {
-		return InternalError("cannot call exec: %v", err)
+		return ServerError("cannot call exec: %v", err)
 	}
 
 	change := st.NewChange("exec", fmt.Sprintf("Execute command %q", args.Command[0]))

--- a/internals/daemon/api_health.go
+++ b/internals/daemon/api_health.go
@@ -42,7 +42,7 @@ func v1Health(c *Command, r *http.Request, _ *UserState) Response {
 	checks, err := getChecks(c.d.overlord)
 	if err != nil {
 		logger.Noticef("Cannot fetch checks: %v", err.Error())
-		return InternalError("internal server error")
+		return ServerError("internal server error")
 	}
 
 	healthy := true

--- a/internals/daemon/api_logs.go
+++ b/internals/daemon/api_logs.go
@@ -87,7 +87,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if len(services) == 0 {
 		infos, err := r.svcMgr.Services(nil)
 		if err != nil {
-			response := InternalError("cannot fetch services: %v", err)
+			response := ServerError("cannot fetch services: %v", err)
 			response.ServeHTTP(w, req)
 			return
 		}
@@ -99,7 +99,7 @@ func (r logsResponse) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	itsByName, err := r.svcMgr.ServiceLogs(services, numLogs)
 	if err != nil {
-		response := InternalError("cannot fetch log iterators: %v", err)
+		response := ServerError("cannot fetch log iterators: %v", err)
 		response.ServeHTTP(w, req)
 		return
 	}

--- a/internals/daemon/api_notices.go
+++ b/internals/daemon/api_notices.go
@@ -124,7 +124,7 @@ func v1GetNotices(c *Command, r *http.Request, user *UserState) Response {
 		// DeadlineExceeded will occur if timeout elapses; in that case return
 		// an empty list of notices, not an error.
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-			return InternalError("cannot wait for notices: %s", err)
+			return ServerError("cannot wait for notices: %s", err)
 		}
 	} else {
 		// No timeout given, fetch currently-available notices
@@ -234,7 +234,7 @@ func v1PostNotices(c *Command, r *http.Request, user *UserState) Response {
 		RepeatAfter: repeatAfter,
 	})
 	if err != nil {
-		return InternalError("%v", err)
+		return ServerError("%v", err)
 	}
 
 	return SyncResponse(addedNotice{ID: noticeId})

--- a/internals/daemon/api_pairing.go
+++ b/internals/daemon/api_pairing.go
@@ -31,7 +31,7 @@ func v1PostPairing(c *Command, r *http.Request, user *UserState) Response {
 	switch payload.Action {
 	case "pair":
 		if r.TLS == nil {
-			return InternalError("cannot find TLS connection state")
+			return ServerError("cannot find TLS connection state")
 		}
 		// Validate that exactly one peer certificate is provided
 		if len(r.TLS.PeerCertificates) != 1 {

--- a/internals/daemon/api_plan.go
+++ b/internals/daemon/api_plan.go
@@ -35,7 +35,7 @@ func v1GetPlan(c *Command, r *http.Request, _ *UserState) Response {
 	plan := planMgr.Plan()
 	planYAML, err := yaml.Marshal(plan)
 	if err != nil {
-		return InternalError("cannot serialize plan: %v", err)
+		return ServerError("cannot serialize plan: %v", err)
 	}
 	return SyncResponse(string(planYAML))
 }
@@ -83,7 +83,7 @@ func v1PostLayers(c *Command, r *http.Request, user *UserState) Response {
 		if _, ok := err.(*plan.FormatError); ok {
 			return BadRequest("%v", err)
 		}
-		return InternalError("%v", err)
+		return ServerError("%v", err)
 	}
 	return SyncResponse(true)
 }

--- a/internals/daemon/api_services.go
+++ b/internals/daemon/api_services.go
@@ -41,7 +41,7 @@ func v1GetServices(c *Command, r *http.Request, _ *UserState) Response {
 	servmgr := overlordServiceManager(c.d.overlord)
 	services, err := servmgr.Services(names)
 	if err != nil {
-		return InternalError("%v", err)
+		return ServerError("%v", err)
 	}
 
 	infos := make([]serviceInfo, 0, len(services))
@@ -83,7 +83,7 @@ func v1PostServices(c *Command, r *http.Request, _ *UserState) Response {
 		}
 		services, err := servmgr.DefaultServiceNames()
 		if err != nil {
-			return InternalError("%v", err)
+			return ServerError("%v", err)
 		}
 		if len(services) == 0 {
 			return SyncResponse(&resp{

--- a/internals/daemon/api_signals.go
+++ b/internals/daemon/api_signals.go
@@ -37,7 +37,7 @@ func v1PostSignals(c *Command, req *http.Request, _ *UserState) Response {
 	serviceMgr := c.d.overlord.ServiceManager()
 	err := serviceMgr.SendSignal(payload.Services, payload.Signal)
 	if err != nil {
-		return InternalError("%s", err)
+		return ServerError("%s", err)
 	}
 	return SyncResponse(true)
 }

--- a/internals/daemon/api_tasks.go
+++ b/internals/daemon/api_tasks.go
@@ -74,7 +74,7 @@ func (wr websocketResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rsp.ServeHTTP(w, r)
 	} else if err != nil {
 		logger.Noticef("Websocket %s: cannot connect to %s websocket: %v", wr.task.ID(), wr.websocketID, err)
-		rsp := InternalError("%v", err)
+		rsp := ServerError("%v", err)
 		rsp.ServeHTTP(w, r)
 	}
 	// In the success case, Connect takes over the connection and upgrades to

--- a/internals/daemon/daemon.go
+++ b/internals/daemon/daemon.go
@@ -279,7 +279,7 @@ func (c *Command) Daemon() *Daemon {
 func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// check if we are in degradedMode
 	if c.d.degradedErr != nil && r.Method != "GET" {
-		InternalError(c.d.degradedErr.Error()).ServeHTTP(w, r)
+		ServerError(c.d.degradedErr.Error()).ServeHTTP(w, r)
 		return
 	}
 
@@ -287,7 +287,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err != nil && err != errNoID {
 		logger.Noticef("Cannot parse UID from remote address %q: %s", r.RemoteAddr, err)
-		InternalError(err.Error()).ServeHTTP(w, r)
+		ServerError(err.Error()).ServeHTTP(w, r)
 		return
 	}
 

--- a/internals/daemon/response.go
+++ b/internals/daemon/response.go
@@ -131,7 +131,7 @@ type errorResult struct {
 
 func SyncResponse(result any) Response {
 	if err, ok := result.(error); ok {
-		return InternalError("internal error: %v", err)
+		return ServerError("internal error: %v", err)
 	}
 
 	if rsp, ok := result.(Response); ok {
@@ -192,7 +192,7 @@ func makeErrorResponder(status int) errorResponder {
 }
 
 // errorResponder is a callable that produces an error Response.
-// e.g., InternalError("something broke: %v", err), etc.
+// e.g., ServerError("something broke: %v", err), etc.
 type errorResponder func(string, ...any) Response
 
 // Standard error responses.
@@ -202,6 +202,6 @@ var (
 	Forbidden        = makeErrorResponder(http.StatusForbidden)
 	NotFound         = makeErrorResponder(http.StatusNotFound)
 	MethodNotAllowed = makeErrorResponder(http.StatusMethodNotAllowed)
-	InternalError    = makeErrorResponder(http.StatusInternalServerError)
+	ServerError      = makeErrorResponder(http.StatusInternalServerError)
 	GatewayTimeout   = makeErrorResponder(http.StatusGatewayTimeout)
 )


### PR DESCRIPTION
The name InternalError used for HTTP 500 status codes
causes confusion. The semantics between the two differ.

Rename to clarify.