### PR TITLE
chore: bump go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5


### PR DESCRIPTION
Bumps go to 1.26.4 to fix these govulncheck identified vulnerabilities:

```
Vulnerability #1: GO-2026-5039
    Arbitrary inputs are included in errors without any escaping in
    net/textproto
  More info: https://pkg.go.dev/vuln/GO-2026-5039
  Standard library
    Found in: net/textproto@go1.26.3
    Fixed in: net/textproto@go1.26.4

Vulnerability #2: GO-2026-5037
    Inefficient candidate hostname parsing in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-5037
  Standard library
    Found in: crypto/x509@go1.26.3
    Fixed in: crypto/x509@go1.26.4
```