### PR TITLE
chore: port osutil io, stat and fstype from snapd

### DIFF
--- a/internals/daemon/api_files.go
+++ b/internals/daemon/api_files.go
@@ -500,7 +500,7 @@ func writeFile(item writeFilesItem, source io.Reader) error {
 	if uid != nil && gid != nil {
 		sysUid, sysGid = sys.UserID(*uid), sys.GroupID(*gid)
 	}
-	return atomicWriteChown(item.Path, source, perm, osutil.AtomicWriteChmod, sysUid, sysGid)
+	return atomicWriteChown(item.Path, source, perm, osutil.AtomicWriteFlags(0), sysUid, sysGid)
 }
 
 func mkdirAllUserGroup(path string, perm os.FileMode, uid, gid *int) error {

--- a/internals/daemon/api_files_test.go
+++ b/internals/daemon/api_files_test.go
@@ -405,7 +405,7 @@ func (s *filesSuite) TestMakeDirsSingle(c *C) {
 	c.Check(r.Result, HasLen, 1)
 	checkFileResult(c, r.Result[0], tmpDir+"/newdir", "", "")
 
-	c.Check(osutil.IsDir(tmpDir+"/newdir"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/newdir"), Equals, true)
 }
 
 func (s *filesSuite) TestMakeDirsMultiple(c *C) {
@@ -439,9 +439,9 @@ func (s *filesSuite) TestMakeDirsMultiple(c *C) {
 	checkFileResult(c, r.Result[1], tmpDir+"/will/not/work", "not-found", ".*")
 	checkFileResult(c, r.Result[2], tmpDir+"/make/my/parents", "", "")
 
-	c.Check(osutil.IsDir(tmpDir+"/newdir"), Equals, true)
-	c.Check(osutil.IsDir(tmpDir+"/will/not/work"), Equals, false)
-	c.Check(osutil.IsDir(tmpDir+"/make/my/parents"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/newdir"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/will/not/work"), Equals, false)
+	c.Check(osutil.IsDirectory(tmpDir+"/make/my/parents"), Equals, true)
 	st, err := os.Stat(tmpDir + "/newdir")
 	c.Assert(err, IsNil)
 	c.Check(st.Mode().Perm(), Equals, os.FileMode(0o755))
@@ -528,11 +528,11 @@ func (s *filesSuite) testMakeDirsUserGroup(c *C, uid, gid int, user, group strin
 	checkFileResult(c, r.Result[3], tmpDir+"/nested1/normal", "", "")
 	checkFileResult(c, r.Result[4], tmpDir+"/nested2/user-group", "", "")
 
-	c.Check(osutil.IsDir(tmpDir+"/normal"), Equals, true)
-	c.Check(osutil.IsDir(tmpDir+"/uid-gid"), Equals, true)
-	c.Check(osutil.IsDir(tmpDir+"/user-group"), Equals, true)
-	c.Check(osutil.IsDir(tmpDir+"/nested1/normal"), Equals, true)
-	c.Check(osutil.IsDir(tmpDir+"/nested2/user-group"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/normal"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/uid-gid"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/user-group"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/nested1/normal"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/nested2/user-group"), Equals, true)
 
 	return tmpDir
 }
@@ -630,7 +630,7 @@ func (s *filesSuite) TestRemoveSingle(c *C) {
 	c.Check(r.Result, HasLen, 1)
 	checkFileResult(c, r.Result[0], tmpDir+"/file", "", "")
 
-	c.Check(osutil.CanStat(tmpDir+"/file"), Equals, false)
+	c.Check(osutil.FileExists(tmpDir+"/file"), Equals, false)
 }
 
 func (s *filesSuite) TestRemoveMultiple(c *C) {
@@ -672,10 +672,10 @@ func (s *filesSuite) TestRemoveMultiple(c *C) {
 	checkFileResult(c, r.Result[2], tmpDir+"/non-empty", "generic-file-error", ".*directory not empty")
 	checkFileResult(c, r.Result[3], tmpDir+"/recursive", "", "")
 
-	c.Check(osutil.CanStat(tmpDir+"/file"), Equals, false)
-	c.Check(osutil.IsDir(tmpDir+"/empty"), Equals, false)
-	c.Check(osutil.IsDir(tmpDir+"/non-empty"), Equals, true)
-	c.Check(osutil.IsDir(tmpDir+"/recursive"), Equals, false)
+	c.Check(osutil.FileExists(tmpDir+"/file"), Equals, false)
+	c.Check(osutil.IsDirectory(tmpDir+"/empty"), Equals, false)
+	c.Check(osutil.IsDirectory(tmpDir+"/non-empty"), Equals, true)
+	c.Check(osutil.IsDirectory(tmpDir+"/recursive"), Equals, false)
 }
 
 func (s *filesSuite) TestWriteNoMetadata(c *C) {
@@ -1204,10 +1204,10 @@ group not found
 	checkFileResult(c, r.Result[4], pathUserNotFound, "generic-file-error", ".*unknown user.*")
 	checkFileResult(c, r.Result[5], pathGroupNotFound, "generic-file-error", ".*unknown group.*")
 
-	c.Check(osutil.CanStat(pathNoContent), Equals, false)
-	c.Check(osutil.CanStat(pathNotAbsolute), Equals, false)
-	c.Check(osutil.CanStat(pathNotFound), Equals, false)
-	c.Check(osutil.CanStat(pathPermissionDenied), Equals, false)
+	c.Check(osutil.FileExists(pathNoContent), Equals, false)
+	c.Check(osutil.FileExists(pathNotAbsolute), Equals, false)
+	c.Check(osutil.FileExists(pathNotFound), Equals, false)
+	c.Check(osutil.FileExists(pathPermissionDenied), Equals, false)
 }
 
 func assertFile(c *C, path string, perm os.FileMode, content string) {

--- a/internals/osutil/export_test.go
+++ b/internals/osutil/export_test.go
@@ -84,6 +84,11 @@ func SetUnsafeIO(b bool) (restore func()) {
 	}
 }
 
+func GetUnsafeIO() bool {
+	// a getter so that tests do not attempt to modify that directly
+	return unsafeIO
+}
+
 func SetAtomicFileRenamed(aw *AtomicFile, renamed bool) {
 	aw.renamed = renamed
 }
@@ -125,10 +130,18 @@ func FakeEnviron(f func() []string) (restore func()) {
 	}
 }
 
-func FakeRandomString(f func(int) string) (restore func()) {
-	old := randomString
-	randomString = f
+func FakeFChmod(f func(file *os.File, mode os.FileMode) error) (restore func()) {
+	old := fChmod
+	fChmod = f
 	return func() {
-		randomString = old
+		fChmod = old
+	}
+}
+
+func FakeLookPath(new func(string) (string, error)) (restore func()) {
+	old := lookPath
+	lookPath = new
+	return func() {
+		lookPath = old
 	}
 }

--- a/internals/osutil/io.go
+++ b/internals/osutil/io.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2014-2026 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -17,12 +17,14 @@ package osutil
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
-
-	"github.com/canonical/x-go/randutil"
+	"time"
 
 	"github.com/canonical/pebble/internals/osutil/sys"
 )
@@ -30,21 +32,10 @@ import (
 // AtomicWriteFlags are a bitfield of flags for AtomicWriteFile
 type AtomicWriteFlags uint
 
-const (
-	// AtomicWriteFollow makes AtomicWriteFile follow symlinks
-	AtomicWriteFollow AtomicWriteFlags = 1 << iota
-	// AtomicWriteChmod performs an explicit chmod to file permissions after
-	// creation for e.g. overcoming any umask modifications.
-	AtomicWriteChmod
-)
-
 // Allow disabling sync for testing. This brings massive improvements on
 // certain filesystems (like btrfs) and very much noticeable improvements in
 // all unit tests in general.
 var unsafeIO bool = testing.Testing() && os.Getenv("UNSAFE_IO") == "1"
-
-// For testing
-var randomString = randutil.RandomString
 
 // An AtomicFile is similar to an os.File but it has an additional
 // Commit() method that does whatever needs to be done so the
@@ -58,6 +49,7 @@ type AtomicFile struct {
 	tmpname string
 	uid     sys.UserID
 	gid     sys.GroupID
+	mtime   time.Time
 	closed  bool
 	renamed bool
 }
@@ -65,10 +57,10 @@ type AtomicFile struct {
 // NewAtomicFile builds an AtomicFile backed by an *os.File that will have
 // the given filename, permissions and uid/gid when Committed.
 //
-// It _might_ be implemented using O_TMPFILE (see open(2)).
+//	It _might_ be implemented using O_TMPFILE (see open(2)).
 //
 // Note that it won't follow symlinks and will replace existing symlinks with
-// the real file, unless the AtomicWriteFollow flag is specified.
+// the real file. Also, umask is ignored when setting the file's permissions.
 //
 // It is the caller's responsibility to clean up on error, by calling Cancel().
 //
@@ -78,15 +70,11 @@ type AtomicFile struct {
 // Also note that there are a number of scenarios where Commit fails and then
 // Cancel also fails. In all these scenarios your filesystem was probably in a
 // rather poor state. Good luck.
-func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) (aw *AtomicFile, err error) {
-	if flags&AtomicWriteFollow != 0 {
-		if fn, err := os.Readlink(filename); err == nil || (fn != "" && os.IsNotExist(err)) {
-			if filepath.IsAbs(fn) {
-				filename = fn
-			} else {
-				filename = filepath.Join(filepath.Dir(filename), fn)
-			}
-		}
+func NewAtomicFile(filename string, perm os.FileMode, _ AtomicWriteFlags, uid sys.UserID, gid sys.GroupID) (aw *AtomicFile, err error) {
+	basename := filepath.Base(filename)
+	dirname := filepath.Dir(filename)
+	if strings.Contains(basename, "*") {
+		return nil, fmt.Errorf("cannot create tempfile for filename containing '*': %q", basename)
 	}
 	// The tilde is appended so that programs that inspect all files in some
 	// directory are more likely to ignore this file as an editor backup file.
@@ -95,28 +83,32 @@ func NewAtomicFile(filename string, perm os.FileMode, flags AtomicWriteFlags, ui
 	// aa-enforce. Tools from this package enumerate all profiles by loading
 	// parsing any file found in /etc/apparmor.d/, skipping only very specific
 	// suffixes, such as the one we selected below.
-	tmp := filename + "." + randomString(12) + "~"
-
-	fd, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+	fd, err := os.CreateTemp(dirname, basename+".*~")
 	if err != nil {
 		return nil, err
 	}
-
-	if flags&AtomicWriteChmod != 0 {
-		err := fd.Chmod(perm)
+	defer func() {
 		if err != nil {
-			return nil, err
+			fd.Close()
+			os.Remove(fd.Name())
 		}
+	}()
+
+	// Chmod ignores umask
+	if err = fChmod(fd, perm); err != nil {
+		return nil, err
 	}
 
 	return &AtomicFile{
 		File:    fd,
 		target:  filename,
-		tmpname: tmp,
+		tmpname: fd.Name(),
 		uid:     uid,
 		gid:     gid,
 	}, nil
 }
+
+var fChmod = (*os.File).Chmod
 
 // ErrCannotCancel means the Commit operation failed at the last step, and
 // your luck has run out.
@@ -153,12 +145,12 @@ var chown = sys.Chown
 
 const NoChown = sys.FlagID
 
-// Commit the modification; make it permanent.
-//
-// If Commit succeeds, the writer is closed and further attempts to
-// write will fail. If Commit fails, the writer _might_ be closed;
-// Cancel() needs to be called to clean up.
-func (aw *AtomicFile) Commit() error {
+// SetModTime sets the given modification time on the created file.
+func (aw *AtomicFile) SetModTime(t time.Time) {
+	aw.mtime = t
+}
+
+func (aw *AtomicFile) commit() error {
 	if aw.uid != NoChown || aw.gid != NoChown {
 		if err := chown(aw.File, aw.uid, aw.gid); err != nil {
 			return err
@@ -184,6 +176,12 @@ func (aw *AtomicFile) Commit() error {
 		return err
 	}
 
+	if !aw.mtime.IsZero() {
+		if err := os.Chtimes(aw.tmpname, time.Now(), aw.mtime); err != nil {
+			return err
+		}
+	}
+
 	if err := os.Rename(aw.tmpname, aw.target); err != nil {
 		return err
 	}
@@ -194,6 +192,31 @@ func (aw *AtomicFile) Commit() error {
 	}
 
 	return nil
+}
+
+// Commit the modification; make it permanent.
+//
+// If Commit succeeds, the writer is closed and further attempts to
+// write will fail. If Commit fails, the writer _might_ be closed;
+// Cancel() needs to be called to clean up.
+func (aw *AtomicFile) Commit() error {
+	return aw.commit()
+}
+
+// CommitAs commits the file under a new target name, following the same rules
+// as Commit. The new target name must be located in the same directory as the
+// original filename provided when creating AtomicFile.
+//
+// The call is useful when the target name is not known until the end (eg. it
+// may depend on data being written to the file), in which case one can create
+// AtomicFile using a temporary name and later override the actual name by
+// calling CommitAs.
+func (aw *AtomicFile) CommitAs(filename string) error {
+	if dir := filepath.Dir(filename); dir != filepath.Dir(aw.target) {
+		return fmt.Errorf("cannot commit as %q to a different directory %q", filepath.Base(filename), dir)
+	}
+	aw.target = filename
+	return aw.commit()
 }
 
 // The AtomicWrite* family of functions work like os.WriteFile(), but the
@@ -234,4 +257,99 @@ func AtomicWriteChown(filename string, reader io.Reader, perm os.FileMode, flags
 	}
 
 	return aw.Commit()
+}
+
+// AtomicRename attempts to rename a path from oldName to newName atomically.
+func AtomicRename(oldName, newName string) (err error) {
+	var oldDir, newDir *os.File
+
+	// unsafeIO controls the ability to ignore expensive disk
+	// synchronization. It is only used inside tests.
+	if !unsafeIO {
+		// if called with a path with trailing '/', filepath.Dir
+		// returns the dir itself instead of the parent
+		oldName = filepath.Clean(oldName)
+		newName = filepath.Clean(newName)
+
+		oldDirPath := filepath.Dir(oldName)
+		newDirPath := filepath.Dir(newName)
+
+		oldDir, err = os.Open(oldDirPath)
+		if err != nil {
+			return err
+		}
+		defer oldDir.Close()
+
+		newDir, err = os.Open(newDirPath)
+		if err != nil {
+			return err
+		}
+		defer newDir.Close()
+
+		oldInfo, err := oldDir.Stat()
+		if err != nil {
+			return err
+		}
+		newInfo, err := newDir.Stat()
+		if err != nil {
+			return err
+		}
+		if oldStat, ok := oldInfo.Sys().(*syscall.Stat_t); ok {
+			if newStat, ok := newInfo.Sys().(*syscall.Stat_t); ok {
+				// Old and new directories refer to the same location. We can only sync once.
+				if oldStat.Dev == newStat.Dev && oldStat.Ino == newStat.Ino {
+					newDir = nil
+				}
+			}
+		}
+	}
+
+	if err := os.Rename(oldName, newName); err != nil {
+		return err
+	}
+	var err1, err2 error
+	if oldDir != nil {
+		err1 = oldDir.Sync()
+	}
+	if newDir != nil {
+		err2 = newDir.Sync()
+	}
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func atomicLinkOp(target, linkPath string, op func(target, tmp string) error) error {
+	basename := filepath.Base(linkPath)
+	dirname := filepath.Dir(linkPath)
+	if strings.Contains(basename, "*") {
+		return fmt.Errorf("cannot create tempfile for link path containing '*': %q", basename)
+	}
+	tmpDir, err := os.MkdirTemp(dirname, basename+".*~")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	tmp := filepath.Join(tmpDir, "link")
+	if err := op(target, tmp); err != nil {
+		return err
+	}
+	return AtomicRename(tmp, linkPath)
+}
+
+// AtomicSymlink attempts to atomically create a symlink at linkPath, pointing
+// to a given target. The process creates a temporary symlink object pointing to
+// the target, and then proceeds to rename it atomically, replacing the
+// linkPath.
+func AtomicSymlink(target, linkPath string) error {
+	return atomicLinkOp(target, linkPath, os.Symlink)
+}
+
+// AtomicLink attempts to atomically create a hardlink at linkPath, referencing
+// the given target. The process creates a temporary hardlink object pointing
+// to the target, and then proceeds to rename it atomically, replacing the
+// linkPath.
+func AtomicLink(target, linkPath string) error {
+	return atomicLinkOp(target, linkPath, os.Link)
 }

--- a/internals/osutil/io_test.go
+++ b/internals/osutil/io_test.go
@@ -1,21 +1,16 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2014-2015 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2014-2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package osutil_test
 
@@ -24,7 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -83,103 +78,62 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	c.Assert(os.Chmod(rodir, 0500), IsNil)
 	defer os.Chmod(rodir, 0700)
 
-	if os.Getuid() == 0 {
-		c.Skip("requires running as non-root user")
-	}
 	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
 	c.Assert(err, NotNil)
 }
 
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAbsoluteSymlinks(c *C) {
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInDirOkay(c *C) {
 	tmpdir := c.MkDir()
-	rodir := filepath.Join(tmpdir, "ro")
-	p := filepath.Join(rodir, "foo")
-	s := filepath.Join(tmpdir, "foo")
-	c.Assert(os.MkdirAll(rodir, 0755), IsNil)
-	c.Assert(os.Symlink(s, p), IsNil)
-	c.Assert(os.Chmod(rodir, 0500), IsNil)
-	defer os.Chmod(rodir, 0700)
 
-	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow)
+	dir := filepath.Join(tmpdir, "foo*bar")
+	c.Assert(os.MkdirAll(dir, 0o755), IsNil)
+
+	p := filepath.Join(dir, "baz")
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
 	c.Assert(err, IsNil)
-
-	c.Assert(p, testutil.FileEquals, "hi")
 }
 
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileChmod(c *C) {
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInBasenameError(c *C) {
 	tmpdir := c.MkDir()
-	oldmask := syscall.Umask(0222)
-	defer syscall.Umask(oldmask)
 
-	path := filepath.Join(tmpdir, "foo")
-	err := osutil.AtomicWriteFile(path, []byte{}, 0777, osutil.AtomicWriteChmod)
+	p := filepath.Join(tmpdir, "foo*bar")
+	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, 0)
+	c.Assert(err, ErrorMatches, `cannot create tempfile for filename containing '\*': "foo\*bar"`)
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
+	tmpdir := c.MkDir()
+
+	err := os.Chmod(tmpdir, 0o644) // no directory traversal allowed
 	c.Assert(err, IsNil)
-
-	st, err := os.Stat(path)
-	c.Assert(err, IsNil)
-	c.Assert(st.Mode()&os.ModePerm, Equals, os.FileMode(0777))
-}
-
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteAbsoluteSymlink(c *C) {
-	tmpdir := c.MkDir()
-	rodir := filepath.Join(tmpdir, "ro")
-	p := filepath.Join(rodir, "foo")
-	s := filepath.Join(tmpdir, "foo")
-	c.Assert(os.MkdirAll(rodir, 0755), IsNil)
-	c.Assert(os.Symlink(s, p), IsNil)
-	c.Assert(os.Chmod(rodir, 0500), IsNil)
-	defer os.Chmod(rodir, 0700)
-
-	c.Assert(os.WriteFile(s, []byte("hello"), 0644), IsNil)
-	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
-
-	c.Assert(p, testutil.FileEquals, "hi")
-}
-
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileRelativeSymlinks(c *C) {
-	tmpdir := c.MkDir()
-	rodir := filepath.Join(tmpdir, "ro")
-	p := filepath.Join(rodir, "foo")
-	c.Assert(os.MkdirAll(rodir, 0755), IsNil)
-	c.Assert(os.Symlink("../foo", p), IsNil)
-	c.Assert(os.Chmod(rodir, 0500), IsNil)
-	defer os.Chmod(rodir, 0700)
-
-	err := osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow)
-	c.Assert(err, IsNil)
-
-	c.Assert(p, testutil.FileEquals, "hi")
-}
-
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwriteRelativeSymlink(c *C) {
-	tmpdir := c.MkDir()
-	rodir := filepath.Join(tmpdir, "ro")
-	p := filepath.Join(rodir, "foo")
-	s := filepath.Join(tmpdir, "foo")
-	c.Assert(os.MkdirAll(rodir, 0755), IsNil)
-	c.Assert(os.Symlink("../foo", p), IsNil)
-	c.Assert(os.Chmod(rodir, 0500), IsNil)
-	defer os.Chmod(rodir, 0700)
-
-	c.Assert(os.WriteFile(s, []byte("hello"), 0644), IsNil)
-	c.Assert(osutil.AtomicWriteFile(p, []byte("hi"), 0600, osutil.AtomicWriteFollow), IsNil)
-
-	c.Assert(p, testutil.FileEquals, "hi")
-}
-
-func (ts *AtomicWriteTestSuite) TestAtomicWriteFileNoOverwriteTmpExisting(c *C) {
-	tmpdir := c.MkDir()
-	osutil.FakeRandomString(func(length int) string {
-		// ensure we always get the same result
-		return strings.Repeat("a", length)
-	})
 
 	p := filepath.Join(tmpdir, "foo")
-	err := os.WriteFile(p+"."+strings.Repeat("a", 12)+"~", []byte(""), 0644)
-	c.Assert(err, IsNil)
-
 	err = osutil.AtomicWriteFile(p, []byte(""), 0600, 0)
-	c.Assert(err, ErrorMatches, "open .*: file exists")
+	c.Assert(err, ErrorMatches, `open /.*/foo\..*~: permission denied`)
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileChmodError(c *C) {
+	tmpdir := c.MkDir()
+
+	// Nothing in the directory to begin
+	entries, err := os.ReadDir(tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(entries, HasLen, 0)
+
+	customError := errors.New("something happened")
+	restore := osutil.FakeFChmod(func(file *os.File, mode os.FileMode) error {
+		return customError
+	})
+	defer restore()
+
+	p := filepath.Join(tmpdir, "foo")
+	err = osutil.AtomicWriteFile(p, []byte(""), 0o644, 0)
+	c.Assert(err, Equals, customError)
+
+	// Nothing in the directory after error
+	entries, err = os.ReadDir(tmpdir)
+	c.Assert(err, IsNil)
+	c.Check(entries, HasLen, 0)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicFileChownError(c *C) {
@@ -245,25 +199,374 @@ func (ts *AtomicWriteTestSuite) TestAtomicFileCancel(c *C) {
 	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
 	c.Assert(err, IsNil)
 	fn := aw.File.Name()
-	c.Check(osutil.CanStat(fn), Equals, true)
+	c.Check(osutil.FileExists(fn), Equals, true)
 	c.Check(aw.Cancel(), IsNil)
-	c.Check(osutil.CanStat(fn), Equals, false)
+	c.Check(osutil.FileExists(fn), Equals, false)
 }
 
-// SafeIoAtomicWriteTestSuite runs all AtomicWrite with safe
+func (ts *AtomicWriteTestSuite) TestAtomicFileModTime(c *C) {
+	d := c.MkDir()
+	p := filepath.Join(d, "foo")
+
+	aw, err := osutil.NewAtomicFile(p, 0644, 0, osutil.NoChown, osutil.NoChown)
+	c.Assert(err, IsNil)
+	t := time.Date(2010, time.January, 1, 13, 0, 0, 0, time.UTC)
+	aw.SetModTime(t)
+	c.Assert(aw.Commit(), IsNil)
+
+	finfo, err := os.Stat(p)
+	c.Assert(err, IsNil)
+	c.Assert(finfo.ModTime().Equal(t), Equals, true)
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAs(c *C) {
+	d := c.MkDir()
+	initialTarget := filepath.Join(d, "foo")
+	actualTarget := filepath.Join(d, "bar")
+
+	aw, err := osutil.NewAtomicFile(initialTarget, 0644, 0, osutil.NoChown, osutil.NoChown)
+	c.Assert(err, IsNil)
+	defer aw.Cancel()
+	fn := aw.File.Name()
+	c.Check(osutil.FileExists(fn), Equals, true)
+	c.Check(strings.HasPrefix(fn, initialTarget), Equals, true, Commentf("unexpected temporary file name prefix: %q", fn))
+	_, err = aw.WriteString("this is test data")
+	c.Assert(err, IsNil)
+
+	err = aw.CommitAs(actualTarget)
+	c.Assert(err, IsNil)
+	c.Check(fn, testutil.FileAbsent)
+	c.Check(actualTarget, testutil.FileEquals, "this is test data")
+	c.Check(initialTarget, testutil.FileAbsent)
+
+	// not confused when CommitAs uses the same name as initially
+	sameNameTarget := filepath.Join(d, "baz")
+	aw, err = osutil.NewAtomicFile(sameNameTarget, 0644, 0, osutil.NoChown, osutil.NoChown)
+	c.Assert(err, IsNil)
+	defer aw.Cancel()
+	_, err = aw.WriteString("this is baz")
+	c.Assert(err, IsNil)
+	err = aw.CommitAs(sameNameTarget)
+	c.Assert(err, IsNil)
+	c.Check(sameNameTarget, testutil.FileEquals, "this is baz")
+
+	// overwrites any existing file on CommitAs (same as Commit)
+	overwrittenTarget := filepath.Join(d, "will-overwrite")
+	err = os.WriteFile(overwrittenTarget, []byte("overwritten"), 0644)
+	c.Assert(err, IsNil)
+	aw, err = osutil.NewAtomicFile(filepath.Join(d, "temp-name"), 0644, 0, osutil.NoChown, osutil.NoChown)
+	c.Assert(err, IsNil)
+	defer aw.Cancel()
+	_, err = aw.WriteString("this will overwrite existing file")
+	c.Assert(err, IsNil)
+	err = aw.CommitAs(overwrittenTarget)
+	c.Assert(err, IsNil)
+	c.Check(overwrittenTarget, testutil.FileEquals, "this will overwrite existing file")
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicFileCommitAsDifferentDirErr(c *C) {
+	d := c.MkDir()
+	initialTarget := filepath.Join(d, "foo")
+	differentDirTarget := filepath.Join(c.MkDir(), "bar")
+
+	aw, err := osutil.NewAtomicFile(initialTarget, 0644, 0, osutil.NoChown, osutil.NoChown)
+	c.Assert(err, IsNil)
+	_, err = aw.WriteString("this is test data")
+	c.Assert(err, IsNil)
+
+	err = aw.CommitAs(differentDirTarget)
+	c.Assert(err, ErrorMatches, `cannot commit as "bar" to a different directory .*`)
+}
+
+type AtomicSymlinkTestSuite struct{}
+
+var _ = Suite(&AtomicSymlinkTestSuite{})
+
+func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
+	mustReadSymlink := func(p, exp string) {
+		target, err := os.Readlink(p)
+		c.Assert(err, IsNil)
+		c.Check(exp, Equals, target)
+	}
+
+	checkLeftoverFiles := func(sym string, exp []string) {
+		res, err := filepath.Glob(sym + "*")
+		c.Assert(err, IsNil)
+		if len(exp) != 0 {
+			c.Assert(res, DeepEquals, exp)
+		} else {
+			c.Assert(res, HasLen, 0)
+		}
+	}
+
+	d := c.MkDir()
+	barSymlink := filepath.Join(d, "bar")
+	err := osutil.AtomicSymlink("target", barSymlink)
+	c.Assert(err, IsNil)
+	mustReadSymlink(barSymlink, "target")
+	checkLeftoverFiles(barSymlink, []string{barSymlink})
+
+	// no nested directory
+	nested := filepath.Join(d, "nested")
+	nestedBarSymlink := filepath.Join(nested, "bar")
+	err = osutil.AtomicSymlink("target", nestedBarSymlink)
+	c.Assert(err, ErrorMatches, `stat /.*/nested: no such file or directory`)
+	checkLeftoverFiles(nestedBarSymlink, nil)
+
+	if os.Geteuid() != 0 {
+		// create a dir without write permission
+		err = os.MkdirAll(nested, 0644)
+		c.Assert(err, IsNil)
+
+		// no permission to write in dir
+		err = osutil.AtomicSymlink("target", nestedBarSymlink)
+		c.Assert(err, ErrorMatches, `mkdir /.*/nested/bar\..*~: permission denied`)
+		checkLeftoverFiles(nestedBarSymlink, nil)
+
+		err = os.Chmod(nested, 0755)
+		c.Assert(err, IsNil)
+	}
+
+	err = osutil.AtomicSymlink("target", nestedBarSymlink)
+	c.Assert(err, IsNil)
+	mustReadSymlink(nestedBarSymlink, "target")
+	checkLeftoverFiles(nestedBarSymlink, []string{nestedBarSymlink})
+
+	// symlink gets replaced
+	err = osutil.AtomicSymlink("new-target", nestedBarSymlink)
+	c.Assert(err, IsNil)
+	mustReadSymlink(nestedBarSymlink, "new-target")
+	checkLeftoverFiles(nestedBarSymlink, []string{nestedBarSymlink})
+
+	// don't care about symlink target
+	err = osutil.AtomicSymlink("/this/is/some/funny/path", nestedBarSymlink)
+	c.Assert(err, IsNil)
+	mustReadSymlink(nestedBarSymlink, "/this/is/some/funny/path")
+	checkLeftoverFiles(nestedBarSymlink, []string{nestedBarSymlink})
+}
+
+func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkAsteriskInDirOkay(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	dir := filepath.Join(tmpdir, "foo*bar")
+	c.Assert(os.MkdirAll(dir, 0o755), IsNil)
+
+	p := filepath.Join(dir, "baz")
+	err := osutil.AtomicSymlink(target, p)
+	c.Assert(err, IsNil)
+}
+
+func (ts *AtomicSymlinkTestSuite) TestAtomicSymlinkAsteriskInBasenameError(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	p := filepath.Join(tmpdir, "foo*bar")
+	err := osutil.AtomicSymlink(target, p)
+	c.Assert(err, ErrorMatches, `cannot create tempfile for link path containing '\*': "foo\*bar"`)
+}
+
+type AtomicLinkTestSuite struct{}
+
+var _ = Suite(&AtomicLinkTestSuite{})
+
+func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
+	mustReadLink := func(target, link string) {
+		match, err := osutil.ComparePathsByDeviceInode(target, link)
+		c.Assert(err, IsNil)
+		c.Check(match, Equals, true)
+	}
+
+	checkLeftoverFiles := func(link string, exp []string) {
+		res, err := filepath.Glob(link + "*")
+		c.Assert(err, IsNil)
+		if len(exp) != 0 {
+			c.Assert(res, DeepEquals, exp)
+		} else {
+			c.Assert(res, HasLen, 0)
+		}
+	}
+
+	d := c.MkDir()
+	target := filepath.Join(d, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	barLink := filepath.Join(d, "bar")
+	err := osutil.AtomicLink(target, barLink)
+	c.Assert(err, IsNil)
+	mustReadLink(barLink, target)
+	checkLeftoverFiles(barLink, []string{barLink})
+
+	// no nested directory
+	nested := filepath.Join(d, "nested")
+	nestedBarLink := filepath.Join(nested, "bar")
+	err = osutil.AtomicLink(target, nestedBarLink)
+	c.Assert(err, ErrorMatches, `stat /.*/nested: no such file or directory`)
+	checkLeftoverFiles(nestedBarLink, nil)
+
+	if os.Geteuid() != 0 {
+		// create a dir without write permission
+		err = os.MkdirAll(nested, 0o644)
+		c.Assert(err, IsNil)
+
+		// no permission to write in dir
+		err = osutil.AtomicLink(target, nestedBarLink)
+		c.Assert(err, ErrorMatches, `mkdir /.*/nested/bar\..*~: permission denied`)
+		checkLeftoverFiles(nestedBarLink, nil)
+
+		err = os.Chmod(nested, 0o755)
+		c.Assert(err, IsNil)
+	}
+
+	err = osutil.AtomicLink(target, nestedBarLink)
+	c.Assert(err, IsNil)
+	mustReadLink(nestedBarLink, target)
+	checkLeftoverFiles(nestedBarLink, []string{nestedBarLink})
+
+	// link gets replaced
+	newTarget := filepath.Join(d, "new-target")
+	c.Assert(os.WriteFile(newTarget, []byte(""), 0o644), IsNil)
+	err = osutil.AtomicLink(newTarget, nestedBarLink)
+	c.Assert(err, IsNil)
+	mustReadLink(nestedBarLink, newTarget)
+	checkLeftoverFiles(nestedBarLink, []string{nestedBarLink})
+}
+
+func (ts *AtomicLinkTestSuite) TestAtomicLinkAsteriskInDirOkay(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	dir := filepath.Join(tmpdir, "foo*bar")
+	c.Assert(os.MkdirAll(dir, 0o755), IsNil)
+
+	p := filepath.Join(dir, "baz")
+	err := osutil.AtomicLink(target, p)
+	c.Assert(err, IsNil)
+}
+
+func (ts *AtomicLinkTestSuite) TestAtomicLinkAsteriskInBasenameError(c *C) {
+	tmpdir := c.MkDir()
+
+	target := filepath.Join(tmpdir, "target")
+	c.Assert(os.WriteFile(target, []byte("some data"), 0o644), IsNil)
+
+	p := filepath.Join(tmpdir, "foo*bar")
+	err := osutil.AtomicLink(target, p)
+	c.Assert(err, ErrorMatches, `cannot create tempfile for link path containing '\*': "foo\*bar"`)
+}
+
+type AtomicRenameTestSuite struct{}
+
+var _ = Suite(&AtomicRenameTestSuite{})
+
+func (ts *AtomicRenameTestSuite) TestAtomicRenameFile(c *C) {
+	d := c.MkDir()
+
+	err := os.WriteFile(filepath.Join(d, "foo"), []byte("foobar"), 0644)
+	c.Assert(err, IsNil)
+
+	err = osutil.AtomicRename(filepath.Join(d, "foo"), filepath.Join(d, "bar"))
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(d, "bar"), testutil.FileEquals, "foobar")
+
+	// no nested directory
+	nested := filepath.Join(d, "nested")
+	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+	if !osutil.GetUnsafeIO() {
+		// with safe IO first op is to open the source and target directories
+		c.Assert(err, ErrorMatches, "open /.*/nested: no such file or directory")
+	} else {
+		c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: no such file or directory")
+	}
+
+	if os.Geteuid() != 0 {
+		// create a dir without write permission
+		err = os.MkdirAll(nested, 0644)
+		c.Assert(err, IsNil)
+
+		// no permission to write in dir
+		err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+		c.Assert(err, ErrorMatches, "rename /.*/bar /.*/nested/bar: permission denied")
+
+		err = os.Chmod(nested, 0755)
+		c.Assert(err, IsNil)
+	}
+
+	// all good now
+	err = osutil.AtomicRename(filepath.Join(d, "bar"), filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+
+	err = os.WriteFile(filepath.Join(nested, "new-bar"), []byte("barbar"), 0644)
+	c.Assert(err, IsNil)
+
+	// target is overwritten
+	err = osutil.AtomicRename(filepath.Join(nested, "new-bar"), filepath.Join(nested, "bar"))
+	c.Assert(err, IsNil)
+	c.Check(filepath.Join(nested, "bar"), testutil.FileEquals, "barbar")
+
+	// no source
+	err = osutil.AtomicRename(filepath.Join(d, "does-not-exist"), filepath.Join(nested, "bar"))
+	c.Assert(err, ErrorMatches, "rename /.*/does-not-exist /.*/nested/bar: no such file or directory")
+}
+
+// SafeIoAtomicTestSuite runs all Atomic* tests with safe
 // io enabled
-type SafeIoAtomicWriteTestSuite struct {
+type SafeIoAtomicTestSuite struct {
 	AtomicWriteTestSuite
+	AtomicSymlinkTestSuite
+	AtomicRenameTestSuite
 
 	restoreUnsafeIO func()
 }
 
-var _ = Suite(&SafeIoAtomicWriteTestSuite{})
+var _ = Suite(&SafeIoAtomicTestSuite{})
 
-func (s *SafeIoAtomicWriteTestSuite) SetUpSuite(c *C) {
+func (s *SafeIoAtomicTestSuite) SetUpSuite(c *C) {
 	s.restoreUnsafeIO = osutil.SetUnsafeIO(false)
 }
 
-func (s *SafeIoAtomicWriteTestSuite) TearDownSuite(c *C) {
+func (s *SafeIoAtomicTestSuite) TearDownSuite(c *C) {
 	s.restoreUnsafeIO()
+}
+
+func (ts *AtomicWriteTestSuite) TestAtomicRenameDir(c *C) {
+	// create a source directory
+	srcParentDir := c.MkDir()
+	src := filepath.Join(srcParentDir, "foo")
+
+	err := os.MkdirAll(src, 0755)
+	c.Assert(err, IsNil)
+
+	// put a file in the source directory
+	srcFile := filepath.Join(src, "file")
+	contents := []byte("contents")
+	err = osutil.AtomicWriteFile(srcFile, contents, 0644, 0)
+	c.Assert(err, IsNil)
+
+	// the parent dir of the destination
+	dstParentDir := c.MkDir()
+	dst := filepath.Join(dstParentDir, "bar")
+
+	// ensure it works even with trailing '/'
+	err = osutil.AtomicRename(src+"/", dst+"/")
+	c.Assert(err, IsNil)
+
+	d, err := os.ReadDir(dst)
+	c.Assert(err, IsNil)
+	c.Assert(len(d), Equals, 1)
+	c.Assert(d[0].Name(), Equals, "file")
+
+	data, err := os.ReadFile(filepath.Join(dst, "file"))
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, contents)
+
+	exists, _, err := osutil.DirExists(src)
+	c.Assert(err, IsNil)
+	c.Assert(exists, Equals, false)
 }

--- a/internals/osutil/io_test.go
+++ b/internals/osutil/io_test.go
@@ -69,6 +69,9 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root: directory permissions are bypassed")
+	}
 	tmpdir := c.MkDir()
 	rodir := filepath.Join(tmpdir, "ro")
 	p := filepath.Join(rodir, "foo")
@@ -102,6 +105,9 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInBasenameError(c *C)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root: directory permissions are bypassed")
+	}
 	tmpdir := c.MkDir()
 
 	err := os.Chmod(tmpdir, 0o644) // no directory traversal allowed
@@ -325,6 +331,10 @@ func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 
 		err = os.Chmod(nested, 0755)
 		c.Assert(err, IsNil)
+	} else {
+		// running as root, dir permission checks are bypassed, so just
+		// create the directory needed by the rest of the test
+		c.Assert(os.MkdirAll(nested, 0755), IsNil)
 	}
 
 	err = osutil.AtomicSymlink("target", nestedBarSymlink)
@@ -420,6 +430,10 @@ func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
 
 		err = os.Chmod(nested, 0o755)
 		c.Assert(err, IsNil)
+	} else {
+		// running as root, dir permission checks are bypassed, so just
+		// create the directory needed by the rest of the test
+		c.Assert(os.MkdirAll(nested, 0o755), IsNil)
 	}
 
 	err = osutil.AtomicLink(target, nestedBarLink)
@@ -496,6 +510,10 @@ func (ts *AtomicRenameTestSuite) TestAtomicRenameFile(c *C) {
 
 		err = os.Chmod(nested, 0755)
 		c.Assert(err, IsNil)
+	} else {
+		// running as root, dir permission checks are bypassed, so just
+		// create the directory needed by the rest of the test
+		c.Assert(os.MkdirAll(nested, 0755), IsNil)
 	}
 
 	// all good now

--- a/internals/osutil/mkdir_test.go
+++ b/internals/osutil/mkdir_test.go
@@ -37,7 +37,7 @@ func (mkdirSuite) TestSimpleDir(c *check.C) {
 
 	err := osutil.Mkdir(tmpDir+"/foo", 0o755, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
 }
 
 func (mkdirSuite) TestExistOK(c *check.C) {
@@ -45,7 +45,7 @@ func (mkdirSuite) TestExistOK(c *check.C) {
 
 	err := osutil.Mkdir(tmpDir+"/foo", 0o755, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
 
 	err = osutil.Mkdir(tmpDir+"/foo", 0o755, &osutil.MkdirOptions{
 		ExistOK: true,
@@ -58,7 +58,7 @@ func (mkdirSuite) TestExistNotOK(c *check.C) {
 
 	err := osutil.Mkdir(tmpDir+"/foo", 0o755, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
 
 	err = osutil.Mkdir(tmpDir+"/foo", 0o755, nil)
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
@@ -88,8 +88,8 @@ func (mkdirSuite) TestMakeParents(c *check.C) {
 		MakeParents: true,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo/bar"), check.Equals, true)
 }
 
 func (mkdirSuite) TestMakeParentsAndExistOK(c *check.C) {
@@ -99,8 +99,8 @@ func (mkdirSuite) TestMakeParentsAndExistOK(c *check.C) {
 		MakeParents: true,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo/bar"), check.Equals, true)
 
 	err = osutil.Mkdir(tmpDir+"/foo/bar/", 0o755, &osutil.MkdirOptions{
 		ExistOK: true,
@@ -115,8 +115,8 @@ func (mkdirSuite) TestMakeParentsAndExistNotOK(c *check.C) {
 		MakeParents: true,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo/bar"), check.Equals, true)
 
 	err = osutil.Mkdir(tmpDir+"/foo/bar", 0o755, nil)
 	c.Assert(err, check.ErrorMatches, `.*: file exists`)
@@ -144,7 +144,7 @@ func (mkdirSuite) TestChmod(c *check.C) {
 		Chmod: true,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
 
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, check.IsNil)
@@ -159,7 +159,7 @@ func (mkdirSuite) TestNoChmod(c *check.C) {
 
 	err := osutil.Mkdir(tmpDir+"/foo", 0o777, nil)
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
 
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, check.IsNil)
@@ -174,8 +174,8 @@ func (mkdirSuite) TestMakeParentsAndChmod(c *check.C) {
 		Chmod:       true,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo/bar"), check.Equals, true)
 
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, check.IsNil)
@@ -196,8 +196,8 @@ func (mkdirSuite) TestMakeParentsAndNoChmod(c *check.C) {
 		MakeParents: true,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo/bar"), check.Equals, true)
 
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, check.IsNil)
@@ -237,8 +237,8 @@ func (mkdirSuite) TestMakeParentsChmodAndChown(c *check.C) {
 		GroupID:     sys.GroupID(gid),
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(osutil.IsDir(tmpDir+"/foo"), check.Equals, true)
-	c.Assert(osutil.IsDir(tmpDir+"/foo/bar"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo"), check.Equals, true)
+	c.Assert(osutil.IsDirectory(tmpDir+"/foo/bar"), check.Equals, true)
 
 	info, err := os.Stat(tmpDir + "/foo")
 	c.Assert(err, check.IsNil)

--- a/internals/osutil/squashfs/fstype.go
+++ b/internals/osutil/squashfs/fstype.go
@@ -21,15 +21,12 @@ import (
 	"github.com/canonical/pebble/internals/osutil"
 )
 
-// useFuse detects if we should be using squashfuse instead
-var useFuse = useFuseImpl
-
-func useFuseImpl() bool {
-	if !osutil.CanStat("/dev/fuse") {
+var needsFuseImpl = func() bool {
+	if !osutil.FileExists("/dev/fuse") {
 		return false
 	}
 
-	if !osutil.IsExecInPath("squashfuse") && !osutil.IsExecInPath("snapfuse") {
+	if !osutil.ExecutableExists("squashfuse") && !osutil.ExecutableExists("snapfuse") {
 		return false
 	}
 
@@ -39,39 +36,49 @@ func useFuseImpl() bool {
 	}
 
 	virt := strings.TrimSpace(string(out))
-	if virt != "none" { // lint:ignore S1008 Should use 'return cond'
+	if virt != "none" {
 		return true
 	}
 
 	return false
 }
 
-// FakeUseFuse is exported so useFuse can be overridden by testing.
-func FakeUseFuse(r bool) func() {
-	oldUseFuse := useFuse
-	useFuse = func() bool {
+// FakeNeedsFuse is exported so NeedsFuse can be overridden by testing.
+func FakeNeedsFuse(r bool) func() {
+	oldNeedsFuseImpl := needsFuseImpl
+	needsFuseImpl = func() bool {
 		return r
 	}
-	return func() { useFuse = oldUseFuse }
+	return func() { needsFuseImpl = oldNeedsFuseImpl }
 }
 
-// FSType returns what fstype to use for squashfs mounts and what
-// mount options
-func FSType() (fstype string, options []string, err error) {
-	fstype = "squashfs"
-	options = []string{"ro", "x-gdu.hide"}
+// NeedsFuse returns true if the given system needs fuse to mount snaps
+func NeedsFuse() bool {
+	return needsFuseImpl()
+}
 
-	if useFuse() {
+// StandardOptions returns base squashfs options.
+func StandardOptions() []string {
+	return []string{"ro", "x-gdu.hide", "x-gvfs-hide"}
+}
+
+// FsType returns what fstype to use for squashfs mounts and what
+// mount options
+func FsType() (fstype string, options []string) {
+	fstype = "squashfs"
+	options = StandardOptions()
+
+	if NeedsFuse() {
 		options = append(options, "allow_other")
 		switch {
-		case osutil.IsExecInPath("squashfuse"):
+		case osutil.ExecutableExists("squashfuse"):
 			fstype = "fuse.squashfuse"
-		case osutil.IsExecInPath("snapfuse"):
+		case osutil.ExecutableExists("snapfuse"):
 			fstype = "fuse.snapfuse"
 		default:
-			panic("cannot happen because useFuse() ensures one of the two executables is there")
+			panic("cannot happen because NeedsFuse() ensures one of the two executables is there")
 		}
 	}
 
-	return fstype, options, nil
+	return fstype, options
 }

--- a/internals/osutil/squashfs/fstype.go
+++ b/internals/osutil/squashfs/fstype.go
@@ -36,11 +36,7 @@ var needsFuseImpl = func() bool {
 	}
 
 	virt := strings.TrimSpace(string(out))
-	if virt != "none" {
-		return true
-	}
-
-	return false
+	return virt != "none"
 }
 
 // FakeNeedsFuse is exported so NeedsFuse can be overridden by testing.

--- a/internals/osutil/stat.go
+++ b/internals/osutil/stat.go
@@ -1,53 +1,50 @@
-// -*- Mode: Go; indent-tabs-mode: t -*-
-
-/*
- * Copyright (c) 2014-2015 Canonical Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 3 as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+// Copyright (c) 2014-2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as
+// published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package osutil
 
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 )
 
-// CanStat returns true if stat succeeds on the given path.
-// It may return false on permission issues.
-func CanStat(path string) bool {
+// FileExists return true if given path can be stat()ed by us. Note that
+// it may return false on e.g. permission issues.
+func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
 
-// IsDir returns true if the given path is a directory.
-// It may return false on permission issues.
-func IsDir(path string) bool {
+// IsDirectory return true if the given path can be stat()ed by us and
+// is a directory. Note that it may return false on e.g. permission issues.
+func IsDirectory(path string) bool {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return false
 	}
+
 	return fileInfo.IsDir()
 }
 
-// IsDevice returns true if mode coresponds to a device (char/block).
+// IsDevice checks if the given os.FileMode coresponds to a device (char/block)
 func IsDevice(mode os.FileMode) bool {
 	return (mode & (os.ModeDevice | os.ModeCharDevice)) != 0
 }
 
-// IsSymlink returns true if path is a symlink.
+// IsSymlink returns true if the given file is a symlink
 func IsSymlink(path string) bool {
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
@@ -57,8 +54,8 @@ func IsSymlink(path string) bool {
 	return (fileInfo.Mode() & os.ModeSymlink) != 0
 }
 
-// IsExec returns true if path points to an executable file.
-func IsExec(path string) bool {
+// IsExecutable returns true when given path points to an executable file
+func IsExecutable(path string) bool {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return false
@@ -66,9 +63,10 @@ func IsExec(path string) bool {
 	return !stat.IsDir() && (stat.Mode().Perm()&0111 != 0)
 }
 
-// IsExecInPath returns true if name is an executable in $PATH.
-func IsExecInPath(name string) bool {
+// ExecutableExists returns whether there an exists an executable with the given name somewhere on $PATH.
+func ExecutableExists(name string) bool {
 	_, err := exec.LookPath(name)
+
 	return err == nil
 }
 
@@ -83,6 +81,19 @@ func LookPathDefault(name string, defaultPath string) string {
 		return defaultPath
 	}
 	return p
+}
+
+// LookInPaths is a simplified version of exec.LookPath which looks for am
+// executable in caller provided list of colon separated paths. Returns empty
+// string if executable was not found.
+func LookInPaths(name string, searchPath string) string {
+	for _, dir := range filepath.SplitList(searchPath) {
+		p := filepath.Join(dir, name)
+		if IsExecutable(p) {
+			return p
+		}
+	}
+	return ""
 }
 
 // IsWritable checks if the given file/directory can be written by
@@ -111,8 +122,8 @@ func IsDirNotExist(err error) bool {
 	return err == syscall.ENOTDIR || err == syscall.ENOENT || err == os.ErrNotExist
 }
 
-// ExistIsDir checks whether a given path exists, and if so whether it is a directory.
-func ExistsIsDir(fn string) (exists bool, isDir bool, err error) {
+// DirExists checks whether a given path exists, and if so whether it is a directory.
+func DirExists(fn string) (exists bool, isDir bool, err error) {
 	st, err := os.Stat(fn)
 	if err != nil {
 		if IsDirNotExist(err) {
@@ -121,4 +132,28 @@ func ExistsIsDir(fn string) (exists bool, isDir bool, err error) {
 		return false, false, err
 	}
 	return true, st.IsDir(), nil
+}
+
+// RegularFileExists checks whether a given path exists, and if so whether it is a regular file.
+func RegularFileExists(fn string) (exists, isReg bool, err error) {
+	fileStat, err := os.Lstat(fn)
+	if err != nil {
+		return false, false, err
+	}
+	return true, fileStat.Mode().IsRegular(), nil
+}
+
+// ComparePathsByDeviceInode compares the devices and inodes of the given paths, following symlinks.
+func ComparePathsByDeviceInode(a, b string) (match bool, err error) {
+	fi1, err := os.Stat(a)
+	if err != nil {
+		return false, err
+	}
+
+	fi2, err := os.Stat(b)
+	if err != nil {
+		return false, err
+	}
+
+	return os.SameFile(fi1, fi2), nil
 }

--- a/internals/osutil/stat_test.go
+++ b/internals/osutil/stat_test.go
@@ -142,6 +142,9 @@ func makeTestPathInDir(c *C, dir, path string, mode os.FileMode) string {
 }
 
 func (ts *StatTestSuite) TestIsWritableDir(c *C) {
+	if os.Getuid() == 0 {
+		c.Skip("cannot run test as root: file permissions are bypassed")
+	}
 	for _, t := range []struct {
 		path       string
 		mode       os.FileMode
@@ -214,6 +217,11 @@ func (ts *StatTestSuite) TestDirExists(c *C) {
 	}
 
 	p := makeTestPath(c, "foo/bar", 0)
+	if os.Getuid() == 0 {
+		// running as root, directory permission checks are bypassed,
+		// so DirExists won't report a permission error.
+		return
+	}
 	c.Assert(os.Chmod(filepath.Dir(p), 0), IsNil)
 	defer os.Chmod(filepath.Dir(p), 0755)
 	exists, isDir, err := osutil.DirExists(p)

--- a/internals/osutil/stat_test.go
+++ b/internals/osutil/stat_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 Canonical Ltd
+// Copyright (c) 2014-2026 Canonical Ltd
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package osutil
+package osutil_test
 
 import (
 	"fmt"
@@ -22,36 +22,44 @@ import (
 	"syscall"
 
 	. "gopkg.in/check.v1"
+
+	"github.com/canonical/pebble/internals/osutil"
 )
 
 type StatTestSuite struct{}
 
 var _ = Suite(&StatTestSuite{})
 
-func (ts *StatTestSuite) TestCanStat(c *C) {
+func (ts *StatTestSuite) TestFileDoesNotExist(c *C) {
+	c.Assert(osutil.FileExists("/i-do-not-exist"), Equals, false)
+}
+
+func (ts *StatTestSuite) TestFileExistsSimple(c *C) {
 	fname := filepath.Join(c.MkDir(), "foo")
 	err := os.WriteFile(fname, []byte(fname), 0644)
 	c.Assert(err, IsNil)
 
-	c.Assert(CanStat(fname), Equals, true)
-	c.Assert(CanStat("/i-do-not-exist"), Equals, false)
+	c.Assert(osutil.FileExists(fname), Equals, true)
 }
 
-func (ts *StatTestSuite) TestCanStatOddPerms(c *C) {
+func (ts *StatTestSuite) TestFileExistsExistsOddPermissions(c *C) {
 	fname := filepath.Join(c.MkDir(), "foo")
 	err := os.WriteFile(fname, []byte(fname), 0100)
 	c.Assert(err, IsNil)
 
-	c.Assert(CanStat(fname), Equals, true)
+	c.Assert(osutil.FileExists(fname), Equals, true)
 }
 
-func (ts *StatTestSuite) TestIsDir(c *C) {
+func (ts *StatTestSuite) TestIsDirectoryDoesNotExist(c *C) {
+	c.Assert(osutil.IsDirectory("/i-do-not-exist"), Equals, false)
+}
+
+func (ts *StatTestSuite) TestIsDirectorySimple(c *C) {
 	dname := filepath.Join(c.MkDir(), "bar")
 	err := os.Mkdir(dname, 0700)
 	c.Assert(err, IsNil)
 
-	c.Assert(IsDir(dname), Equals, true)
-	c.Assert(IsDir("/i-do-not-exist"), Equals, false)
+	c.Assert(osutil.IsDirectory(dname), Equals, true)
 }
 
 func (ts *StatTestSuite) TestIsSymlink(c *C) {
@@ -59,40 +67,65 @@ func (ts *StatTestSuite) TestIsSymlink(c *C) {
 	err := os.Symlink("/", sname)
 	c.Assert(err, IsNil)
 
-	c.Assert(IsSymlink(sname), Equals, true)
-	c.Assert(IsSymlink(c.MkDir()), Equals, false)
+	c.Assert(osutil.IsSymlink(sname), Equals, true)
 }
 
-func (ts *StatTestSuite) TestIsExecInPath(c *C) {
+func (ts *StatTestSuite) TestIsSymlinkNoSymlink(c *C) {
+	c.Assert(osutil.IsSymlink(c.MkDir()), Equals, false)
+}
+
+func (ts *StatTestSuite) TestExecutableExists(c *C) {
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
 	d := c.MkDir()
 	os.Setenv("PATH", d)
-	c.Check(IsExecInPath("xyzzy"), Equals, false)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	fname := filepath.Join(d, "xyzzy")
 	c.Assert(os.WriteFile(fname, []byte{}, 0644), IsNil)
-	c.Check(IsExecInPath("xyzzy"), Equals, false)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, false)
 
 	c.Assert(os.Chmod(fname, 0755), IsNil)
-	c.Check(IsExecInPath("xyzzy"), Equals, true)
+	c.Check(osutil.ExecutableExists("xyzzy"), Equals, true)
 }
 
-func (s *StatTestSuite) TestLookPathDefaultGivesCorrectPath(c *C) {
-	lookPath = func(name string) (string, error) { return "/bin/true", nil }
-	c.Assert(LookPathDefault("true", "/bin/foo"), Equals, "/bin/true")
+func (ts *StatTestSuite) TestLookPathDefaultGivesCorrectPath(c *C) {
+	r := osutil.FakeLookPath(func(name string) (string, error) { return "/bin/true", nil })
+	defer r()
+	c.Assert(osutil.LookPathDefault("true", "/bin/foo"), Equals, "/bin/true")
 }
 
-func (s *StatTestSuite) TestLookPathDefaultReturnsDefaultWhenNotFound(c *C) {
-	lookPath = func(name string) (string, error) { return "", fmt.Errorf("Not found") }
-	c.Assert(LookPathDefault("bar", "/bin/bla"), Equals, "/bin/bla")
+func (ts *StatTestSuite) TestLookPathDefaultReturnsDefaultWhenNotFound(c *C) {
+	r := osutil.FakeLookPath(func(name string) (string, error) { return "", fmt.Errorf("Not found") })
+	defer r()
+	c.Assert(osutil.LookPathDefault("bar", "/bin/bla"), Equals, "/bin/bla")
+}
+
+func (ts *StatTestSuite) TestLookInPaths(c *C) {
+	d1 := c.MkDir()
+	d2 := c.MkDir()
+	d3 := c.MkDir()
+
+	makeTestPathInDir(c, d1, "ls", 0o755)
+	makeTestPathInDir(c, d2, "ls", 0o755)
+	makeTestPathInDir(c, d3, "ls", 0o644)
+
+	c.Check(osutil.LookInPaths("ls", ""), Equals, "")
+	realLs := osutil.LookInPaths("ls", os.Getenv("PATH"))
+	c.Check(realLs, Not(Equals), "")
+	c.Check(osutil.LookInPaths("ls", d1+":"+d2+":"+d3), Equals, filepath.Join(d1, "ls"))
+	c.Check(osutil.LookInPaths("ls", d2+":"+d1+":"+d3), Equals, filepath.Join(d2, "ls"))
+	// ls in d3 is not executable
+	c.Check(osutil.LookInPaths("ls", d3+":"+d2+":"+d1), Equals, filepath.Join(d2, "ls"))
+	c.Check(osutil.LookInPaths("ls", d1+":"+d2+":"+os.Getenv("PATH")), Equals, filepath.Join(d1, "ls"))
+	c.Check(osutil.LookInPaths("ls", os.Getenv("PATH")+":"+d1+":"+d2), Equals, realLs)
 }
 
 func makeTestPath(c *C, path string, mode os.FileMode) string {
 	return makeTestPathInDir(c, c.MkDir(), path, mode)
 }
 
-func makeTestPathInDir(c *C, dir string, path string, mode os.FileMode) string {
+func makeTestPathInDir(c *C, dir, path string, mode os.FileMode) string {
 	mkdir := strings.HasSuffix(path, "/")
 	path = filepath.Join(dir, path)
 
@@ -108,11 +141,7 @@ func makeTestPathInDir(c *C, dir string, path string, mode os.FileMode) string {
 	return path
 }
 
-func (s *StatTestSuite) TestIsWritableDir(c *C) {
-	if os.Getuid() == 0 {
-		c.Skip("requires running as non-root user")
-	}
-
+func (ts *StatTestSuite) TestIsWritableDir(c *C) {
 	for _, t := range []struct {
 		path       string
 		mode       os.FileMode
@@ -132,12 +161,12 @@ func (s *StatTestSuite) TestIsWritableDir(c *C) {
 		{"file", 0600, true},
 		{"file", 0400, false},
 	} {
-		writable := IsWritable(makeTestPath(c, t.path, t.mode))
+		writable := osutil.IsWritable(makeTestPath(c, t.path, t.mode))
 		c.Check(writable, Equals, t.isWritable, Commentf("incorrect result for %q (%s), got %v, expected %v", t.path, t.mode, writable, t.isWritable))
 	}
 }
 
-func (s *StatTestSuite) TestIsDirNotExist(c *C) {
+func (ts *StatTestSuite) TestIsDirNotExist(c *C) {
 	for _, e := range []error{
 		os.ErrNotExist,
 		syscall.ENOENT,
@@ -149,18 +178,18 @@ func (s *StatTestSuite) TestIsDirNotExist(c *C) {
 		&os.SyscallError{Err: syscall.ENOENT},
 		&os.SyscallError{Err: syscall.ENOTDIR},
 	} {
-		c.Check(IsDirNotExist(e), Equals, true, Commentf("%#v (%v)", e, e))
+		c.Check(osutil.IsDirNotExist(e), Equals, true, Commentf("%#v (%v)", e, e))
 	}
 
 	for _, e := range []error{
 		nil,
 		fmt.Errorf("hello"),
 	} {
-		c.Check(IsDirNotExist(e), Equals, false)
+		c.Check(osutil.IsDirNotExist(e), Equals, false)
 	}
 }
 
-func (s *StatTestSuite) TestExistsIsDir(c *C) {
+func (ts *StatTestSuite) TestDirExists(c *C) {
 	for _, t := range []struct {
 		make   string
 		path   string
@@ -178,29 +207,26 @@ func (s *StatTestSuite) TestExistsIsDir(c *C) {
 		if t.make != "" {
 			makeTestPathInDir(c, base, t.make, 0755)
 		}
-		exists, isDir, err := ExistsIsDir(filepath.Join(base, t.path))
+		exists, isDir, err := osutil.DirExists(filepath.Join(base, t.path))
 		c.Check(exists, Equals, t.exists, comm)
 		c.Check(isDir, Equals, t.isDir, comm)
 		c.Check(err, IsNil, comm)
 	}
 
-	if os.Getuid() == 0 {
-		c.Skip("requires running as non-root user")
-	}
 	p := makeTestPath(c, "foo/bar", 0)
 	c.Assert(os.Chmod(filepath.Dir(p), 0), IsNil)
 	defer os.Chmod(filepath.Dir(p), 0755)
-	exists, isDir, err := ExistsIsDir(p)
+	exists, isDir, err := osutil.DirExists(p)
 	c.Check(exists, Equals, false)
 	c.Check(isDir, Equals, false)
 	c.Check(err, NotNil)
 }
 
-func (s *StatTestSuite) TestIsExec(c *C) {
-	c.Check(IsExec("non-existent"), Equals, false)
-	c.Check(IsExec("."), Equals, false)
+func (ts *StatTestSuite) TestIsExecutable(c *C) {
+	c.Check(osutil.IsExecutable("non-existent"), Equals, false)
+	c.Check(osutil.IsExecutable("."), Equals, false)
 	dir := c.MkDir()
-	c.Check(IsExec(dir), Equals, false)
+	c.Check(osutil.IsExecutable(dir), Equals, false)
 
 	for _, tc := range []struct {
 		mode os.FileMode
@@ -222,6 +248,132 @@ func (s *StatTestSuite) TestIsExec(c *C) {
 
 		err = os.WriteFile(p, []byte(""), tc.mode)
 		c.Assert(err, IsNil)
-		c.Check(IsExec(p), Equals, tc.is)
+		c.Check(osutil.IsExecutable(p), Equals, tc.is)
 	}
+}
+
+func (ts *StatTestSuite) TestRegularFileExists(c *C) {
+	tt := []struct {
+		make           bool
+		makeNonRegular bool
+		path           string
+		expExists      bool
+		expIsReg       bool
+		expErr         string
+		comment        string
+	}{
+		{
+			make:      true,
+			path:      "foo",
+			expExists: true,
+			expIsReg:  true,
+			comment:   "file is regular",
+		},
+		{
+			make:           true,
+			makeNonRegular: true,
+			path:           "bar",
+			expExists:      true,
+			comment:        "file is symlink",
+		},
+		{
+			path:      "not-exists",
+			expExists: false,
+			expErr:    ".*no such file or directory",
+			comment:   "file doesn't exist",
+		},
+	}
+
+	for _, t := range tt {
+		fullpath := filepath.Join(c.MkDir(), t.path)
+		comment := Commentf(t.comment)
+
+		if t.make {
+			if t.makeNonRegular {
+				// make it a symlink
+				err := os.Symlink("foo", fullpath)
+				c.Assert(err, IsNil, comment)
+			} else {
+				// make it a normal file
+				err := os.WriteFile(fullpath, nil, 0644)
+				c.Assert(err, IsNil, comment)
+			}
+		}
+
+		exists, isReg, err := osutil.RegularFileExists(fullpath)
+		if t.expErr != "" {
+			c.Assert(err, ErrorMatches, t.expErr, comment)
+			continue
+		}
+		c.Assert(exists, Equals, t.expExists, comment)
+		c.Assert(isReg, Equals, t.expIsReg, comment)
+	}
+}
+
+func (ts *StatTestSuite) TestComparePathsByDeviceInodeHappy(c *C) {
+	base := c.MkDir()
+
+	// Same file
+	path_a := filepath.Join(base, "file-a")
+	c.Assert(os.WriteFile(path_a, nil, 0644), IsNil)
+	match, err := osutil.ComparePathsByDeviceInode(path_a, path_a)
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, true)
+
+	// Different files
+	path_b := filepath.Join(base, "file-b")
+	c.Assert(os.WriteFile(path_b, nil, 0644), IsNil)
+	match, err = osutil.ComparePathsByDeviceInode(path_a, path_b)
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, false)
+
+	// Same directory
+	match, err = osutil.ComparePathsByDeviceInode(base, base)
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, true)
+
+	// Different directories
+	path_a = filepath.Join(base, "dir-a")
+	c.Assert(os.Mkdir(path_a, 0644), IsNil)
+	match, err = osutil.ComparePathsByDeviceInode(base, path_a)
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, false)
+
+	// Symlink to directory and directory
+	path_b = filepath.Join(base, "symlink-to-dir-a")
+	c.Assert(os.Symlink(path_a, path_b), IsNil)
+	match, err = osutil.ComparePathsByDeviceInode(path_b, path_b)
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, true)
+
+	// Different symlinks to same directory
+	path_c := filepath.Join(base, "another-symlink-to-dir-a")
+	c.Assert(os.Symlink(path_a, path_c), IsNil)
+	match, err = osutil.ComparePathsByDeviceInode(path_b, path_c)
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, true)
+
+	// Path including symlink to directory and directory
+	path_a = filepath.Join(base, "dir-b/dir-c/dir-e/dir-f")
+	c.Assert(os.MkdirAll(path_a, 0755), IsNil)
+	path_b = filepath.Join(base, "dir-b/dir-c")
+	path_c = filepath.Join(base, "symlink-to-dir-c")
+	c.Assert(os.Symlink(path_b, path_c), IsNil)
+	match, err = osutil.ComparePathsByDeviceInode(path_a, filepath.Join(path_c, "dir-e/dir-f"))
+	c.Assert(err, IsNil)
+	c.Assert(match, Equals, true)
+}
+
+func (ts *StatTestSuite) TestComparePathsByDeviceInodeErrorPathNotExist(c *C) {
+	base := c.MkDir()
+
+	// Path a does not exist
+	match, err := osutil.ComparePathsByDeviceInode(filepath.Join(base, "missing-dir"), base)
+	c.Assert(err, ErrorMatches, "*: no such file or directory")
+	c.Assert(match, Equals, false)
+
+	// Path b does not exist
+	match, err = osutil.ComparePathsByDeviceInode(base, filepath.Join(base, "missing-dir"))
+	c.Assert(err, ErrorMatches, "*: no such file or directory")
+	c.Assert(match, Equals, false)
 }

--- a/internals/overlord/overlord.go
+++ b/internals/overlord/overlord.go
@@ -147,7 +147,7 @@ func New(opts *Options) (*Overlord, error) {
 	if !filepath.IsAbs(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q must be absolute", o.pebbleDir)
 	}
-	if !osutil.IsDir(o.pebbleDir) {
+	if !osutil.IsDirectory(o.pebbleDir) {
 		return nil, fmt.Errorf("directory %q does not exist", o.pebbleDir)
 	}
 	if !osutil.IsWritable(o.pebbleDir) {
@@ -314,10 +314,10 @@ func getCurrentBootID() (string, error) {
 func loadState(curBootID, statePath string, restartHandler restart.Handler, backend state.Backend) (*state.State, *restart.RestartManager, error) {
 	timings := timing.Start("", "", map[string]string{"startup": "load-state"})
 
-	if !osutil.CanStat(statePath) {
+	if !osutil.FileExists(statePath) {
 		// fail fast, mostly interesting for tests, this dir is set up by pebble
 		stateDir := filepath.Dir(statePath)
-		if !osutil.IsDir(stateDir) {
+		if !osutil.IsDirectory(stateDir) {
 			return nil, nil, fmt.Errorf("fatal: directory %q must be present", stateDir)
 		}
 		s := state.New(backend)
@@ -718,8 +718,7 @@ func (m *Overlord) StartOfOperationTime() (time.Time, error) {
 	err := m.State().Get("start-of-operation-time", &opTime)
 	if err == nil {
 		return opTime, nil
-	}
-	if err != nil && !errors.Is(err, state.ErrNoState) {
+	} else if !errors.Is(err, state.ErrNoState) {
 		return opTime, err
 	}
 	opTime = timeNow()

--- a/internals/systemd/sdnotify.go
+++ b/internals/systemd/sdnotify.go
@@ -27,7 +27,7 @@ var osGetenv = os.Getenv
 
 func SocketAvailable() bool {
 	notifySocket := osGetenv("NOTIFY_SOCKET")
-	return notifySocket != "" && osutil.CanStat(notifySocket)
+	return notifySocket != "" && osutil.FileExists(notifySocket)
 }
 
 // SdNotify sends the given state string notification to systemd.

--- a/internals/systemd/systemd.go
+++ b/internals/systemd/systemd.go
@@ -653,14 +653,11 @@ func (s *systemd) AddMountUnitFile(snapName, revision, what, where, fstype strin
 
 	options := []string{"nodev"}
 	if fstype == "squashfs" {
-		newFSType, newOptions, err := squashfs.FSType()
-		if err != nil {
-			return "", err
-		}
+		newFSType, newOptions := squashfs.FsType()
 		options = append(options, newOptions...)
 		fstype = newFSType
 	}
-	if osutil.IsDir(what) {
+	if osutil.IsDirectory(what) {
 		options = append(options, "bind")
 		fstype = "none"
 	}
@@ -715,7 +712,7 @@ func (s *systemd) RemoveMountUnitFile(mountedDir string) error {
 	}
 
 	unit := MountUnitPath(unitNamePath)
-	if !osutil.CanStat(unit) {
+	if !osutil.FileExists(unit) {
 		return nil
 	}
 

--- a/internals/systemd/systemd_test.go
+++ b/internals/systemd/systemd_test.go
@@ -502,7 +502,7 @@ func makeFakeFile(c *C, path string) {
 }
 
 func (s *SystemdTestSuite) TestAddMountUnit(c *C) {
-	restore := squashfs.FakeUseFuse(false)
+	restore := squashfs.FakeNeedsFuse(false)
 	defer restore()
 
 	fakeSnapPath := filepath.Join(c.MkDir(), "/var/lib/snappy/snaps/foo_1.0.snap")
@@ -521,7 +521,7 @@ Before=snapd.service
 What=%s
 Where=/snap/snapname/123
 Type=squashfs
-Options=nodev,ro,x-gdu.hide
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 
 [Install]
 WantedBy=multi-user.target
@@ -535,7 +535,7 @@ WantedBy=multi-user.target
 }
 
 func (s *SystemdTestSuite) TestAddMountUnitForDirs(c *C) {
-	restore := squashfs.FakeUseFuse(false)
+	restore := squashfs.FakeNeedsFuse(false)
 	defer restore()
 
 	// a directory instead of a file produces a different output
@@ -553,7 +553,7 @@ Before=snapd.service
 What=%s
 Where=/snap/snapname/x1
 Type=none
-Options=nodev,ro,x-gdu.hide,bind
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide,bind
 
 [Install]
 WantedBy=multi-user.target
@@ -567,7 +567,7 @@ WantedBy=multi-user.target
 }
 
 func (s *SystemdTestSuite) TestFuseInContainer(c *C) {
-	if !osutil.CanStat("/dev/fuse") {
+	if !osutil.FileExists("/dev/fuse") {
 		c.Skip("No /dev/fuse on the system")
 	}
 
@@ -601,7 +601,7 @@ Before=snapd.service
 What=%s
 Where=/snap/snapname/123
 Type=fuse.squashfuse
-Options=nodev,ro,x-gdu.hide,allow_other
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide,allow_other
 
 [Install]
 WantedBy=multi-user.target
@@ -639,7 +639,7 @@ Before=snapd.service
 What=%s
 Where=/snap/snapname/123
 Type=squashfs
-Options=nodev,ro,x-gdu.hide
+Options=nodev,ro,x-gdu.hide,x-gvfs-hide
 
 [Install]
 WantedBy=multi-user.target
@@ -713,7 +713,7 @@ func (s *SystemdTestSuite) TestRemoveMountUnit(c *C) {
 	c.Assert(err, IsNil)
 
 	// the file is gone
-	c.Check(osutil.CanStat(mountUnit), Equals, false)
+	c.Check(osutil.FileExists(mountUnit), Equals, false)
 	// and the unit is disabled and the daemon reloaded
 	c.Check(s.argses, DeepEquals, [][]string{
 		{"--root", s.rootDir, "disable", "snap-foo-42.mount"},


### PR DESCRIPTION
This ports https://github.com/canonical/snapd/pull/17093 to Pebble.

In doing so, to reduce divergence the following files were copied:
- `internals/osutil/squashfs/fstype.go`
- `internals/osutil/io.go`
- `internals/osutil/io_test.go`
They are patched slightly to conform to Pebble project style (e.g. `MockXXX` -> `FakeXXX`).

The remainder of the changes are fixing up usages of what these files provided:
- License comment block.
- `AtomicWriteFlags` usage (chmod is always used now).
- `IsDir` -> `IsDirectory`
- `CanStat` -> `FileExists`