### PR TITLE
build: armhf + re-enable other architectures

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [amd64, arm64, armhf, ppc64le, riscv64, s390x]
+        goarch: [amd64, arm64, armv6, ppc64le, riscv64, s390x]
 
     runs-on: ubuntu-latest
 
@@ -46,6 +46,13 @@ jobs:
       run: |
         echo Generating version file
         go generate ./cmd
+
+        # If GOARCH is armvN (e.g. armv6, armv5), set GOARCH=arm and GOARM=N
+        if [[ "$GOARCH" == armv* ]]; then
+          export GOARM="${GOARCH#armv}"
+          export GOARCH=arm
+          echo Using GOARM=$GOARM
+        fi
 
         echo Building for $GOOS $GOARCH
         go build -trimpath -ldflags='-s -w' -o dist/build/pebble ./cmd/pebble

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [amd64, arm64, ppc64le, riscv64, s390x]
+        goarch: [amd64, arm64, armhf, ppc64le, riscv64, s390x]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -70,9 +70,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # TODO: temporarily pause ppc64el, s390x, and riscv64 builds while builders are broken
-        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
-        arch: ["amd64", "arm64", "armhf"]
+        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
     steps:
       - name: Checkout Pebble repo
         uses: actions/checkout@v6
@@ -173,9 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: temporarily pause ppc64el, s390x, and riscv64 builds while builders are broken
-        # arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
-        arch: ["amd64", "arm64", "armhf"]
+        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,10 @@ parts:
       which go
       go version
       snap info go
+      if [ "$CRAFT_ARCH_BUILD_FOR" = "armhf" ]; then
+        export GOARCH=arm
+        export GOARM=6
+      fi
       CGO_ENABLED=0 go build -trimpath -ldflags=-w -ldflags=-s -o $CRAFT_PART_INSTALL/bin/pebble ./cmd/pebble
 
   pebble-release-data:


### PR DESCRIPTION
This builds pebble binaries for armv6/armhf and re-enables snap building
for ppc64el, riscv64 and s390x.