### PR TITLE
docs: exclude reused content from sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ sitemap_excludes = [
     "404/",
     "genindex/",
     "search/",
+    "reuse/*",
 ]
 
 ################################


### PR DESCRIPTION
Some of our doc pages pull in shared content from a directory called `reuse`. The [generated sitemap](https://ubuntu.com/docs/pebble/doc-sitemap.xml) contains three URLs that shouldn't be listed:

- `/reuse/verify/`
- `/reuse/install/`
- `/reuse/service-start-order/`

This PR excludes them from the sitemap. [Preview of the fixed sitemap](https://canonical-ubuntu-pebble--909.com.readthedocs.build/doc-sitemap.xml).