### PR TITLE
fix: allow running on read-only filesystem

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -194,10 +194,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	plan.RegisterSectionExtension(workloads.WorkloadsField, &workloads.WorkloadsSectionExtension{})
 	plan.RegisterSectionExtension(pairingstate.PairingField, &pairingstate.SectionExtension{})
 
-	// When state isn't persisted (in-memory backend, e.g. on a read-only
-	// rootfs) the identity key is ephemeral too -- it's never written to disk.
 	persist := os.Getenv("PEBBLE_PERSIST") != "never"
-
 	idPath := filepath.Join(rcmd.pebbleDir, "identity")
 	idSigner, err := idkey.Get(idPath, persist)
 	if err != nil {

--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -194,8 +194,12 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	plan.RegisterSectionExtension(workloads.WorkloadsField, &workloads.WorkloadsSectionExtension{})
 	plan.RegisterSectionExtension(pairingstate.PairingField, &pairingstate.SectionExtension{})
 
+	// When state isn't persisted (in-memory backend, e.g. on a read-only
+	// rootfs) the identity key is ephemeral too -- it's never written to disk.
+	persist := os.Getenv("PEBBLE_PERSIST") != "never"
+
 	idPath := filepath.Join(rcmd.pebbleDir, "identity")
-	idSigner, err := idkey.Get(idPath)
+	idSigner, err := idkey.Get(idPath, persist)
 	if err != nil {
 		return err
 	}
@@ -210,7 +214,7 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	if os.Getenv("PEBBLE_VERBOSE") == "1" || rcmd.Verbose {
 		dopts.ServiceOutput = os.Stdout
 	}
-	if os.Getenv("PEBBLE_PERSIST") == "never" {
+	if !persist {
 		dopts.Persist = overlord.PersistNever
 	}
 

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -69,7 +69,7 @@ func Get(keyDir string, persist bool) (*IDKey, error) {
 // e.g. on a read-only rootfs). This function should only ever be called on the
 // first boot otherwise the existing identity will be overwritten.
 //
-// When persisted, this function is equivalent to running:
+// This function is equivalent to running:
 //
 //	openssl genpkey -algorithm Ed25519 -out key.pem
 func Generate(keyDir string, persist bool) (*IDKey, error) {

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -33,6 +33,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/canonical/pebble/internals/logger"
 )
 
 const identityKeyFile = "key.pem"
@@ -46,10 +48,10 @@ type IDKey struct {
 }
 
 // Get checks if an existing private identity key exists, and loads the key
-// if it does. It creates a new private identity key and persists it to disk
-// if no key was found. Cases where explicit control is desired on when to
+// if it does. If no key was found it creates a new one, persisting it to disk
+// when persist is true. Cases where explicit control is desired on when to
 // generate or load can use Generate and Load directly.
-func Get(keyDir string) (*IDKey, error) {
+func Get(keyDir string, persist bool) (*IDKey, error) {
 	keyPath := filepath.Join(keyDir, identityKeyFile)
 	exists, err := pathExists(keyPath)
 	if err != nil {
@@ -58,33 +60,54 @@ func Get(keyDir string) (*IDKey, error) {
 	if exists {
 		return Load(keyDir)
 	}
-	return Generate(keyDir)
+	return Generate(keyDir, persist)
 }
 
-// Generate generates a new identity key and persists it to disk. This
-// function should only ever be called on the first boot otherwise the
-// existing identity will be overwritten.
+// Generate generates a new identity key. When persist is true the key is
+// written to disk; when false an ephemeral in-memory identity is returned
+// that does not touch the filesystem (see issue #801) -- used with the
+// in-memory state backend, e.g. on a read-only rootfs. This function should
+// only ever be called on the first boot otherwise the existing identity will
+// be overwritten.
 //
-// This function is equivalent to running:
+// When persisted, this function is equivalent to running:
 //
 //	openssl genpkey -algorithm Ed25519 -out key.pem
-func Generate(keyDir string) (*IDKey, error) {
+func Generate(keyDir string, persist bool) (*IDKey, error) {
 	k := &IDKey{
 		keyDir: keyDir,
 	}
-	err := k.createDir()
-	if err != nil {
-		return nil, fmt.Errorf("cannot create identity directory: %w", err)
-	}
-	_, k.key, err = ed25519.GenerateKey(rand.Reader)
+	_, key, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate identity key: %w", err)
 	}
-	err = k.save()
+	k.key = key
+
+	if !persist {
+		// Ephemeral identity: skip the disk entirely. It won't survive a
+		// restart, matching the in-memory state backend it's paired with.
+		logger.Noticef("Not persisting identity key; using an ephemeral identity.")
+		return k, nil
+	}
+
+	err = k.persist()
 	if err != nil {
-		return nil, fmt.Errorf("cannot save identity key: %w", err)
+		return nil, err
 	}
 	return k, nil
+}
+
+// persist creates the key directory and writes the key to disk.
+func (k *IDKey) persist() error {
+	err := k.createDir()
+	if err != nil {
+		return fmt.Errorf("cannot create identity directory: %w", err)
+	}
+	err = k.save()
+	if err != nil {
+		return fmt.Errorf("cannot save identity key: %w", err)
+	}
+	return nil
 }
 
 // Load loads an existing identity key from disk.

--- a/internals/idkey/idkey.go
+++ b/internals/idkey/idkey.go
@@ -63,12 +63,11 @@ func Get(keyDir string, persist bool) (*IDKey, error) {
 	return Generate(keyDir, persist)
 }
 
-// Generate generates a new identity key. When persist is true the key is
-// written to disk; when false an ephemeral in-memory identity is returned
-// that does not touch the filesystem (see issue #801) -- used with the
-// in-memory state backend, e.g. on a read-only rootfs. This function should
-// only ever be called on the first boot otherwise the existing identity will
-// be overwritten.
+// Generate generates a new identity key and, when persist is true, writes it
+// to disk. When persist is false an ephemeral in-memory identity is returned
+// that never touches the filesystem (used with the in-memory state backend,
+// e.g. on a read-only rootfs). This function should only ever be called on the
+// first boot otherwise the existing identity will be overwritten.
 //
 // When persisted, this function is equivalent to running:
 //
@@ -77,37 +76,26 @@ func Generate(keyDir string, persist bool) (*IDKey, error) {
 	k := &IDKey{
 		keyDir: keyDir,
 	}
-	_, key, err := ed25519.GenerateKey(rand.Reader)
+	var err error
+	_, k.key, err = ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate identity key: %w", err)
 	}
-	k.key = key
 
 	if !persist {
-		// Ephemeral identity: skip the disk entirely. It won't survive a
-		// restart, matching the in-memory state backend it's paired with.
 		logger.Noticef("Not persisting identity key; using an ephemeral identity.")
 		return k, nil
 	}
 
-	err = k.persist()
+	err = k.createDir()
 	if err != nil {
-		return nil, err
-	}
-	return k, nil
-}
-
-// persist creates the key directory and writes the key to disk.
-func (k *IDKey) persist() error {
-	err := k.createDir()
-	if err != nil {
-		return fmt.Errorf("cannot create identity directory: %w", err)
+		return nil, fmt.Errorf("cannot create identity directory: %w", err)
 	}
 	err = k.save()
 	if err != nil {
-		return fmt.Errorf("cannot save identity key: %w", err)
+		return nil, fmt.Errorf("cannot save identity key: %w", err)
 	}
-	return nil
+	return k, nil
 }
 
 // Load loads an existing identity key from disk.

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -31,7 +31,7 @@ func (ks *keySuite) TestNoDirectory(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	firstBoot, err := idkey.Generate(keyDir)
+	firstBoot, err := idkey.Generate(keyDir, true)
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
@@ -48,11 +48,11 @@ func (ks *keySuite) TestGet(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	firstBoot, err := idkey.Get(keyDir)
+	firstBoot, err := idkey.Get(keyDir, true)
 	c.Assert(err, IsNil)
 
 	// Load the identity key (other boots)
-	nextBoot, err := idkey.Get(keyDir)
+	nextBoot, err := idkey.Get(keyDir, true)
 	c.Assert(err, IsNil)
 
 	// Both should be the same identity.
@@ -71,7 +71,7 @@ func (ks *keySuite) TestDirectoryInvalid(c *C) {
 	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
 
 	// Saving
-	_, err = idkey.Generate(keyDir)
+	_, err = idkey.Generate(keyDir, true)
 	c.Assert(err, ErrorMatches, ".* expected permission 0o700 .*")
 }
 
@@ -81,7 +81,7 @@ func (ks *keySuite) TestDirInvalid(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "foo/identity")
 
 	// Saving
-	_, err := idkey.Generate(keyDir)
+	_, err := idkey.Generate(keyDir, true)
 	c.Assert(err, ErrorMatches, "cannot create identity directory.*")
 }
 
@@ -90,7 +90,7 @@ func (ks *keySuite) TestInvalidKey(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	_, err := idkey.Generate(keyDir)
+	_, err := idkey.Generate(keyDir, true)
 	c.Assert(err, IsNil)
 
 	err = os.Chmod(filepath.Join(keyDir, "key.pem"), 0o644)
@@ -106,7 +106,7 @@ func (ks *keySuite) TestEmptyKey(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	_, err := idkey.Generate(keyDir)
+	_, err := idkey.Generate(keyDir, true)
 	c.Assert(err, IsNil)
 
 	// Zero the existing file.
@@ -126,7 +126,7 @@ func (ks *keySuite) TestKeyWithTrailingBytes(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	_, err := idkey.Generate(keyDir)
+	_, err := idkey.Generate(keyDir, true)
 	c.Assert(err, IsNil)
 
 	// Append some unexpected bytes after the PEM block.
@@ -147,7 +147,7 @@ func (ks *keySuite) TestKeySign(c *C) {
 	keyDir := filepath.Join(c.MkDir(), "identity")
 
 	// Create a new identity key (first boot)
-	signer, err := idkey.Generate(keyDir)
+	signer, err := idkey.Generate(keyDir, true)
 	c.Assert(err, IsNil)
 
 	message := []byte("hello world")
@@ -170,7 +170,7 @@ func (ks *keySuite) TestKeySign(c *C) {
 func (ks *keySuite) BenchmarkKeyGeneration(c *C) {
 	for i := 0; i < c.N; i++ {
 		keyDir := filepath.Join(c.MkDir(), "identity")
-		_, err := idkey.Generate(keyDir)
+		_, err := idkey.Generate(keyDir, true)
 		c.Assert(err, IsNil)
 	}
 }

--- a/internals/idkey/idkey_test.go
+++ b/internals/idkey/idkey_test.go
@@ -59,6 +59,31 @@ func (ks *keySuite) TestGet(c *C) {
 	c.Assert(firstBoot.Fingerprint(), Equals, nextBoot.Fingerprint())
 }
 
+// TestEphemeral checks that an ephemeral key is generated without touching
+// the filesystem, even when the directory can't be written.
+func (ks *keySuite) TestEphemeral(c *C) {
+	// A non-existent non-leaf directory would fail a persisted Generate, but
+	// must be tolerated when ephemeral since the disk is never touched.
+	keyDir := filepath.Join(c.MkDir(), "foo/identity")
+
+	k, err := idkey.Generate(keyDir, false)
+	c.Assert(err, IsNil)
+	c.Check(k, NotNil)
+	c.Check(k.Fingerprint(), Not(Equals), "")
+
+	// Nothing should have been written to disk.
+	_, err = os.Stat(keyDir)
+	c.Check(os.IsNotExist(err), Equals, true)
+
+	// Get with persist=false on an empty dir behaves the same.
+	keyDir2 := filepath.Join(c.MkDir(), "identity")
+	k2, err := idkey.Get(keyDir2, false)
+	c.Assert(err, IsNil)
+	c.Check(k2, NotNil)
+	_, err = os.Stat(filepath.Join(keyDir2, "key.pem"))
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
 // TestDirectoryInvalid confirms that if the leaf directory has invalid
 // permissions we exit.
 func (ks *keySuite) TestDirectoryInvalid(c *C) {

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -150,7 +150,9 @@ func New(opts *Options) (*Overlord, error) {
 	if !osutil.IsDir(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q does not exist", o.pebbleDir)
 	}
-	if !osutil.IsWritable(o.pebbleDir) {
+	// Only require a writable directory when state is persisted to disk. With
+	// PersistNever (in-memory backend) pebble can run on a read-only rootfs.
+	if opts.Persist == PersistDefault && !osutil.IsWritable(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q not writable", o.pebbleDir)
 	}
 

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -150,8 +150,6 @@ func New(opts *Options) (*Overlord, error) {
 	if !osutil.IsDir(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q does not exist", o.pebbleDir)
 	}
-	// Only require a writable directory when state is persisted to disk. With
-	// PersistNever (in-memory backend) pebble can run on a read-only rootfs.
 	if opts.Persist == PersistDefault && !osutil.IsWritable(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q not writable", o.pebbleDir)
 	}

--- a/internals/overlord/overlord_test.go
+++ b/internals/overlord/overlord_test.go
@@ -134,6 +134,29 @@ func (ovs *overlordSuite) TestNewInMemoryBackend(c *C) {
 	c.Check(errors.Is(err, fs.ErrNotExist), Equals, true)
 }
 
+func (ovs *overlordSuite) TestNewNonWritableDir(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("requires non-root user")
+	}
+	restore := patch.Fake(42, 2, nil)
+	defer restore()
+
+	// A non-writable pebble dir mimics a read-only filesystem.
+	err := os.Chmod(ovs.dir, 0o500)
+	c.Assert(err, IsNil)
+	defer os.Chmod(ovs.dir, 0o700)
+	c.Assert(osutil.IsWritable(ovs.dir), Equals, false)
+
+	// PersistDefault still requires a writable directory.
+	_, err = overlord.New(&overlord.Options{PebbleDir: ovs.dir})
+	c.Assert(err, ErrorMatches, `directory ".*" not writable`)
+
+	// PersistNever uses the in-memory backend and tolerates a read-only dir.
+	o, err := overlord.New(&overlord.Options{PebbleDir: ovs.dir, Persist: overlord.PersistNever})
+	c.Assert(err, IsNil)
+	c.Check(o, NotNil)
+}
+
 func (ovs *overlordSuite) TestNewWithGoodState(c *C) {
 	fakeState := fmt.Appendf(nil, `{
 		"data": {"patch-level": %d, "patch-sublevel": %d, "patch-sublevel-last-version": %q, "some": "data", "pairing-details": {"paired": false}},

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -273,8 +273,7 @@ services:
 }
 
 // TestPersistNever tests that when the environment variable `PEBBLE_PERSIST` is set to "never",
-// Pebble persists nothing to disk: neither the state file nor the identity key. The identity
-// becomes ephemeral, which is what lets Pebble run on a read-only filesystem.
+// Pebble does not persist its state to the disk.
 func TestPersistNever(t *testing.T) {
 	t.Setenv("PEBBLE_PERSIST", "never")
 	pebbleDir := t.TempDir()
@@ -295,7 +294,6 @@ services:
 	waitForLog(t, stderrCh, "pebble", "using an ephemeral identity", 3*time.Second)
 	waitForFile(t, filepath.Join(pebbleDir, "svc1"), 3*time.Second)
 
-	// The state file must not be written.
 	_, err := os.Stat(filepath.Join(pebbleDir, ".pebble.state"))
 	if err == nil {
 		t.Fatalf("pebble run with PEBBLE_PERSIST set to 'never' still created the state file")

--- a/tests/run_test.go
+++ b/tests/run_test.go
@@ -273,7 +273,8 @@ services:
 }
 
 // TestPersistNever tests that when the environment variable `PEBBLE_PERSIST` is set to "never",
-// Pebble does not persist its state to the disk.
+// Pebble persists nothing to disk: neither the state file nor the identity key. The identity
+// becomes ephemeral, which is what lets Pebble run on a read-only filesystem.
 func TestPersistNever(t *testing.T) {
 	t.Setenv("PEBBLE_PERSIST", "never")
 	pebbleDir := t.TempDir()
@@ -290,12 +291,23 @@ services:
 
 	createLayer(t, pebbleDir, "001-simple-layer.yaml", layerYAML)
 
-	_, _ = pebbleDaemon(t, pebbleDir, "run")
+	_, stderrCh := pebbleDaemon(t, pebbleDir, "run")
+	waitForLog(t, stderrCh, "pebble", "using an ephemeral identity", 3*time.Second)
 	waitForFile(t, filepath.Join(pebbleDir, "svc1"), 3*time.Second)
 
+	// The state file must not be written.
 	_, err := os.Stat(filepath.Join(pebbleDir, ".pebble.state"))
 	if err == nil {
 		t.Fatalf("pebble run with PEBBLE_PERSIST set to 'never' still created the state file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("pebble run with PEBBLE_PERSIST set to 'never' got error other than ErrNotExist: %v", err)
+	}
+
+	// The identity key must not be written either.
+	_, err = os.Stat(filepath.Join(pebbleDir, "identity", "key.pem"))
+	if err == nil {
+		t.Fatalf("pebble run with PEBBLE_PERSIST set to 'never' still wrote the identity key")
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("pebble run with PEBBLE_PERSIST set to 'never' got error other than ErrNotExist: %v", err)


### PR DESCRIPTION
runs pebble on a read-only rootfs. addresses #801.

two things get written to the pebble dir on startup and break when it's read-only: the state file and the identity key file. when `PEBBLE_PERSIST` is set, the state and the key are now stored in memory. 

btw, here are the things which still need a writable path:
  - the unix socket. could switch to abstract sockets maybe, but i'm not sure what would be the repercussions.. 
  - the TLS identity certificate on the first https connection. so https still breaks.
  
for both i thought it better to keep this PR small and fix this separately.

for now, "demo.sh":

```bash
rootfs="$PWD/rootfs"
socket="$PWD/pebble.socket"

trap 'kill ${pid:-} 2>/dev/null; umount rootfs 2>/dev/null; rm -rf "$rootfs"; rm -f "$socket"' EXIT

mkdir -p "$rootfs" && mount -t tmpfs -o size=1m tmpfs "$rootfs" && mount -o remount,ro "$rootfs"

env \
    PEBBLE="$PWD/rootfs" \
    PEBBLE_SOCKET="$socket" \
    PEBBLE_PERSIST=never \
    ./pebble run --hold &
pid=$!

for _ in $(seq 100); do [[ -S "$socket" ]] && break; sleep 0.1; done
[[ -S "$socket" ]] || { echo "FAIL: socket never appeared"; exit 1; }
```

from repo root:

```bash
$ sudo bash ./demo.sh
2026-06-22T12:03:03.560Z [pebble] Not persisting identity key; using an ephemeral identity.
2026-06-22T12:03:03.560Z [pebble] {"type":"security","datetime":"2026-06-22T12:03:03Z","level":"WARN","event":"sys_startup:0","description":"Starting daemon","appid":"pebble"}
2026-06-22T12:03:03.560Z [pebble] Started daemon.
2026-06-22T12:03:03.660Z [pebble] Exiting on terminated signal.
2026-06-22T12:03:03.660Z [pebble] {"type":"security","datetime":"2026-06-22T12:03:03Z","level":"WARN","event":"sys_shutdown:0","description":"Shutting down daemon","appid":"pebble"}
```