### PR TITLE
ci: allow snaps to optionally be built via qemu

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -96,7 +96,15 @@ jobs:
         fi
 
         if [[ -n "$TAG" ]]; then
-          PATTERN="pebble_${TAG}_${GOOS}_${GOARCH}.tar.gz"
+          # Match the GOARCH rewrite done in the build step below, where
+          # armvN (e.g. armv6) becomes arm (with GOARM=N), so the archive
+          # name reflects "arm" rather than "armv6".
+          ARCHIVE_GOARCH="$GOARCH"
+          if [[ "$GOARCH" == armv* ]]; then
+            ARCHIVE_GOARCH=arm
+          fi
+
+          PATTERN="pebble_${TAG}_${GOOS}_${ARCHIVE_GOARCH}.tar.gz"
           if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qxF "$PATTERN"; then
             echo "Archive $PATTERN already attached to release $TAG, skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,48 @@ on:
         required: false
         type: boolean
         default: false
+      qemu-build-arch-amd64:
+        description: >-
+          Build the amd64 snap locally via QEMU emulation instead of
+          Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-build-arch-arm64:
+        description: >-
+          Build the arm64 snap locally via QEMU emulation instead of
+          Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-build-arch-armv6:
+        description: >-
+          Build the armv6/armhf snap locally via QEMU emulation instead of
+          Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-build-arch-ppc64le:
+        description: >-
+          Build the ppc64le/ppc64el snap locally via QEMU emulation instead
+          of Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-build-arch-riscv64:
+        description: >-
+          Build the riscv64 snap locally via QEMU emulation instead of
+          Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-build-arch-s390x:
+        description: >-
+          Build the s390x snap locally via QEMU emulation instead of
+          Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
       skip-sbomber:
         description: "Skip running sbomber and uploading its report to the release"
         required: false
@@ -751,6 +793,12 @@ jobs:
       skip-ppc64el: ${{ inputs.skip-arch-ppc64le }}
       skip-riscv64: ${{ inputs.skip-arch-riscv64 }}
       skip-s390x: ${{ inputs.skip-arch-s390x }}
+      qemu-amd64: ${{ inputs.qemu-build-arch-amd64 }}
+      qemu-arm64: ${{ inputs.qemu-build-arch-arm64 }}
+      qemu-armhf: ${{ inputs.qemu-build-arch-armv6 }}
+      qemu-ppc64el: ${{ inputs.qemu-build-arch-ppc64le }}
+      qemu-riscv64: ${{ inputs.qemu-build-arch-riscv64 }}
+      qemu-s390x: ${{ inputs.qemu-build-arch-s390x }}
 
   sbomber:
     needs: [draft-release, draft-release-finish, snap]

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -66,6 +66,48 @@ on:
         required: false
         type: boolean
         default: false
+      qemu-amd64:
+        description: >-
+          Build the amd64 snap locally inside a QEMU-emulated VM instead of
+          via Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-arm64:
+        description: >-
+          Build the arm64 snap locally inside a QEMU-emulated VM instead of
+          via Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-armhf:
+        description: >-
+          Build the armhf snap locally inside a QEMU-emulated VM instead of
+          via Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-ppc64el:
+        description: >-
+          Build the ppc64el snap locally inside a QEMU-emulated VM instead
+          of via Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-riscv64:
+        description: >-
+          Build the riscv64 snap locally inside a QEMU-emulated VM instead
+          of via Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
+      qemu-s390x:
+        description: >-
+          Build the s390x snap locally inside a QEMU-emulated VM instead of
+          via Launchpad's remote-build service.
+        required: false
+        type: boolean
+        default: false
     secrets:
       LP_CREDENTIALS:
         description: "Launchpad credentials used for the remote snap build"
@@ -182,10 +224,17 @@ jobs:
           TAG: ${{ inputs.release-tag }}
           ARCH: ${{ matrix.arch }}
           SKIP_ARCH: ${{ inputs[format('skip-{0}', matrix.arch)] }}
+          QEMU_BUILD: ${{ inputs[format('qemu-{0}', matrix.arch)] }}
         run: |
           set -eu
           if [[ "$SKIP_ARCH" == "true" ]]; then
             echo "Architecture $ARCH skipped via input."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$QEMU_BUILD" == "true" ]]; then
+            echo "Architecture $ARCH is being built via QEMU emulation instead, skipping remote-build."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -256,16 +305,278 @@ jobs:
           name: pebble-snap-${{ matrix.arch }}
           path: ${{ steps.build-snap.outputs.snap }}
 
+  qemu-build:
+    # Alternative to remote-build: builds a snap for an architecture the
+    # runner can't run natively by booting a full-system QEMU VM of that
+    # architecture (running the Ubuntu release matching snapcraft.yaml's
+    # build-base), and building inside it with `snapcraft pack
+    # --destructive-mode`. This produces an unsigned ("dangerous") .snap,
+    # same as any locally-built snap. Opt in per architecture via the
+    # qemu-<arch> inputs; remote-build skips any architecture built this
+    # way (see its "Check if this architecture should be skipped" step).
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    if: |
+      github.event_name != 'pull_request' &&
+      github.event_name != 'release' &&
+      !inputs.skip-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            qemu-pkg: qemu-system-x86
+            qemu-bin: qemu-system-x86_64
+            machine: pc
+            accel-flags: -cpu host -enable-kvm
+          - arch: arm64
+            qemu-pkg: qemu-system-arm
+            qemu-bin: qemu-system-aarch64
+            machine: virt
+            accel-flags: -cpu max
+            firmware-pkg: qemu-efi-aarch64
+            firmware-path: /usr/share/AAVMF/AAVMF_CODE.fd
+          - arch: armhf
+            qemu-pkg: qemu-system-arm
+            qemu-bin: qemu-system-arm
+            machine: virt
+            accel-flags: -cpu cortex-a15
+            firmware-pkg: qemu-efi-arm
+            firmware-path: /usr/share/AAVMF/AAVMF32_CODE.fd
+          - arch: ppc64el
+            qemu-pkg: qemu-system-ppc
+            qemu-bin: qemu-system-ppc64
+            machine: pseries
+            accel-flags: -cpu POWER9
+          - arch: riscv64
+            qemu-pkg: qemu-system-misc
+            qemu-bin: qemu-system-riscv64
+            machine: virt
+            accel-flags: -cpu rv64
+            firmware-flags: -bios default
+          - arch: s390x
+            qemu-pkg: qemu-system-s390x
+            qemu-bin: qemu-system-s390x
+            machine: s390-ccw-virtio
+            accel-flags: -cpu max
+    steps:
+      - name: Checkout Pebble repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.release-tag }}
+
+      # Opt-in gate: only run when the qemu-<arch> input requested a
+      # QEMU-emulated local build for this architecture, and (idempotency)
+      # skip if a snap for this arch is already attached to the release.
+      - name: Check if this architecture should build via QEMU
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.release-tag }}
+          ARCH: ${{ matrix.arch }}
+          QEMU_BUILD: ${{ inputs[format('qemu-{0}', matrix.arch)] }}
+        run: |
+          set -eu
+          if [[ "$QEMU_BUILD" != "true" ]]; then
+            echo "QEMU build for $ARCH not requested."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -n "$TAG" ]] && gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qE "^pebble.*${ARCH}.*\.snap$"; then
+            echo "Snap for $ARCH already attached to release $TAG, skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
+        with:
+          go-version-file: "go.mod"
+
+      # Generate the version files on the host; they're copied into the VM
+      # along with the rest of the source tree below.
+      - if: steps.check.outputs.skip != 'true'
+        run: go generate ./cmd
+
+      - name: Install QEMU and supporting tools
+        if: steps.check.outputs.skip != 'true'
+        env:
+          QEMU_PKG: ${{ matrix.qemu-pkg }}
+          FIRMWARE_PKG: ${{ matrix.firmware-pkg }}
+        run: |
+          set -eu
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            "$QEMU_PKG" qemu-utils cloud-image-utils genisoimage openssh-client rsync \
+            ${FIRMWARE_PKG:+$FIRMWARE_PKG}
+
+      # The target Ubuntu release comes straight from snapcraft.yaml, so the
+      # VM matches whatever base the snap actually builds against.
+      - name: Determine Ubuntu base image for this build
+        if: steps.check.outputs.skip != 'true'
+        id: base
+        run: |
+          set -eu
+          # Prefer build-base (required whenever base: bare is used, as it
+          # is here) and only fall back to base if build-base is absent.
+          BUILD_BASE=$(grep -E '^build-base:' snap/snapcraft.yaml | head -n1 | awk '{print $2}')
+          if [[ -z "$BUILD_BASE" ]]; then
+            BUILD_BASE=$(grep -E '^base:' snap/snapcraft.yaml | head -n1 | awk '{print $2}')
+          fi
+          case "$BUILD_BASE" in
+            core18) CODENAME=bionic ;;
+            core20) CODENAME=focal ;;
+            core22) CODENAME=jammy ;;
+            core24) CODENAME=noble ;;
+            *) echo "Unrecognised build-base '$BUILD_BASE' in snap/snapcraft.yaml" >&2; exit 1 ;;
+          esac
+          echo "Using Ubuntu $CODENAME cloud image (snapcraft.yaml build-base: $BUILD_BASE)"
+          echo "codename=$CODENAME" >> "$GITHUB_OUTPUT"
+
+      - name: Download Ubuntu cloud image for ${{ matrix.arch }}
+        if: steps.check.outputs.skip != 'true'
+        env:
+          CODENAME: ${{ steps.base.outputs.codename }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -eu
+          IMAGE_URL="https://cloud-images.ubuntu.com/releases/${CODENAME}/release/${CODENAME}-server-cloudimg-${ARCH}.img"
+          echo "Downloading $IMAGE_URL"
+          curl -fSL "$IMAGE_URL" -o vm-base.img
+          qemu-img resize vm-base.img +8G
+          qemu-img create -f qcow2 -F qcow2 -b vm-base.img vm-disk.qcow2
+
+      - name: Prepare cloud-init seed
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          set -eu
+          ssh-keygen -t ed25519 -N "" -f vm-key
+          cat > user-data <<CLOUDEOF
+          #cloud-config
+          hostname: qemu-build
+          ssh_pwauth: false
+          package_update: false
+          users:
+            - name: builder
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              shell: /bin/bash
+              ssh_authorized_keys:
+                - $(cat vm-key.pub)
+          CLOUDEOF
+          cat > meta-data <<METAEOF
+          instance-id: qemu-build
+          local-hostname: qemu-build
+          METAEOF
+          cloud-localds seed.img user-data meta-data
+
+      - name: Boot QEMU VM for ${{ matrix.arch }}
+        if: steps.check.outputs.skip != 'true'
+        env:
+          QEMU_BIN: ${{ matrix.qemu-bin }}
+          MACHINE: ${{ matrix.machine }}
+          ACCEL_FLAGS: ${{ matrix.accel-flags }}
+          FIRMWARE_FLAGS: ${{ matrix.firmware-flags }}
+          FIRMWARE_PATH: ${{ matrix.firmware-path }}
+        run: |
+          set -eu
+          FW_ARGS=()
+          if [[ -n "${FIRMWARE_PATH:-}" ]]; then
+            FW_ARGS=(-drive "if=pflash,format=raw,readonly=on,file=${FIRMWARE_PATH}")
+          elif [[ -n "${FIRMWARE_FLAGS:-}" ]]; then
+            FW_ARGS=(${FIRMWARE_FLAGS})
+          fi
+
+          "$QEMU_BIN" \
+            -machine "$MACHINE" ${ACCEL_FLAGS} \
+            -m 4096 -smp 2 \
+            "${FW_ARGS[@]}" \
+            -drive if=virtio,format=qcow2,file=vm-disk.qcow2 \
+            -drive if=virtio,format=raw,file=seed.img \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -nographic -serial file:serial.log \
+            &
+          echo $! > qemu.pid
+          disown
+
+          echo "Waiting for SSH to come up..."
+          for i in $(seq 1 60); do
+            if ssh -i vm-key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 builder@127.0.0.1 true 2>/dev/null; then
+              echo "VM is up."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for the VM to boot" >&2
+          cat serial.log || true
+          exit 1
+
+      - name: Copy Pebble source into the VM
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          set -eu
+          SSH_OPTS=(-i vm-key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+          ssh "${SSH_OPTS[@]}" builder@127.0.0.1 mkdir -p ~/pebble
+          rsync -az --exclude .git -e "ssh ${SSH_OPTS[*]}" ./ builder@127.0.0.1:~/pebble/
+
+      - name: Build snap inside the VM
+        id: build-snap
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          set -eu
+          SSH_OPTS=(-i vm-key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+          ssh "${SSH_OPTS[@]}" builder@127.0.0.1 "sudo snap install snapcraft --classic"
+          ssh "${SSH_OPTS[@]}" builder@127.0.0.1 "cd ~/pebble && sudo snapcraft pack --destructive-mode"
+          SNAP_NAME=$(ssh "${SSH_OPTS[@]}" builder@127.0.0.1 "cd ~/pebble && ls -1 *.snap" | tail -n1)
+          scp "${SSH_OPTS[@]}" "builder@127.0.0.1:~/pebble/${SNAP_NAME}" "./${SNAP_NAME}"
+          echo "snap=${SNAP_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Shut down the VM
+        if: always() && steps.check.outputs.skip != 'true'
+        run: |
+          if [[ -f qemu.pid ]]; then
+            kill "$(cat qemu.pid)" 2>/dev/null || true
+          fi
+
+      - name: Attest build provenance
+        if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+        with:
+          subject-path: ${{ steps.build-snap.outputs.snap }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        if: steps.check.outputs.skip != 'true' && always()
+        with:
+          name: qemu-build-logs-${{ matrix.arch }}
+          path: serial.log
+
+      - name: Attach ${{ steps.build-snap.outputs.snap }} to GH workflow execution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
+        with:
+          name: pebble-snap-${{ matrix.arch }}
+          path: ${{ steps.build-snap.outputs.snap }}
+
   test:
     runs-on: ubuntu-latest
-    needs: [local-build, remote-build]
+    needs: [local-build, remote-build, qemu-build]
     env:
       # Testing is only enabled on amd64. We can add arm64 once we have such runners.
       TEST_ON: amd64
     if: |
       always() &&
       (needs.local-build.result == 'success' || needs.local-build.result == 'skipped') &&
-      (needs.remote-build.result == 'success' || needs.remote-build.result == 'skipped')
+      (needs.remote-build.result == 'success' || needs.remote-build.result == 'skipped') &&
+      (needs.qemu-build.result == 'success' || needs.qemu-build.result == 'skipped')
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:


### PR DESCRIPTION
Due to issues with riscv builds via launchpad taking a very long time, this
adds an optional fallback to build via qemu for any specified architecture.