### PR TITLE
logstate: make gatherer teardown timeouts configurable

### DIFF
--- a/internals/overlord/logstate/gatherer.go
+++ b/internals/overlord/logstate/gatherer.go
@@ -88,6 +88,8 @@ type logGathererOptions struct {
 	bufferTimeout       time.Duration
 	maxBufferedEntries  int
 	timeoutCurrentFlush time.Duration
+	timeoutPullers      time.Duration
+	timeoutMainLoop     time.Duration
 	timeoutFinalFlush   time.Duration
 	// method to get a new client
 	newClient func(*plan.LogTarget) (logClient, error)
@@ -132,6 +134,12 @@ func fillDefaultOptions(options *logGathererOptions) *logGathererOptions {
 	}
 	if options.timeoutCurrentFlush == 0 {
 		options.timeoutCurrentFlush = timeoutCurrentFlush
+	}
+	if options.timeoutPullers == 0 {
+		options.timeoutPullers = timeoutPullers
+	}
+	if options.timeoutMainLoop == 0 {
+		options.timeoutMainLoop = timeoutMainLoop
 	}
 	if options.timeoutFinalFlush == 0 {
 		options.timeoutFinalFlush = timeoutFinalFlush
@@ -284,7 +292,7 @@ func (g *logGatherer) Stop() {
 
 	// Wait up to timeoutPullers for the pullers to pull the final logs from the
 	// iterator and send to the main loop.
-	time.AfterFunc(timeoutPullers, func() {
+	time.AfterFunc(g.timeoutPullers, func() {
 		logger.Debugf("gatherer %q: force killing log pullers", g.targetName)
 		g.pullers.KillAll()
 	})
@@ -296,7 +304,7 @@ func (g *logGatherer) Stop() {
 	select {
 	case <-g.pullers.Done():
 		logger.Debugf("gatherer %q: pullers have finished", g.targetName)
-	case <-time.After(timeoutMainLoop):
+	case <-time.After(g.timeoutMainLoop):
 		logger.Debugf("gatherer %q: force killing main loop", g.targetName)
 	}
 

--- a/internals/overlord/logstate/gatherer_test.go
+++ b/internals/overlord/logstate/gatherer_test.go
@@ -48,6 +48,7 @@ func (s *gathererSuite) TestGatherer(c *C) {
 
 	g, err := newLogGathererInternal(&plan.LogTarget{Name: "tgt1"}, &gathererOptions)
 	c.Assert(err, IsNil)
+	defer g.Stop()
 
 	testSvc := newTestService("svc1")
 	g.ServiceStarted(testSvc.config, testSvc.ringBuffer)
@@ -85,6 +86,7 @@ func (s *gathererSuite) TestGathererTimeout(c *C) {
 
 	g, err := newLogGathererInternal(&plan.LogTarget{Name: "tgt1"}, &gathererOptions)
 	c.Assert(err, IsNil)
+	defer g.Stop()
 
 	testSvc := newTestService("svc1")
 	g.ServiceStarted(testSvc.config, testSvc.ringBuffer)
@@ -170,6 +172,7 @@ func (s *gathererSuite) TestRetryLoki(c *C) {
 		},
 	)
 	c.Assert(err, IsNil)
+	defer g.Stop()
 
 	testSvc := newTestService("svc1")
 	g.PlanChanged(&plan.Plan{

--- a/internals/overlord/logstate/manager_test.go
+++ b/internals/overlord/logstate/manager_test.go
@@ -45,6 +45,7 @@ func (*managerSuite) TestPlanChange(c *C) {
 		},
 	}
 	m := NewLogManager()
+	defer m.Stop()
 	m.newGatherer = func(t *plan.LogTarget) (*logGatherer, error) {
 		return newLogGathererInternal(t, &gathererOptions)
 	}
@@ -131,6 +132,8 @@ func (s *managerSuite) TestTimelyShutdown(c *C) {
 
 	gathererOptions := logGathererOptions{
 		timeoutCurrentFlush: 5 * time.Millisecond,
+		timeoutPullers:      5 * time.Millisecond,
+		timeoutMainLoop:     5 * time.Millisecond,
 		timeoutFinalFlush:   5 * time.Millisecond,
 		newClient: func(_ *plan.LogTarget) (logClient, error) {
 			return client, nil
@@ -220,6 +223,7 @@ func (s *managerSuite) TestLabels(c *C) {
 	}
 
 	m := NewLogManager()
+	defer m.Stop()
 	m.newGatherer = func(t *plan.LogTarget) (*logGatherer, error) {
 		return newLogGathererInternal(t, &logGathererOptions{
 			newClient: func(_ *plan.LogTarget) (logClient, error) { return fakeClient, nil },


### PR DESCRIPTION
## Problem
When there are active log targets (forwarding gatherers), tearing down gatherers or shutting down the daemon experiences a delay because `timeoutPullers` and `timeoutMainLoop` inside `logGatherer` were hardcoded constants (2s and 3s respectively). In tests or during fast shutdown, `LogManager.Stop()` could take up to 2 seconds waiting for puller tombs to be killed.

## Solution
- Added `timeoutPullers` and `timeoutMainLoop` to `logGathererOptions` with fallback defaults, making teardown timeouts configurable in tests.
- Configured `TestTimelyShutdown` in `internals/overlord/logstate/manager_test.go` with fast timeouts.
- Added proper `defer g.Stop()` / `defer m.Stop()` in logstate test suites to prevent puller goroutine leaks.

Fixes #681

## Testing
- Executed unit tests in `internals/servicelog`, `internals/overlord/logstate`, and `internals/plan`:
  ```bash
  go test -v ./internals/servicelog ./internals/overlord/logstate ./internals/plan
  ```
- All tests passed cleanly.