### PR TITLE
docs: test new docs (don't merge)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ reference/index
 explanation/index
 ```
 
+This is a preview of the documentation.
+
 **Pebble** is a lightweight Linux service manager.
 
 It helps you orchestrate a set of local processes as an organized set. It resembles well-known tools such as _supervisord_, _runit_, or _s6_, in that it can easily manage non-system processes independently from the system services. However, it was designed with unique features such as layered configuration and an HTTP API that help with more specific use cases.


### PR DESCRIPTION
This PR is for testing that preview docs build correctly after migrating to https://ubuntu.com/docs/pebble/ (and that only one set of preview docs builds). Not for merging.