### PR TITLE
docs: move docs to ubuntu.com/docs/pebble

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ _Take control of your internal daemons!_
 
 Pebble's key features:
 
-- [Layer](https://documentation.ubuntu.com/pebble/reference/layer-specification/)-based configuration
-- Service [dependencies](https://documentation.ubuntu.com/pebble/explanation/service-dependencies/)
-- Service [logs](https://documentation.ubuntu.com/pebble/reference/cli-commands/#logs) and [log forwarding](https://documentation.ubuntu.com/pebble/reference/log-forwarding/)
-- [Health checks](https://documentation.ubuntu.com/pebble/reference/health-checks/)
-- [Notices](https://documentation.ubuntu.com/pebble/reference/notices/) (aggregated events)
-- [Identities](https://documentation.ubuntu.com/pebble/how-to/manage-identities/)
-- Can be used in [virtual machines and containers](https://documentation.ubuntu.com/pebble/how-to/manage-a-remote-system/)
-- [CLI commands](https://documentation.ubuntu.com/pebble/reference/cli-commands/)
-- [HTTP API](https://documentation.ubuntu.com/pebble/explanation/api-and-clients/) with a [Go client](https://pkg.go.dev/github.com/canonical/pebble/client) and a [Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py)
+- [Layer](https://ubuntu.com/docs/pebble/reference/layer-specification/)-based configuration
+- Service [dependencies](https://ubuntu.com/docs/pebble/explanation/service-dependencies/)
+- Service [logs](https://ubuntu.com/docs/pebble/reference/cli-commands/#logs) and [log forwarding](https://ubuntu.com/docs/pebble/reference/log-forwarding/)
+- [Health checks](https://ubuntu.com/docs/pebble/reference/health-checks/)
+- [Notices](https://ubuntu.com/docs/pebble/reference/notices/) (aggregated events)
+- [Identities](https://ubuntu.com/docs/pebble/how-to/manage-identities/)
+- Can be used in [virtual machines and containers](https://ubuntu.com/docs/pebble/how-to/manage-a-remote-system/)
+- [CLI commands](https://ubuntu.com/docs/pebble/reference/cli-commands/)
+- [HTTP API](https://ubuntu.com/docs/pebble/explanation/api-and-clients/) with a [Go client](https://pkg.go.dev/github.com/canonical/pebble/client) and a [Python client](https://github.com/canonical/operator/blob/main/ops/pebble.py)
 
 ## Quick start
 
@@ -41,13 +41,13 @@ services:
 pebble run
 ```
 
-Read more about Pebble's general model [here](https://documentation.ubuntu.com/pebble/explanation/general-model/).
+Read more about Pebble's general model [here](https://ubuntu.com/docs/pebble/explanation/general-model/).
 
-For a hands-on introduction to Pebble, we recommend going through the [tutorial](https://documentation.ubuntu.com/pebble/tutorial/getting-started/).
+For a hands-on introduction to Pebble, we recommend going through the [tutorial](https://ubuntu.com/docs/pebble/tutorial/getting-started/).
 
 ## Getting help
 
-To get the most out of Pebble, we recommend starting with the [documentation](https://documentation.ubuntu.com/pebble/).
+To get the most out of Pebble, we recommend starting with the [documentation](https://ubuntu.com/docs/pebble/).
 
 You can [create an issue](https://github.com/canonical/pebble/issues/new) and we will help!
 

--- a/docs/_static/overwrite_links.js
+++ b/docs/_static/overwrite_links.js
@@ -1,0 +1,28 @@
+// Our docs are proxied through to ubuntu.com/docs/pebble.
+// If multiple doc versions are configured, Read the Docs renders a version switcher.
+// The version switcher has the readthedocs-hosted.com URL in links, which we don't want,
+// so this script overwrites those links to use the correct public-facing URL.
+
+// Replace oldDomain with newDomain
+const oldDomain = 'canonical-ubuntu-pebble.readthedocs-hosted.com';
+const newDomain = 'ubuntu.com/docs/pebble';
+
+// Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+const observer = new MutationObserver(function(mutations, obs) {
+    const rtdFlyout = document.querySelector('readthedocs-flyout');
+    if (!rtdFlyout) return;
+
+    obs.disconnect();
+
+    rtdFlyout.addEventListener('click', function() {
+        const shadowRoot = rtdFlyout.shadowRoot;
+        if (!shadowRoot) return;
+
+        const anchors = shadowRoot.querySelectorAll('a');
+        anchors.forEach(anchor => {
+            anchor.href = anchor.href.replace(new RegExp(oldDomain, 'g'), newDomain);
+        });
+    });
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ copyright = f"{datetime.date.today().year}"
 html_title = project + " documentation"
 
 # Documentation website URL
-ogp_site_url = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+ogp_site_url = "https://ubuntu.com/docs/pebble/"
 
 # Preview name of the documentation website
 # TODO: To use a different name for the project in previews, update the next line.
@@ -111,17 +111,18 @@ html_context = {
 # Project slug
 # TODO: If your documentation is hosted on https://documentation.ubuntu.com/,
 #       uncomment and set to the RTD slug.
-slug = "pebble"
+slug = "docs/pebble"
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
 #######################
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = "https://ubuntu.com/docs/pebble/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 sitemap_url_scheme = "{link}"
+sitemap_filename = "doc-sitemap.xml"
 
 # Include `lastmod` dates in the sitemap:
 sitemap_show_lastmod = True
@@ -248,6 +249,7 @@ html_css_files = [
 # Adds custom JavaScript files, located remotely or in 'html_static_path'.
 html_js_files = [
     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
+    "overwrite_links.js",
 ]
 
 # Appends extra markup to the end of every document written in reST

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,7 +116,7 @@ slug = "docs/pebble"
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
 #######################
 
-# Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
+# Used for the canonical URL of each page
 html_baseurl = "https://ubuntu.com/docs/pebble/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ html_context = {
 # }
 
 # Project slug
-# Set to the path after https://ubuntu.com
+# Set to the path after https://ubuntu.com/
 slug = "docs/pebble"
 
 #######################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,8 +109,7 @@ html_context = {
 # }
 
 # Project slug
-# TODO: If your documentation is hosted on https://documentation.ubuntu.com/,
-#       uncomment and set to the RTD slug.
+# Set to the path after https://ubuntu.com
 slug = "docs/pebble"
 
 #######################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,7 +287,7 @@ html_js_files = [
 # Configuration for Intersphinx projects
 #
 intersphinx_mapping = {
-    "operator": ("https://documentation.ubuntu.com/ops/latest/", None),
+    "operator": ("https://canonical.com/juju/docs/ops/latest/", None),
     "juju": ("https://documentation.ubuntu.com/juju/3.6/", None),
     "rockcraft": ("https://documentation.ubuntu.com/rockcraft/latest/", None),
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ description: |
 
   **Documentation**
 
-  To learn more about Pebble, see https://documentation.ubuntu.com/pebble/.
+  To learn more about Pebble, see https://ubuntu.com/docs/pebble/.
 issues: https://github.com/canonical/pebble/issues
 source-code: https://github.com/canonical/pebble
 license: GPL-3.0


### PR DESCRIPTION
This PR updates our doc config so that all URLs use `ubuntu.com/docs/pebble` instead of the backend URL from Read the Docs. Our docs are still hosted on Read the Docs, but we'll be proxying them under ubuntu.com/docs.

<mark>**[Preview docs](https://ubuntu.com/docs/pebble/)** built from this branch. After this PR merges, I'll switch those docs to build from `master` and redirect the existing docs.</mark>

**Main changes**

- Updated Pebble doc URLs in `docs/conf.py`.
- Updated hardcoded URLs for Pebble.
- Added a script `docs/_static/overwrite_links.js`, which is not strictly needed at the moment. This script makes sure that the version switcher from Read the Docs has correct URLs - but we don't use the version switcher. I'm including the script because it's a standard part of the new docs setup at Canonical.

**Extra changes**

- Updated the intersphinx URL for Ops. To account for [operator#2545](https://github.com/canonical/operator/pull/2545).

**Future work (not in this PR)**

- Update URLs for other docs - Juju and Rockcraft.