### PR TITLE
chore: bump version to v1.32.0 for release

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 //go:generate ./mkversion.sh
 
 // Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.31.0"
+var Version = "v1.32.0"
 
 func MockVersion(version string) (restore func()) {
 	old := Version


### PR DESCRIPTION
Bumps the version to v1.32.0 for release.