### PR TITLE
ci: swap attest-build-provenance for actions/attest

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -142,7 +142,7 @@ jobs:
 
     - name: Attest build provenance
       if: steps.check.outputs.skip != 'true' && steps.release.outputs.tag != ''
-      uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2
       with:
         subject-path: dist/${{ steps.build.outputs.ARCHIVE_FILE }}
 

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2
         with:
           subject-path: ${{ steps.build-snap.outputs.snap }}
 


### PR DESCRIPTION
`actions/attest-build-provenance` has been a thin wrapper around `actions/attest` since its v4.0.0, and its release notes recommend using `actions/attest` directly, so this swaps the action in both places it's used: the binaries workflow and the snap one.

With no predicate inputs, `actions/attest` defaults to build provenance, so `subject-path` is the only input either action needs and the job permissions are unchanged. Both were still pinned to v4.1.1; the new pin is v4.2.2, the current release.