### PR TITLE
chore: set dependabot commit-message prefix to "chore" (no scope)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,7 +17,6 @@ updates:
       prefix: "chore"
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,8 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 100
+    commit-message:
+      prefix: "chore"
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -30,6 +32,8 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 100
+    commit-message:
+      prefix: "chore"
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
Follow-up to the dependabot conventions rollout ([pebble#905](https://github.com/canonical/pebble/pull/905)). Add explicit `commit-message.prefix: "chore"` on every `updates:` entry so Dependabot always produces the plain `chore: bump foo to 1.2.3` shape.