### PR TITLE
docs: replace the PGP key with the upstream page in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,8 @@ to determine whether the issue qualifies as a security issue and, if so, in
 which component. We will then figure out a fix, get a CVE
 assigned, and coordinate the release of the fix.
 
-You may also send email to security@ubuntu.com. Email may optionally be
-encrypted to OpenPGP key
-[`4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0)
+You may also send email to security@ubuntu.com. If you want to encrypt your email,
+follow [Canonical's reporting instructions](https://ubuntu.com/security/disclosure-policy#contact-us).
 
 If you have a deadline for public disclosure, please let us know.
 Our vulnerability management team intends to respond within 3 working


### PR DESCRIPTION
This PR replaces the PGP key in `SECURITY.md` to the upstream link https://ubuntu.com/security/disclosure-policy#contact-us.

It is a part of https://github.com/canonical/operator/issues/2287.