### PR TITLE
docs: fix broken chisel slice cross-reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -289,4 +289,5 @@ intersphinx_mapping = {
     "operator": ("https://canonical.com/juju/docs/ops/latest/", None),
     "juju": ("https://documentation.ubuntu.com/juju/3.6/", None),
     "rockcraft": ("https://documentation.ubuntu.com/rockcraft/latest/", None),
+    "chisel": ("https://ubuntu.com/chisel/docs/latest/", None),
 }

--- a/docs/how-to/capture-logs-from-files.md
+++ b/docs/how-to/capture-logs-from-files.md
@@ -59,7 +59,7 @@ by staging the `coreutils_bins` slice in your `rockcraft.yaml` file:
 
 The `coreutils_bins` slice brings in around a dozen shared objects and some hundred binaries.
 For a truly minimal rock, consider
-{external+rockcraft:ref}`defining a custom chisel slice <how-to-create-a-package-slice-for-chisel>`.
+{external+chisel:doc}`defining a custom chisel slice <how-to/slice-a-package>`.
 
 See the {external+rockcraft:doc}`Rockcraft documentation <index>` to learn more.
 


### PR DESCRIPTION
The intersphinx ref `how-to-create-a-package-slice-for-chisel` in `docs/how-to/capture-logs-from-files.md` no longer resolves: the corresponding `create-slice` page was deleted from rockcraft in [canonical/rockcraft#1267](https://github.com/canonical/rockcraft/pull/1267) (Chisel content deduplication). Rockcraft now redirects that URL to `install-slice`, which only covers installing an existing slice — not creating one. The slice-creation content now lives in the chisel docs at `how-to/slice-a-package`.

The PR adds `chisel` to `intersphinx_mapping` in `docs/conf.py` and switches the reference to `{external+chisel:doc}`.

[Preview](https://canonical-ubuntu-pebble--895.com.readthedocs.build/how-to/capture-logs-from-files/)