### PR TITLE
chore: update Go version to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5


### PR DESCRIPTION
This PR bumps the Go version to 1.26.3 to resolve the issues reported by `govulncheck` in our CI (see [this CI run](https://github.com/canonical/pebble/actions/runs/25673337908/job/75364234870)).

`govulncheck` revealed 2 issues for Go version 1.26.2, which are fixed in Go version 1.26.3 (see [Go release log](https://go.dev/doc/devel/release#go1.26.minor)).

```
Vulnerability #1: GO-2026-4971
    Panic in Dial and LookupPort when handling NUL byte on Windows in net
...

Vulnerability #2: GO-2026-4918
    Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in
    net/http/internal/http2 in golang.org/x/net
...
```

We have validated that bumping the Go version to 1.26.3 fixed a similar issue in the concierge repo https://github.com/canonical/concierge/pull/193.