### PR TITLE
chore: bump Go version to 1.26.5; bump version to v1.32.1 for release

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 //go:generate ./mkversion.sh
 
 // Version will be overwritten at build-time via mkversion.sh
-var Version = "v1.32.0"
+var Version = "v1.32.1"
 
 func MockVersion(version string) (restore func()) {
 	old := Version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/pebble
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5


### PR DESCRIPTION
What it says on the tin. The bump to Go 1.26.5 will address a couple of CVEs that govulncheck is showing:

```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
...
```

