### PR TITLE
feat: log authz_fail security events on client-cert verify failure

### DIFF
--- a/internals/overlord/identities/identities.go
+++ b/internals/overlord/identities/identities.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GehirnInc/crypt/sha512_crypt"
 
+	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/overlord/state"
 )
 
@@ -360,6 +361,12 @@ func (m *Manager) IdentityFromInputs(userID *uint32, username, password string, 
 				if err == nil {
 					return identity
 				}
+				// The presented certificate matched a stored identity
+				// certificate by equality but failed signature
+				// verification against itself as a self-signed root.
+				// This is unexpected for a known identity and worth
+				// auditing.
+				logger.SecurityWarn(logger.SecurityAuthzFail, identity.Name, "client certificate matched stored identity but failed self-signed verification: "+err.Error())
 			}
 		}
 		// If a client certificate is provided, but did not match, we bail.

--- a/internals/overlord/pairingstate/manager.go
+++ b/internals/overlord/pairingstate/manager.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/canonical/pebble/internals/logger"
 	"github.com/canonical/pebble/internals/overlord/identities"
 	"github.com/canonical/pebble/internals/overlord/state"
 	"github.com/canonical/pebble/internals/plan"
@@ -230,6 +231,7 @@ func (m *PairingManager) PairMTLS(clientCert *x509.Certificate) error {
 	}
 	_, err := clientCert.Verify(opts)
 	if err != nil {
+		logger.SecurityWarn(logger.SecurityAuthzFail, "", "client certificate failed self-signed verification during pairing: "+err.Error())
 		return fmt.Errorf("cannot verify client certificate signature: %w", err)
 	}
 


### PR DESCRIPTION
This was flagged in the TIOBE security review, which mostly produced false positive noise, but this seems reasonable to do.

The PR adds emission of a `SecurityWarn(SecurityAuthzFail, ...)` audit record when a client certificate fails self-signed verification, both during identity lookup (`identities.IdentityFromInputs`) and during pairing (`pairingstate.PairMTLS`).

These provide a SIEM-friendly audit trail distinct from the generic error returned to the caller. It follows the pattern of the security event logging added a while back.