### PR TITLE
fix: only generate identity key when HTTPS is enabled

### DIFF
--- a/internals/cli/cmd_run.go
+++ b/internals/cli/cmd_run.go
@@ -166,6 +166,26 @@ func sanityCheck() error {
 	return nil
 }
 
+// setupTLSOptions returns the TLS options for the daemon based on the
+// configured HTTPS address. If HTTPS is not requested no identity key is
+// loaded. If HTTPS is requested, an identity key is loaded (or generated)
+// from pebbleDir; this requires persistent state, so an error is returned
+// when persist is overlord.PersistNever.
+func setupTLSOptions(pebbleDir, httpsAddress string, persist overlord.PersistMode) (tlsstate.Options, error) {
+	if httpsAddress == "" {
+		return tlsstate.Options{}, nil
+	}
+	if persist == overlord.PersistNever {
+		return tlsstate.Options{}, fmt.Errorf("cannot use --https with PEBBLE_PERSIST=never: identity key requires persistent state")
+	}
+	idPath := filepath.Join(pebbleDir, "identity")
+	idSigner, err := idkey.Get(idPath)
+	if err != nil {
+		return tlsstate.Options{}, err
+	}
+	return tlsstate.Options{Signer: idSigner}, nil
+}
+
 func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	err := reaper.Start()
 	if err != nil {
@@ -194,16 +214,9 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	plan.RegisterSectionExtension(workloads.WorkloadsField, &workloads.WorkloadsSectionExtension{})
 	plan.RegisterSectionExtension(pairingstate.PairingField, &pairingstate.SectionExtension{})
 
-	idPath := filepath.Join(rcmd.pebbleDir, "identity")
-	idSigner, err := idkey.Get(idPath)
-	if err != nil {
-		return err
-	}
-
 	dopts := daemon.Options{
 		Dir:          rcmd.pebbleDir,
 		SocketPath:   rcmd.socketPath,
-		TLSOptions:   tlsstate.Options{Signer: idSigner},
 		HTTPAddress:  rcmd.HTTP,
 		HTTPSAddress: rcmd.HTTPS,
 	}
@@ -213,6 +226,12 @@ func runDaemon(rcmd *cmdRun, ch chan os.Signal, ready chan<- func()) error {
 	if os.Getenv("PEBBLE_PERSIST") == "never" {
 		dopts.Persist = overlord.PersistNever
 	}
+
+	tlsOpts, err := setupTLSOptions(rcmd.pebbleDir, rcmd.HTTPS, dopts.Persist)
+	if err != nil {
+		return err
+	}
+	dopts.TLSOptions = tlsOpts
 
 	d, err := daemon.New(&dopts)
 	if err != nil {

--- a/internals/cli/cmd_run_test.go
+++ b/internals/cli/cmd_run_test.go
@@ -18,10 +18,12 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/canonical/pebble/internals/cli"
+	"github.com/canonical/pebble/internals/overlord"
 )
 
 func (s *PebbleSuite) TestMaybeCopyPebbleDir(c *C) {
@@ -124,4 +126,55 @@ func (s *PebbleSuite) TestMaybeCopyPebbleDirSourceNotADirectory(c *C) {
 	c.Assert(err, IsNil)
 	err = cli.MaybeCopyPebbleDir(dst, src)
 	c.Assert(err, ErrorMatches, ".*not a directory.*")
+}
+
+func (s *PebbleSuite) TestSetupTLSOptionsHTTPSNotSet(c *C) {
+	pebbleDir := c.MkDir()
+
+	// No HTTPS configured: no identity should be loaded or generated, and
+	// the persist mode must not matter.
+	opts, err := cli.SetupTLSOptions(pebbleDir, "", overlord.PersistDefault)
+	c.Assert(err, IsNil)
+	c.Check(opts.Signer, IsNil)
+
+	opts, err = cli.SetupTLSOptions(pebbleDir, "", overlord.PersistNever)
+	c.Assert(err, IsNil)
+	c.Check(opts.Signer, IsNil)
+
+	// Also confirm idkey.Get was never called by checking no "identity"
+	// directory was created in pebbleDir.
+	_, err = os.Stat(filepath.Join(pebbleDir, "identity"))
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *PebbleSuite) TestSetupTLSOptionsHTTPSWithPersistNever(c *C) {
+	pebbleDir := c.MkDir()
+
+	opts, err := cli.SetupTLSOptions(pebbleDir, ":8443", overlord.PersistNever)
+	c.Assert(err, ErrorMatches, `cannot use --https with PEBBLE_PERSIST=never: identity key requires persistent state`)
+	c.Check(opts.Signer, IsNil)
+
+	// No identity directory or key should have been created.
+	_, err = os.Stat(filepath.Join(pebbleDir, "identity"))
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *PebbleSuite) TestSetupTLSOptionsHTTPSWithPersistDefault(c *C) {
+	pebbleDir := c.MkDir()
+
+	opts, err := cli.SetupTLSOptions(pebbleDir, ":8443", overlord.PersistDefault)
+	c.Assert(err, IsNil)
+	c.Assert(opts.Signer, NotNil)
+	c.Check(opts.Signer.Fingerprint(), Not(Equals), "")
+
+	// The identity key was persisted to disk.
+	info, err := os.Stat(filepath.Join(pebbleDir, "identity", "key.pem"))
+	c.Assert(err, IsNil)
+	c.Check(info.Mode().IsRegular(), Equals, true)
+
+	// Calling again should reuse the existing key (same fingerprint).
+	opts2, err := cli.SetupTLSOptions(pebbleDir, ":8443", overlord.PersistDefault)
+	c.Assert(err, IsNil)
+	c.Assert(opts2.Signer, NotNil)
+	c.Check(opts2.Signer.Fingerprint(), Equals, opts.Signer.Fingerprint())
 }

--- a/internals/cli/export_test.go
+++ b/internals/cli/export_test.go
@@ -66,6 +66,8 @@ var (
 
 	MaybeCopyPebbleDir = maybeCopyPebbleDir
 
+	SetupTLSOptions = setupTLSOptions
+
 	WithDefaultRunOptions = withDefaultRunOptions
 )
 


### PR DESCRIPTION
Previously `pebble run` always loaded or generated an identity
key under `$PEBBLE/identity`, even when HTTPS was not configured and
the key would never be used.

Skip the call to `idkey.Get` entirely when `--https` is unset. When
`--https` is set with `PEBBLE_PERSIST=never`, fail with an error since
the identity key cannot be generated without persistent state.

Fixes #801