### PR TITLE
feat: structured output for version and health commands

### DIFF
--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -318,9 +318,12 @@ The health command queries the health of configured checks.
 
 It returns an exit code 0 if all the requested checks are healthy, or
 an exit code 1 if at least one of the requested checks are unhealthy.
+If --format is passed either json or yaml, an exit code of 0 is returned for
+both healthy and unhealthy requested checks.
 
 [health command options]
-      --level=[alive|ready]   Check level to filter for
+      --format=[text|json|yaml]   Output format (default: text)
+      --level=[alive|ready]       Check level to filter for
 ```
 <!-- END AUTOMATED OUTPUT FOR health -->
 
@@ -1365,7 +1368,8 @@ Usage:
 The version command displays the versions of the running client and server.
 
 [version command options]
-      --client    Only display the client version
+      --format=[text|json|yaml]   Output format (default: text)
+      --client                    Only display the client version
 ```
 <!-- END AUTOMATED OUTPUT FOR version -->
 

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -162,7 +162,7 @@ func Parser(opts *ParserOptions) *flags.Parser {
 	// Implement --version by default on every command
 	defaultOpts := defaultOptions{
 		Version: func() {
-			printVersions(opts.Client)
+			printVersions(opts.Client, nil)
 			panic(&exitStatus{0})
 		},
 	}

--- a/internals/cli/cli.go
+++ b/internals/cli/cli.go
@@ -146,7 +146,7 @@ func fixupArg(optName string) string {
 }
 
 type defaultOptions struct {
-	Version func() `long:"version" hidden:"yes" description:"Print the version and exit"`
+	Version func() `long:"version" hidden:"yes" description:"Print the client version and exit"`
 }
 
 type ParserOptions struct {
@@ -161,10 +161,7 @@ type ParserOptions struct {
 func Parser(opts *ParserOptions) *flags.Parser {
 	// Implement --version by default on every command
 	defaultOpts := defaultOptions{
-		Version: func() {
-			printVersions(opts.Client, nil)
-			panic(&exitStatus{0})
-		},
+		Version: printClientVersion,
 	}
 
 	flagOpts := flags.Options(flags.PassDoubleDash)
@@ -508,4 +505,9 @@ func cliStatePath() string {
 		configDir = os.ExpandEnv("$HOME/.config")
 	}
 	return filepath.Join(configDir, "pebble", "cli.json")
+}
+
+func printClientVersion() {
+	fmt.Fprintln(Stdout, cmd.Version)
+	panic(&exitStatus{0})
 }

--- a/internals/cli/cmd_health.go
+++ b/internals/cli/cmd_health.go
@@ -28,11 +28,14 @@ The health command queries the health of configured checks.
 
 It returns an exit code 0 if all the requested checks are healthy, or
 an exit code 1 if at least one of the requested checks are unhealthy.
+If --format is passed either json or yaml, an exit code of 0 is returned for
+both healthy and unhealthy requested checks.
 `
 
 type cmdHealth struct {
 	client *client.Client
 
+	formatMixin
 	//lint:ignore SA5008 "choice" tag is intentionally duplicated
 	Level      string `long:"level" choice:"alive" choice:"ready"`
 	Positional struct {
@@ -49,11 +52,15 @@ func init() {
 		Name:        "health",
 		Summary:     cmdHealthSummary,
 		Description: cmdHealthDescription,
-		ArgsHelp:    cmdHealthArgsHelp,
+		ArgsHelp:    merge(cmdHealthArgsHelp, formatArgsHelp),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdHealth{client: opts.Client}
 		},
 	})
+}
+
+type healthResult struct {
+	Healthy bool `json:"healthy" yaml:"healthy"`
 }
 
 func (cmd *cmdHealth) Execute(args []string) error {
@@ -70,14 +77,23 @@ func (cmd *cmdHealth) Execute(args []string) error {
 		return err
 	}
 
-	status := "unhealthy"
-	if health {
-		status = "healthy"
-	}
-	fmt.Fprintln(Stdout, status)
+	if cmd.Format == "text" {
+		status := "unhealthy"
+		if health {
+			status = "healthy"
+		}
+		fmt.Fprintln(Stdout, status)
 
-	if !health {
-		panic(&exitStatus{1})
+		if !health {
+			panic(&exitStatus{1})
+		}
+
+		return nil
+	}
+
+	err = cmd.formatNonText(healthResult{Healthy: health})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/internals/cli/cmd_health_test.go
+++ b/internals/cli/cmd_health_test.go
@@ -170,7 +170,7 @@ func (s *PebbleSuite) TestHealthUnhealthyYAML(c *check.C) {
 	exitCode := cli.PebbleMain()
 	// Ensure an unhealthy check does not fail with YAML output.
 	c.Check(exitCode, check.Equals, 0)
-	c.Check(s.Stdout(), check.Equals, `healthy: false`+"\n")
+	c.Check(s.Stdout(), check.Equals, "healthy: false\n")
 	c.Check(s.Stderr(), check.Equals, "")
 }
 

--- a/internals/cli/cmd_health_test.go
+++ b/internals/cli/cmd_health_test.go
@@ -99,3 +99,113 @@ func (s *PebbleSuite) TestHealthBadLevel(c *check.C) {
 	c.Check(s.Stdout(), check.Equals, "")
 	c.Check(s.Stderr(), check.Matches, "error: Invalid value .* Allowed values are: alive or ready\n")
 }
+
+func (s *PebbleSuite) TestHealthJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": {"healthy": true}
+		}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "json")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, `{"healthy":true}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthUnhealthyJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+			"type": "sync",
+			"status-code": 502,
+			"result": {"healthy": false}
+		}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "json")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	// Ensure an unhealthy check does not fail with JSON output.
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, `{"healthy":false}`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+			"type": "sync",
+			"status-code": 200,
+			"result": {"healthy": true}
+		}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "yaml")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, "healthy: true\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthUnhealthyYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+			"type": "sync",
+			"status-code": 502,
+			"result": {"healthy": false}
+		}`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "yaml")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	// Ensure an unhealthy check does not fail with YAML output.
+	c.Check(exitCode, check.Equals, 0)
+	c.Check(s.Stdout(), check.Equals, `healthy: false`+"\n")
+	c.Check(s.Stderr(), check.Equals, "")
+}
+
+func (s *PebbleSuite) TestHealthInvalidFormat(c *check.C) {
+	restore := fakeArgs("pebble", "health", "--format", "foobar")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 1)
+	c.Check(s.Stdout(), check.Equals, "")
+	c.Check(s.Stderr(), check.Matches, "error: Invalid value .* Allowed values are: text, json or yaml\n")
+}
+
+func (s *PebbleSuite) TestHealthInvalidResponseYAML(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, `bad`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "yaml")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 1)
+}
+
+func (s *PebbleSuite) TestHealthInvalidResponseJSON(c *check.C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprintf(w, `bad`)
+	})
+
+	restore := fakeArgs("pebble", "health", "--format", "json")
+	defer restore()
+
+	exitCode := cli.PebbleMain()
+	c.Check(exitCode, check.Equals, 1)
+}

--- a/internals/cli/cmd_version.go
+++ b/internals/cli/cmd_version.go
@@ -59,31 +59,35 @@ func (cmd cmdVersion) Execute(args []string) error {
 		return ErrExtraArgs
 	}
 
+	text := cmd.Format == "text"
+
 	if cmd.ClientOnly {
-		if cmd.Format != "text" {
-			return cmd.formatNonText(
-				versionResult{Client: version.Version},
-			)
+		if !text {
+			return cmd.formatNonText(versionResult{Client: version.Version})
 		}
 		fmt.Fprintln(Stdout, version.Version)
 		return nil
 	}
 
-	return printVersions(cmd.client, &cmd.formatMixin)
-}
-
-func printVersions(cli *client.Client, format *formatMixin) error {
-	serverVersion := "-"
-	sysInfo, err := cli.SysInfo()
-	if err == nil {
+	serverVersion := ""
+	sysInfo, serverErr := cmd.client.SysInfo()
+	if serverErr == nil {
 		serverVersion = sysInfo.Version
+	} else if text {
+		serverVersion = "-"
 	}
-	if format != nil && format.Format != "text" {
-		return format.formatNonText(versionResult{
+
+	if !text {
+		err := cmd.formatNonText(versionResult{
 			Client: version.Version,
 			Server: serverVersion,
 		})
+		if serverErr != nil {
+			return serverErr
+		}
+		return err
 	}
+
 	w := tabWriter()
 	fmt.Fprintf(w, "client\t%s\n", version.Version)
 	fmt.Fprintf(w, "server\t%s\n", serverVersion)

--- a/internals/cli/cmd_version.go
+++ b/internals/cli/cmd_version.go
@@ -31,6 +31,7 @@ The version command displays the versions of the running client and server.
 type cmdVersion struct {
 	client *client.Client
 
+	formatMixin
 	ClientOnly bool `long:"client"`
 }
 
@@ -39,13 +40,18 @@ func init() {
 		Name:        "version",
 		Summary:     cmdVersionSummary,
 		Description: cmdVersionDescription,
-		ArgsHelp: map[string]string{
+		ArgsHelp: merge(formatArgsHelp, map[string]string{
 			"--client": "Only display the client version",
-		},
+		}),
 		New: func(opts *CmdOptions) flags.Commander {
 			return &cmdVersion{client: opts.Client}
 		},
 	})
+}
+
+type versionResult struct {
+	Client string `json:"client" yaml:"client"`
+	Server string `json:"server,omitempty" yaml:"server,omitempty"`
 }
 
 func (cmd cmdVersion) Execute(args []string) error {
@@ -54,18 +60,29 @@ func (cmd cmdVersion) Execute(args []string) error {
 	}
 
 	if cmd.ClientOnly {
+		if cmd.Format != "text" {
+			return cmd.formatNonText(
+				versionResult{Client: version.Version},
+			)
+		}
 		fmt.Fprintln(Stdout, version.Version)
 		return nil
 	}
 
-	return printVersions(cmd.client)
+	return printVersions(cmd.client, &cmd.formatMixin)
 }
 
-func printVersions(cli *client.Client) error {
+func printVersions(cli *client.Client, format *formatMixin) error {
 	serverVersion := "-"
 	sysInfo, err := cli.SysInfo()
 	if err == nil {
 		serverVersion = sysInfo.Version
+	}
+	if format != nil && format.Format != "text" {
+		return format.formatNonText(versionResult{
+			Client: version.Version,
+			Server: serverVersion,
+		})
 	}
 	w := tabWriter()
 	fmt.Fprintf(w, "client\t%s\n", version.Version)

--- a/internals/cli/cmd_version_test.go
+++ b/internals/cli/cmd_version_test.go
@@ -47,6 +47,59 @@ func (s *PebbleSuite) TestVersionClientOnly(c *C) {
 	c.Check(s.Stderr(), Equals, "")
 }
 
+func (s *PebbleSuite) TestVersionJSON(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"version":"7.89"}}`)
+	})
+
+	restore := fakeVersion("4.56")
+	defer restore()
+
+	_, err := cli.ParserForTest().ParseArgs([]string{"version", "--format", "json"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, `{"client":"4.56","server":"7.89"}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestVersionYAML(c *C) {
+	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"sync","status-code":200,"status":"OK","result":{"version":"7.89"}}`)
+	})
+
+	restore := fakeVersion("4.56")
+	defer restore()
+
+	_, err := cli.ParserForTest().ParseArgs([]string{"version", "--format", "yaml"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "client: \"4.56\"\nserver: \"7.89\"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestVersionClientOnlyJSON(c *C) {
+	restore := fakeVersion("v1.2.3")
+	defer restore()
+
+	_, err := cli.ParserForTest().ParseArgs([]string{"version", "--client", "--format", "json"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, `{"client":"v1.2.3"}`+"\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestVersionClientOnlyYAML(c *C) {
+	restore := fakeVersion("v1.2.3")
+	defer restore()
+
+	_, err := cli.ParserForTest().ParseArgs([]string{"version", "--client", "--format", "yaml"})
+	c.Assert(err, IsNil)
+	c.Check(s.Stdout(), Equals, "client: v1.2.3\n")
+	c.Check(s.Stderr(), Equals, "")
+}
+
+func (s *PebbleSuite) TestVersionInvalidFormat(c *C) {
+	_, err := cli.ParserForTest().ParseArgs([]string{"version", "--format", "foobar"})
+	c.Assert(err, ErrorMatches, "Invalid value.*for option.*--format.*")
+}
+
 func (s *PebbleSuite) TestVersionExtraArgs(c *C) {
 	rest, err := cli.ParserForTest().ParseArgs([]string{"version", "extra", "args"})
 	c.Assert(err, Equals, cli.ErrExtraArgs)


### PR DESCRIPTION
This adds format to both `pebble version` and `pebble health` such that they
would be useful for machine interaction.

Version command is rather simple, but the health command removes the non-zero
exit code when health check fails for JSON or YAML format.

Closes #824.