### PR TITLE
ci: attest build provenance for released artefacts

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -15,6 +15,8 @@ jobs:
   create-binaries:
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         goos: [linux]
@@ -60,6 +62,12 @@ jobs:
         # Share variables with subsequent steps
         echo "ARCHIVE_FILE=${ARCHIVE_FILE}" >>$GITHUB_OUTPUT
         echo "PEBBLE_VERSION=${PEBBLE_VERSION}" >>$GITHUB_OUTPUT
+
+    - name: Attest build provenance
+      if: ${{ github.event_name == 'release' }}
+      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+      with:
+        subject-path: dist/${{ steps.build.outputs.ARCHIVE_FILE }}
 
     - name: Upload archive as Actions artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -62,6 +62,10 @@ jobs:
   remote-build:
     runs-on: ubuntu-latest
     environment: snap-build
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     if: github.event_name != 'pull_request'
     strategy:
       fail-fast: true
@@ -102,6 +106,12 @@ jobs:
         uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79  # v1.3.0
         with:
           snapcraft-args: remote-build --build-for=${{ matrix.arch }} --launchpad-accept-public-upload
+
+      - name: Attest build provenance
+        if: steps.build-snap.outcome == 'success'
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+        with:
+          subject-path: ${{ steps.build-snap.outputs.snap }}
 
       - name: Rename the logs file, for colons are not allowed in the artifact name
         if: always()


### PR DESCRIPTION
This PR adds build attestations for the artefacts we release. We do this across other Charm Tech repos, so this adds consistency. In addition, as far as I know, the snap store does not have its own attestation process (particularly a SLSA one), unlike PyPI for our Python packages, so there is more value here.