### PR TITLE
ci: adopt new dependabot conventions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,19 +1,46 @@
+# Routine version-update sweeps only. CVE patches are raised by the
+# repo-level "Dependabot security updates" toggle (managed in
+# canonical-repo-automation: features.dependabot_security_updates = true),
+# which is event-driven and does not honour the schedule below.
 version: 2
+
 updates:
+  # ===================================================================
+  # GitHub Actions: routine lane (monthly, single grouped PR)
+  # ===================================================================
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"  # This is hard-coded to the 1st of the month
+      interval: "monthly"
     labels:
       - "dependencies"
+    open-pull-requests-limit: 100
     cooldown:
       default-days: 7
+      semver-major-days: 14
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # ===================================================================
+  # Go modules: routine lane (monthly, single grouped PR; a runtime
+  # major falls through to its own ungrouped PR).
+  # ===================================================================
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0  # Security updates only
+      interval: "monthly"
     labels:
       - "dependencies"
+    open-pull-requests-limit: 100
     cooldown:
       default-days: 7
+      semver-major-days: 14
+    groups:
+      gomod:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,9 +5,7 @@
 version: 2
 
 updates:
-  # ===================================================================
   # GitHub Actions: routine lane (monthly, single grouped PR)
-  # ===================================================================
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -23,10 +21,8 @@ updates:
         patterns:
           - "*"
 
-  # ===================================================================
   # Go modules: routine lane (monthly, single grouped PR; a runtime
   # major falls through to its own ungrouped PR).
-  # ===================================================================
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR adjusts the dependabot config to match the new Charm Tech standard ([spec: OP0xx-dependabot-config-conventions](https://github.com/canonical/charm-tech/blob/main/specs/OP0xx-dependabot-config-conventions.md)).

Net effect:

**GitHub Actions lane**: keeps monthly cadence; gains:
- `open-pull-requests-limit: 100`.
- `cooldown.semver-major-days: 14` alongside the existing 7-day default.
- A single `actions: ["*"]` group so the monthly bump is one PR.

**Go modules (gomod) lane**: replaces the previous daily security-only entry with a monthly routine lane; gains:
- `open-pull-requests-limit: 100`, `cooldown.default-days: 7`, `semver-major-days: 14`.
- A single `gomod: ["*"]` group, **minor + patch only** — a runtime major falls through to its own ungrouped PR so it never silently rides a patch bundle.

**Existing daily security-only gomod entry dropped** per spec. GHSA-driven CVE PRs are already raised by the repo-level "Dependabot security updates" toggle (managed group-wide in canonical-repo-automation), which is event-driven and independent of any YAML schedule; the separate daily-lane pattern adds nothing on top of that.