### PR TITLE
test: fix goroutine leaks found stress testing daemon and overlord

### DIFF
--- a/internals/daemon/api_checks_test.go
+++ b/internals/daemon/api_checks_test.go
@@ -51,7 +51,7 @@ checks:
             command: sleep x
 `)
 	s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	// Request with no filters.
 	start := time.Now()
@@ -113,7 +113,7 @@ checks:
 
 func (s *apiSuite) TestChecksGetInvalidLevel(c *C) {
 	s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	rsp, body := s.getChecks(c, "?level=foo")
 	c.Check(rsp.Status, Equals, 400)
@@ -126,7 +126,7 @@ func (s *apiSuite) TestChecksGetInvalidLevel(c *C) {
 
 func (s *apiSuite) TestChecksEmpty(c *C) {
 	s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	rsp, body := s.getChecks(c, "")
 	c.Check(rsp.Status, Equals, 200)
@@ -189,7 +189,7 @@ checks:
             command: sleep x
 `)
 	s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	start := time.Now()
 	for {
@@ -246,7 +246,7 @@ checks:
             command: sleep 0.1
 `)
 	s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	// Try to stop a check that's already stopped (disabled)
 	rsp := s.postChecks(c, `{"action": "stop", "checks": ["chk1"]}`)
@@ -284,7 +284,7 @@ checks:
 	checksYAML = strings.Replace(checksYAML, "{{.CheckCommand}}", checkCommand, -1)
 	writeTestLayer(s.pebbleDir, checksYAML)
 	s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	start := time.Now()
 	for {

--- a/internals/daemon/api_exec_test.go
+++ b/internals/daemon/api_exec_test.go
@@ -72,6 +72,7 @@ func (s *execSuite) SetUpTest(c *C) {
 }
 
 func (s *execSuite) TearDownTest(c *C) {
+	s.client.CloseIdleConnections()
 	err := s.daemon.Stop(nil)
 	c.Check(err, IsNil)
 

--- a/internals/daemon/api_health_test.go
+++ b/internals/daemon/api_health_test.go
@@ -276,6 +276,7 @@ func (s *apiSuite) testHealthStateLockNotHeld(c *C, level string, expectErr bool
 		if err != nil {
 			return err
 		}
+		defer pebble.CloseIdleConnections()
 		healthy, err := pebble.Health(&client.HealthOptions{
 			Level: client.CheckLevel(level),
 		})

--- a/internals/daemon/api_metrics_test.go
+++ b/internals/daemon/api_metrics_test.go
@@ -33,7 +33,7 @@ services:
         command: sleep 10
 `)
 	d := s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	// Start test service.
 	payload := bytes.NewBufferString(`{"action": "start", "services": ["test1"]}`)

--- a/internals/daemon/api_signals_test.go
+++ b/internals/daemon/api_signals_test.go
@@ -34,7 +34,7 @@ services:
         on-failure: ignore
 `)
 	d := s.daemon(c)
-	s.startOverlord()
+	s.startOverlord(c)
 
 	// Start test service
 	payload := bytes.NewBufferString(`{"action": "start", "services": ["test1"]}`)

--- a/internals/daemon/api_test.go
+++ b/internals/daemon/api_test.go
@@ -58,11 +58,11 @@ func (s *apiSuite) SetUpTest(c *check.C) {
 }
 
 func (s *apiSuite) TearDownTest(c *check.C) {
-	if s.overlordStarted {
+	if s.d != nil {
 		s.d.Overlord().Stop()
-		s.overlordStarted = false
 	}
 	s.d = nil
+	s.overlordStarted = false
 	s.pebbleDir = ""
 	s.restoreMuxVars()
 
@@ -91,7 +91,8 @@ func (s *apiSuite) daemon(c *check.C) *Daemon {
 	return d
 }
 
-func (s *apiSuite) startOverlord() {
+func (s *apiSuite) startOverlord(c *check.C) {
+	c.Assert(s.overlordStarted, check.Equals, false)
 	s.overlordStarted = true
 	s.d.overlord.Loop()
 }

--- a/internals/daemon/daemon_https_test.go
+++ b/internals/daemon/daemon_https_test.go
@@ -57,6 +57,7 @@ func (s *daemonSuite) TestHTTPSOpenAccess(c *C) {
 			},
 		},
 	}
+	defer httpsClient.CloseIdleConnections()
 
 	request, err := http.NewRequest("GET", fmt.Sprintf("https://localhost:%d/v1/health", port), nil)
 	c.Assert(err, IsNil)
@@ -65,6 +66,8 @@ func (s *daemonSuite) TestHTTPSOpenAccess(c *C) {
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
 	var m map[string]any
 	err = json.NewDecoder(response.Body).Decode(&m)
+	c.Assert(err, IsNil)
+	err = response.Body.Close()
 	c.Assert(err, IsNil)
 	c.Assert(m, DeepEquals, map[string]any{
 		"type":        "sync",
@@ -112,6 +115,7 @@ func (s *daemonSuite) TestHTTPSUserAccessFail(c *C) {
 			},
 		},
 	}
+	defer httpsClient.CloseIdleConnections()
 
 	request, err := http.NewRequest("GET", fmt.Sprintf("https://localhost:%d/v1/checks", port), nil)
 	c.Assert(err, IsNil)
@@ -120,6 +124,8 @@ func (s *daemonSuite) TestHTTPSUserAccessFail(c *C) {
 
 	// Access fails because the TLS client identity is not known.
 	c.Assert(response.StatusCode, Equals, http.StatusUnauthorized)
+	err = response.Body.Close()
+	c.Assert(err, IsNil)
 
 	err = d.Stop(nil)
 	c.Assert(err, IsNil)
@@ -166,6 +172,7 @@ pairing:
 			},
 		},
 	}
+	defer httpsClient.CloseIdleConnections()
 
 	// Enable pairing window
 	pairingMgr := d.overlord.PairingManager()
@@ -188,6 +195,10 @@ pairing:
 
 	// Access succeeds because the TLS client identity is now paired
 	c.Assert(response.StatusCode, Equals, http.StatusOK)
+	err = pairingResponse.Body.Close()
+	c.Assert(err, IsNil)
+	err = response.Body.Close()
+	c.Assert(err, IsNil)
 
 	err = d.Stop(nil)
 	c.Assert(err, IsNil)

--- a/internals/daemon/daemon_test.go
+++ b/internals/daemon/daemon_test.go
@@ -264,7 +264,9 @@ func (s *daemonSuite) TestExplicitPaths(c *C) {
 func (s *daemonSuite) TestCommandMethodDispatch(c *C) {
 	fakeUserAgent := "some-agent-talking-to-pebble/1.0"
 
-	cmd := &Command{d: s.newDaemon(c)}
+	d := s.newDaemon(c)
+	defer d.overlord.Stop()
+	cmd := &Command{d: d}
 	handler := &fakeHandler{cmd: cmd}
 	rf := func(innerCmd *Command, req *http.Request, user *UserState) Response {
 		c.Assert(cmd, Equals, innerCmd)
@@ -305,6 +307,7 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *C) {
 
 func (s *daemonSuite) TestCommandRestartingState(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	cmd := &Command{d: d, ReadAccess: OpenAccess{}}
 	cmd.GET = func(*Command, *http.Request, *UserState) Response {
@@ -351,6 +354,7 @@ func (s *daemonSuite) TestCommandRestartingState(c *C) {
 
 func (s *daemonSuite) TestFillsWarnings(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	cmd := &Command{d: d, ReadAccess: OpenAccess{}}
 	cmd.GET = func(*Command, *http.Request, *UserState) Response {
@@ -393,6 +397,7 @@ type accessCheckerTestCase struct {
 
 func (s *daemonSuite) testAccessChecker(c *C, tests []accessCheckerTestCase, remoteAddr string) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	// Add some named identities for testing with.
 	identitiesMgr := d.overlord.IdentitiesManager()
@@ -580,6 +585,7 @@ func (s *daemonSuite) TestAdminAccess(c *C) {
 
 func (s *daemonSuite) TestDefaultUcredUsers(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	var userSeen *UserState
 	cmd := &Command{
@@ -635,6 +641,7 @@ func (s *daemonSuite) TestDefaultUcredUsers(c *C) {
 
 func (s *daemonSuite) TestAddRoutes(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	expected := make([]string, len(API))
 	for i, v := range API {
@@ -789,7 +796,8 @@ func (s *daemonSuite) TestGracefulStop(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(res.StatusCode, Equals, 200)
 		body, err := io.ReadAll(res.Body)
-		res.Body.Close()
+		c.Assert(err, IsNil)
+		err = res.Body.Close()
 		c.Assert(err, IsNil)
 		c.Check(string(body), Equals, "OKOK")
 		close(alright)
@@ -1298,6 +1306,8 @@ func doTestReq(c *C, cmd *Command, method string) *httptest.ResponseRecorder {
 
 func (s *daemonSuite) TestDegradedModeReply(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
+
 	cmd := &Command{d: d, ReadAccess: OpenAccess{}, WriteAccess: OpenAccess{}}
 	cmd.GET = func(*Command, *http.Request, *UserState) Response {
 		return SyncResponse(nil)
@@ -1889,6 +1899,7 @@ func (t *transportTypeSuite) TestTransportTypeContext(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateLocal(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	// Set up a Local identity.
 	identitiesMgr := d.overlord.IdentitiesManager()
@@ -1937,6 +1948,8 @@ func (s *daemonSuite) TestServeHTTPUserStateLocal(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateUIDOnly(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
+
 	// Don't set up any named identities, so it falls back to UID-only
 
 	// Capture the UserState passed to the response function.
@@ -1970,6 +1983,8 @@ func (s *daemonSuite) TestServeHTTPUserStateUIDOnly(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateUIDOnlyRoot(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
+
 	// Don't set up any named identities, so it falls back to UID-only
 
 	// Capture the UserState passed to the response function.
@@ -2003,6 +2018,8 @@ func (s *daemonSuite) TestServeHTTPUserStateUIDOnlyRoot(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateUIDOnlyDaemonUID(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
+
 	// Don't set up any named identities, so it falls back to UID-only
 
 	// Capture the UserState passed to the response function.
@@ -2037,6 +2054,7 @@ func (s *daemonSuite) TestServeHTTPUserStateUIDOnlyDaemonUID(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateBasicUnixSocket(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	// Set up a Basic auth identity with a hashed password.
 	// Generate sha512-crypt hash for password "test".
@@ -2086,6 +2104,7 @@ func (s *daemonSuite) TestServeHTTPUserStateBasicUnixSocket(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateBasicHTTP(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	// Set up a Basic auth identity with a hashed password.
 	// Generate sha512-crypt hash for password "test".
@@ -2135,6 +2154,7 @@ func (s *daemonSuite) TestServeHTTPUserStateBasicHTTP(c *C) {
 
 func (s *daemonSuite) TestServeHTTPUserStateCert(c *C) {
 	d := s.newDaemon(c)
+	defer d.overlord.Stop()
 
 	// Create a test certificate.
 	certPEM := `-----BEGIN CERTIFICATE-----

--- a/internals/overlord/managers_test.go
+++ b/internals/overlord/managers_test.go
@@ -42,6 +42,7 @@ func (s *mgrsSuite) SetUpTest(c *C) {
 
 	o, err := overlord.New(&overlord.Options{PebbleDir: s.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 	err = o.StartUp()
 	c.Assert(err, IsNil)
 	s.o = o

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -82,7 +82,9 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	restore := patch.Fake(42, 2, nil)
 	defer restore()
 
-	o, _ := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	c.Check(o.StateEngine(), NotNil)
 	c.Check(o.TaskRunner(), NotNil)
@@ -100,7 +102,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	s.Get("patch-sublevel", &patchSublevel)
 	c.Check(patchSublevel, Equals, 2)
 
-	_, err := os.Stat(ovs.statePath)
+	_, err = os.Stat(ovs.statePath)
 	c.Assert(err, IsNil)
 }
 
@@ -111,6 +113,7 @@ func (ovs *overlordSuite) TestNewInMemoryBackend(c *C) {
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, Persist: overlord.PersistNever})
 	c.Assert(err, IsNil)
 	c.Check(o, NotNil)
+	defer o.Stop()
 
 	c.Check(o.StateEngine(), NotNil)
 	c.Check(o.TaskRunner(), NotNil)
@@ -147,6 +150,7 @@ func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 	c.Check(o.RestartManager(), NotNil)
 
 	state := o.State()
@@ -195,6 +199,7 @@ func (ovs *overlordSuite) TestNewWithPatches(c *C) {
 
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	state := o.State()
 	c.Assert(err, IsNil)
@@ -246,6 +251,7 @@ func (wm *witnessManager) Ensure() error {
 func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	err = o.StartUp()
 	c.Assert(err, IsNil)
@@ -259,6 +265,7 @@ func (ovs *overlordSuite) TestTrivialRunAndStop(c *C) {
 func (ovs *overlordSuite) TestUnknownTasks(c *C) {
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	// unknown tasks are ignored and succeed
 	st := o.State()
@@ -579,6 +586,7 @@ func (ovs *overlordSuite) TestOverlordStartUpSetsStartOfOperation(c *C) {
 	// use real overlord, we need device manager to be there
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	st := o.State()
 	st.Lock()
@@ -602,6 +610,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneDoesntAbortShortlyAfterStartOfOpera
 	// use real overlord, we need device manager to be there
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	// avoid immediate transition to Done due to unknown kind
 	o.TaskRunner().AddHandler("bar", func(t *state.Task, _ *tomb.Tomb) error {
@@ -654,6 +663,7 @@ func (ovs *overlordSuite) TestEnsureLoopPruneAbortsOld(c *C) {
 	// use real overlord, we need device manager to be there
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	// avoid immediate transition to Done due to having unknown kind
 	o.TaskRunner().AddHandler("bar", func(t *state.Task, _ *tomb.Tomb) error {
@@ -709,6 +719,7 @@ func (ovs *overlordSuite) TestCheckpoint(c *C) {
 
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	s := o.State()
 	s.Lock()
@@ -792,7 +803,7 @@ func (ovs *overlordSuite) TestTrivialSettle(c *C) {
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
-	defer o.Engine().Stop()
+	defer o.Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -821,7 +832,7 @@ func (ovs *overlordSuite) TestSettleNotConverging(c *C) {
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
-	defer o.Engine().Stop()
+	defer o.Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -848,7 +859,7 @@ func (ovs *overlordSuite) TestSettleChain(c *C) {
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
-	defer o.Engine().Stop()
+	defer o.Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -882,7 +893,7 @@ func (ovs *overlordSuite) TestSettleChainWCleanup(c *C) {
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
-	defer o.Engine().Stop()
+	defer o.Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -927,7 +938,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 	o.AddManager(sm1)
 	o.AddManager(o.TaskRunner())
 
-	defer o.Engine().Stop()
+	defer o.Stop()
 
 	s.Lock()
 	defer s.Unlock()
@@ -950,6 +961,7 @@ func (ovs *overlordSuite) TestSettleExplicitEnsureBefore(c *C) {
 func (ovs *overlordSuite) TestRequestRestartNoHandler(c *C) {
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	st := o.State()
 	st.Lock()
@@ -983,6 +995,7 @@ func (ovs *overlordSuite) TestRequestRestartHandler(c *C) {
 
 	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	st := o.State()
 	st.Lock()
@@ -1000,8 +1013,9 @@ func (ovs *overlordSuite) TestVerifyRebootNoPendingReboot(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	c.Check(rb.rebootState, Equals, "as-expected")
 }
@@ -1013,8 +1027,9 @@ func (ovs *overlordSuite) TestVerifyRebootOK(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	c.Check(rb.rebootState, Equals, "as-expected")
 }
@@ -1043,8 +1058,9 @@ func (ovs *overlordSuite) TestVerifyRebootIsMissing(c *C) {
 
 	rb := &testRestartHandler{}
 
-	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, RestartHandler: rb})
 	c.Assert(err, IsNil)
+	defer o.Stop()
 
 	c.Check(rb.rebootState, Equals, "did-not-happen")
 }
@@ -1096,6 +1112,7 @@ func (ovs *overlordSuite) TestOverlordCanStandby(c *C) {
 
 func (ovs *overlordSuite) TestStartOfOperationTimeAlreadySet(c *C) {
 	o := overlord.Fake()
+	defer o.Stop()
 	st := o.State()
 	st.Lock()
 	defer st.Unlock()
@@ -1110,6 +1127,7 @@ func (ovs *overlordSuite) TestStartOfOperationTimeAlreadySet(c *C) {
 
 func (s *overlordSuite) TestStartOfOperationSetTime(c *C) {
 	o := overlord.Fake()
+	defer o.Stop()
 	st := o.State()
 	st.Lock()
 	defer st.Unlock()


### PR DESCRIPTION
Since #833, `Overlord.New` and `Fake` immediately start a loop goroutine. Any
test that created an overlord or daemon without eventually calling `Stop` leaks
that goroutine.

Additionally, this closes HTTP response bodies and idle client connections in
teardown to prevent `net/http` goroutine leaks.