### PR TITLE
ci: generate build matricies and fix qemu image download

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -48,8 +48,11 @@ jobs:
   # it has nothing to do.
   plan:
     runs-on: ubuntu-latest
+    # contents: write (not just read) is required for `gh release view` to
+    # see a draft release -- drafts are only visible to callers with push
+    # access to the repo.
     permissions:
-      contents: read
+      contents: write
     outputs:
       goarch: ${{ steps.plan.outputs.goarch }}
     steps:
@@ -57,6 +60,7 @@ jobs:
         id: plan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.release-tag }}
           EVENT_NAME: ${{ github.event_name }}
           SKIP_AMD64: ${{ inputs.skip-amd64 }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -41,7 +41,82 @@ on:
 permissions: {}
 
 jobs:
+  # Computes which goarch values actually need a build/upload this run,
+  # before any build runners are spun up. This accounts for skip-<arch>
+  # inputs and (idempotency) architectures whose archive is already attached
+  # to the release, so a build runner never gets allocated just to discover
+  # it has nothing to do.
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      goarch: ${{ steps.plan.outputs.goarch }}
+    steps:
+      - name: Compute architectures to build
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.release-tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          SKIP_AMD64: ${{ inputs.skip-amd64 }}
+          SKIP_ARM64: ${{ inputs.skip-arm64 }}
+          SKIP_ARMV6: ${{ inputs.skip-armv6 }}
+          SKIP_PPC64LE: ${{ inputs.skip-ppc64le }}
+          SKIP_RISCV64: ${{ inputs.skip-riscv64 }}
+          SKIP_S390X: ${{ inputs.skip-s390x }}
+        run: |
+          set -eu
+
+          # Pull request runs are just a test to check that everything
+          # still compiles, so amd64 and arm64 are sufficient.
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            CANDIDATES=(amd64 arm64)
+          else
+            CANDIDATES=(amd64 arm64 armv6 ppc64le riscv64 s390x)
+          fi
+
+          declare -A SKIP=(
+            [amd64]="$SKIP_AMD64"     [arm64]="$SKIP_ARM64"
+            [armv6]="$SKIP_ARMV6"     [ppc64le]="$SKIP_PPC64LE"
+            [riscv64]="$SKIP_RISCV64" [s390x]="$SKIP_S390X"
+          )
+
+          SELECTED=()
+          for GOARCH in "${CANDIDATES[@]}"; do
+            if [[ "${SKIP[$GOARCH]}" == "true" ]]; then
+              echo "Architecture $GOARCH skipped via input."
+              continue
+            fi
+
+            if [[ -n "$TAG" ]]; then
+              # Match the GOARCH rewrite done in the build step, where
+              # armvN (e.g. armv6) becomes arm (with GOARM=N), so the
+              # archive name reflects "arm" rather than "armv6".
+              ARCHIVE_GOARCH="$GOARCH"
+              if [[ "$GOARCH" == armv* ]]; then
+                ARCHIVE_GOARCH=arm
+              fi
+
+              PATTERN="pebble_${TAG}_linux_${ARCHIVE_GOARCH}.tar.gz"
+              if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qxF "$PATTERN"; then
+                echo "Archive $PATTERN already attached to release $TAG, skipping $GOARCH."
+                continue
+              fi
+            fi
+
+            echo "Architecture $GOARCH will be built."
+            SELECTED+=("$GOARCH")
+          done
+
+          GOARCH_JSON=$(jq -nc '$ARGS.positional' --args "${SELECTED[@]}")
+          echo "Building for: ${SELECTED[*]:-<none>}"
+          echo "goarch=$GOARCH_JSON" >> "$GITHUB_OUTPUT"
+
   create-binaries:
+    needs: [plan]
+    # Only runs at all if plan actually selected at least one architecture.
+    if: needs.plan.outputs.goarch != '[]'
     permissions:
       contents: write
       id-token: write
@@ -49,9 +124,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        # Pull request runs are just a test to check that everything still
-        # compiles, so amd64 and arm64 are sufficient.
-        goarch: ${{ github.event_name == 'pull_request' && fromJSON('["amd64","arm64"]') || fromJSON('["amd64","arm64","armv6","ppc64le","riscv64","s390x"]') }}
+        goarch: ${{ fromJSON(needs.plan.outputs.goarch) }}
 
     runs-on: ubuntu-latest
 
@@ -69,54 +142,8 @@ jobs:
         go-version-file: "go.mod"
         cache: false
 
-    - name: Determine release tag
-      id: release
-      env:
-        RELEASE_TAG: ${{ inputs.release-tag }}
-      run: echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
-
-    # Skip this architecture if it was explicitly requested via input, or
-    # (idempotency) if it's already attached to the release -- e.g. a
-    # previous run of this workflow already uploaded it, and we're only
-    # re-running to pick up a different architecture that failed.
-    - name: Check if this architecture should be skipped
-      id: check
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ steps.release.outputs.tag }}
-        GOOS: ${{ matrix.goos }}
-        GOARCH: ${{ matrix.goarch }}
-        SKIP_ARCH: ${{ inputs[format('skip-{0}', matrix.goarch)] }}
-      run: |
-        set -eu
-        if [[ "$SKIP_ARCH" == "true" ]]; then
-          echo "Architecture $GOARCH skipped via input."
-          echo "skip=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        if [[ -n "$TAG" ]]; then
-          # Match the GOARCH rewrite done in the build step below, where
-          # armvN (e.g. armv6) becomes arm (with GOARM=N), so the archive
-          # name reflects "arm" rather than "armv6".
-          ARCHIVE_GOARCH="$GOARCH"
-          if [[ "$GOARCH" == armv* ]]; then
-            ARCHIVE_GOARCH=arm
-          fi
-
-          PATTERN="pebble_${TAG}_${GOOS}_${ARCHIVE_GOARCH}.tar.gz"
-          if gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qxF "$PATTERN"; then
-            echo "Archive $PATTERN already attached to release $TAG, skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-        fi
-
-        echo "skip=false" >> "$GITHUB_OUTPUT"
-
     - name: Build binary and create archive
       id: build
-      if: steps.check.outputs.skip != 'true'
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
@@ -149,13 +176,12 @@ jobs:
         echo "PEBBLE_VERSION=${PEBBLE_VERSION}" >>$GITHUB_OUTPUT
 
     - name: Attest build provenance
-      if: steps.check.outputs.skip != 'true' && steps.release.outputs.tag != ''
+      if: inputs.release-tag != ''
       uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
       with:
         subject-path: dist/${{ steps.build.outputs.ARCHIVE_FILE }}
 
     - name: Upload archive as Actions artifact
-      if: steps.check.outputs.skip != 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: ${{ steps.build.outputs.ARCHIVE_FILE }}
@@ -164,9 +190,9 @@ jobs:
     - name: Upload archive to release
       env:
         ARCHIVE_FILE: ${{ steps.build.outputs.ARCHIVE_FILE }}
-        TAG: ${{ steps.release.outputs.tag }}
+        TAG: ${{ inputs.release-tag }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: steps.check.outputs.skip != 'true' && steps.release.outputs.tag != ''
+      if: inputs.release-tag != ''
       run: |
         echo Uploading $ARCHIVE_FILE to release $TAG
         gh release upload "$TAG" "dist/$ARCHIVE_FILE"

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -193,8 +193,11 @@ jobs:
     if: |
       github.event_name != 'pull_request' &&
       github.event_name != 'release'
+    # contents: write (not just read) is required for `gh release view` to
+    # see a draft release -- drafts are only visible to callers with push
+    # access to the repo.
     permissions:
-      contents: read
+      contents: write
     outputs:
       remote-arch: ${{ steps.plan.outputs.remote-arch }}
       qemu-arch: ${{ steps.plan.outputs.qemu-arch }}
@@ -205,6 +208,7 @@ jobs:
         id: plan
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ inputs.release-tag }}
           SKIP_BUILD: ${{ inputs.skip-build }}
           SKIP_AMD64: ${{ inputs.skip-amd64 }}
@@ -259,11 +263,16 @@ jobs:
                 continue
               fi
 
-              if [[ "${QEMU_OPT[$ARCH]}" == "true" ]]; then
+              # skip-<arch> always wins over qemu-<arch>: it must fully
+              # disable building/publishing that architecture (matching
+              # record-skipped-architectures' bookkeeping below, which is
+              # driven purely by the skip-<arch> inputs), even if someone
+              # also opted it into a QEMU build.
+              if [[ "${SKIP[$ARCH]}" == "true" ]]; then
+                echo "Architecture $ARCH skipped via input."
+              elif [[ "${QEMU_OPT[$ARCH]}" == "true" ]]; then
                 echo "Architecture $ARCH will be built via QEMU emulation."
                 QEMU+=("$ARCH")
-              elif [[ "${SKIP[$ARCH]}" == "true" ]]; then
-                echo "Architecture $ARCH skipped via input."
               else
                 echo "Architecture $ARCH will be built via remote-build."
                 REMOTE+=("$ARCH")
@@ -688,20 +697,23 @@ jobs:
   # dry-run draft (since nothing was actually published to the store).
   record-skipped-architectures:
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [release, plan-snap-builds]
     # `release`'s own `if:` requires `needs.test.result == 'success'`
     # (strictly, not `skipped`) -- so a genuine build/test failure upstream
     # cascades as `release.result == 'skipped'`, indistinguishable at this
-    # level from a legitimate skip. The only legitimate reason for
+    # level from a legitimate "nothing to build" skip. We disambiguate by
+    # checking plan-snap-builds directly: if it succeeded and selected zero
+    # architectures to build this run (via skip-build, every individual
+    # skip-<arch>, or idempotency), that's the only legitimate reason for
     # `release` to not succeed while still wanting to record skipped
-    # architectures is `skip-build` (which means every architecture was
-    # deliberately never attempted). Anything else non-successful means a
-    # real failure occurred somewhere upstream, and must not be recorded as
-    # an intentional per-architecture skip.
+    # architectures. Anything else non-successful means a real failure
+    # occurred somewhere upstream, and must not be recorded as an
+    # intentional per-architecture skip.
     if: |
       always() &&
       inputs.release-tag != '' &&
-      (needs.release.result == 'success' || inputs.skip-build)
+      needs.plan-snap-builds.result == 'success' &&
+      (needs.release.result == 'success' || needs.plan-snap-builds.outputs.built-arch == '[]')
     permissions:
       contents: write
     env:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -444,7 +444,12 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           set -eu
-          IMAGE_URL="https://cloud-images.ubuntu.com/releases/${CODENAME}/release/${CODENAME}-server-cloudimg-${ARCH}.img"
+          # Note: releases/${CODENAME}/release/ names its files with the
+          # Ubuntu version number (e.g. ubuntu-22.04-server-cloudimg-*.img),
+          # not the codename -- ${CODENAME}/current/ is the tree that uses
+          # codename-based filenames for every architecture, including
+          # riscv64 (arch name "riscv64" here matches Ubuntu's own naming).
+          IMAGE_URL="https://cloud-images.ubuntu.com/${CODENAME}/current/${CODENAME}-server-cloudimg-${ARCH}.img"
           echo "Downloading $IMAGE_URL"
           curl -fSL "$IMAGE_URL" -o vm-base.img
           qemu-img resize vm-base.img +8G

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -182,25 +182,126 @@ jobs:
           name: pebble-snap-${{ matrix.arch }}
           path: ${{ steps.build-snap.outputs.snap }}
 
+  # Centralises every "should we build/publish this architecture, and if so
+  # how" decision in one place, before spinning up any runners for
+  # remote-build/qemu-build/release. Those jobs' matrices are generated entirely
+  # from this job's outputs, so an architecture that's skipped via input,
+  # already built via the other method, or already attached to the release,
+  # never gets a runner of its own at all.
+  plan-snap-builds:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' &&
+      github.event_name != 'release'
+    permissions:
+      contents: read
+    outputs:
+      remote-arch: ${{ steps.plan.outputs.remote-arch }}
+      qemu-arch: ${{ steps.plan.outputs.qemu-arch }}
+      qemu-matrix: ${{ steps.plan.outputs.qemu-matrix }}
+      built-arch: ${{ steps.plan.outputs.built-arch }}
+    steps:
+      - name: Compute which architectures to build, and via which method
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.release-tag }}
+          SKIP_BUILD: ${{ inputs.skip-build }}
+          SKIP_AMD64: ${{ inputs.skip-amd64 }}
+          SKIP_ARM64: ${{ inputs.skip-arm64 }}
+          SKIP_ARMHF: ${{ inputs.skip-armhf }}
+          SKIP_PPC64EL: ${{ inputs.skip-ppc64el }}
+          SKIP_RISCV64: ${{ inputs.skip-riscv64 }}
+          SKIP_S390X: ${{ inputs.skip-s390x }}
+          QEMU_AMD64: ${{ inputs.qemu-amd64 }}
+          QEMU_ARM64: ${{ inputs.qemu-arm64 }}
+          QEMU_ARMHF: ${{ inputs.qemu-armhf }}
+          QEMU_PPC64EL: ${{ inputs.qemu-ppc64el }}
+          QEMU_RISCV64: ${{ inputs.qemu-riscv64 }}
+          QEMU_S390X: ${{ inputs.qemu-s390x }}
+        run: |
+          set -eu
+
+          # Per-architecture QEMU boot configuration for qemu-build, kept
+          # here (rather than as a static matrix on that job) so it can be
+          # filtered down to only the architectures actually selected below.
+          QEMU_CONFIG='[
+            {"arch":"amd64","qemu-pkg":"qemu-system-x86","qemu-bin":"qemu-system-x86_64","machine":"pc","accel-flags":"-cpu host -enable-kvm"},
+            {"arch":"arm64","qemu-pkg":"qemu-system-arm","qemu-bin":"qemu-system-aarch64","machine":"virt","accel-flags":"-cpu max","firmware-pkg":"qemu-efi-aarch64","firmware-path":"/usr/share/AAVMF/AAVMF_CODE.fd"},
+            {"arch":"armhf","qemu-pkg":"qemu-system-arm","qemu-bin":"qemu-system-arm","machine":"virt","accel-flags":"-cpu cortex-a15","firmware-pkg":"qemu-efi-arm","firmware-path":"/usr/share/AAVMF/AAVMF32_CODE.fd"},
+            {"arch":"ppc64el","qemu-pkg":"qemu-system-ppc","qemu-bin":"qemu-system-ppc64","machine":"pseries","accel-flags":"-cpu POWER9"},
+            {"arch":"riscv64","qemu-pkg":"qemu-system-misc","qemu-bin":"qemu-system-riscv64","machine":"virt","accel-flags":"-cpu rv64","firmware-flags":"-bios default"},
+            {"arch":"s390x","qemu-pkg":"qemu-system-s390x","qemu-bin":"qemu-system-s390x","machine":"s390-ccw-virtio","accel-flags":"-cpu max"}
+          ]'
+
+          REMOTE=()
+          QEMU=()
+
+          if [[ "$SKIP_BUILD" != "true" ]]; then
+            declare -A SKIP=(
+              [amd64]="$SKIP_AMD64"     [arm64]="$SKIP_ARM64"
+              [armhf]="$SKIP_ARMHF"     [ppc64el]="$SKIP_PPC64EL"
+              [riscv64]="$SKIP_RISCV64" [s390x]="$SKIP_S390X"
+            )
+            declare -A QEMU_OPT=(
+              [amd64]="$QEMU_AMD64"     [arm64]="$QEMU_ARM64"
+              [armhf]="$QEMU_ARMHF"     [ppc64el]="$QEMU_PPC64EL"
+              [riscv64]="$QEMU_RISCV64" [s390x]="$QEMU_S390X"
+            )
+
+            # Idempotency: treat "asset attached to the release" as the
+            # single source of truth for "this architecture is done" -- it's
+            # uploaded together with (and right after) publishing to the
+            # Snap Store, so the two shouldn't normally get out of sync.
+            for ARCH in amd64 arm64 armhf ppc64el riscv64 s390x; do
+              if [[ -n "$TAG" ]] && gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qE "^pebble.*${ARCH}.*\.snap$"; then
+                echo "Snap for $ARCH already attached to release $TAG, nothing to build."
+                continue
+              fi
+
+              if [[ "${QEMU_OPT[$ARCH]}" == "true" ]]; then
+                echo "Architecture $ARCH will be built via QEMU emulation."
+                QEMU+=("$ARCH")
+              elif [[ "${SKIP[$ARCH]}" == "true" ]]; then
+                echo "Architecture $ARCH skipped via input."
+              else
+                echo "Architecture $ARCH will be built via remote-build."
+                REMOTE+=("$ARCH")
+              fi
+            done
+          fi
+
+          REMOTE_JSON=$(jq -nc '$ARGS.positional' --args "${REMOTE[@]}")
+          QEMU_JSON=$(jq -nc '$ARGS.positional' --args "${QEMU[@]}")
+          QEMU_MATRIX_JSON=$(jq -c --argjson sel "$QEMU_JSON" '[.[] | select(.arch as $a | $sel | index($a) != null)]' <<<"$QEMU_CONFIG")
+          BUILT_JSON=$(jq -nc '$ARGS.positional' --args "${REMOTE[@]}" "${QEMU[@]}")
+
+          echo "Selected for remote-build: ${REMOTE[*]:-<none>}"
+          echo "Selected for qemu-build:   ${QEMU[*]:-<none>}"
+
+          echo "remote-arch=$REMOTE_JSON" >> "$GITHUB_OUTPUT"
+          echo "qemu-arch=$QEMU_JSON" >> "$GITHUB_OUTPUT"
+          echo "qemu-matrix=$QEMU_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+          echo "built-arch=$BUILT_JSON" >> "$GITHUB_OUTPUT"
+
   remote-build:
     runs-on: ubuntu-latest
     environment: snap-build
+    needs: [plan-snap-builds]
     permissions:
       id-token: write
       attestations: write
       contents: read
-    # Runs for a push to master, or when called from release.yml -- but
-    # never for a plain pull_request build (see local-build above) or a
-    # bare release-published event (which only promotes an existing
-    # candidate build to stable; see the promote job below).
+    # Only runs at all if plan-snap-builds actually selected at least one
+    # architecture for remote-build (it already accounts for skip-build,
+    # skip-<arch>, qemu-<arch>, and idempotency -- see its own comments).
     if: |
-      github.event_name != 'pull_request' &&
-      github.event_name != 'release' &&
-      !inputs.skip-build
+      needs.plan-snap-builds.result == 'success' &&
+      needs.plan-snap-builds.outputs.remote-arch != '[]'
     strategy:
       fail-fast: true
       matrix:
-        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        arch: ${{ fromJSON(needs.plan-snap-builds.outputs.remote-arch) }}
     steps:
       - name: Checkout Pebble repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -209,46 +310,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.release-tag }}
 
-      # Skip this architecture if it was explicitly requested via input, or
-      # (idempotency) if it's already attached to the release -- e.g. a
-      # previous run of this workflow already built and uploaded it, and
-      # we're only re-running to pick up an architecture that failed. We
-      # treat "asset attached to the release" as the single source of truth
-      # for "this architecture is done" -- it's uploaded together with (and
-      # right after) publishing to the Snap Store, so the two shouldn't
-      # normally get out of sync.
-      - name: Check if this architecture should be skipped
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.release-tag }}
-          ARCH: ${{ matrix.arch }}
-          SKIP_ARCH: ${{ inputs[format('skip-{0}', matrix.arch)] }}
-          QEMU_BUILD: ${{ inputs[format('qemu-{0}', matrix.arch)] }}
-        run: |
-          set -eu
-          if [[ "$SKIP_ARCH" == "true" ]]; then
-            echo "Architecture $ARCH skipped via input."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$QEMU_BUILD" == "true" ]]; then
-            echo "Architecture $ARCH is being built via QEMU emulation instead, skipping remote-build."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ -n "$TAG" ]] && gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qE "^pebble.*${ARCH}.*\.snap$"; then
-            echo "Snap for $ARCH already attached to release $TAG, skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
       - name: Set LP credentials for remote build
-        if: steps.check.outputs.skip != 'true'
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
           PEBBLE_DEV_MAILING_LIST: ${{ secrets.PEBBLE_DEV_MAILING_LIST }}
@@ -260,36 +322,33 @@ jobs:
           git config --global user.name "pebble-dev"
 
       - name: Set up Go
-        if: steps.check.outputs.skip != 'true'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
           go-version-file: "go.mod"
 
       # Ensure Snapcraft will ship the generated version files to LP.
-      - if: steps.check.outputs.skip != 'true'
-        run: |
+      - run: |
           go generate ./cmd
           git add -f ./cmd/VERSION ./cmd/version_generated.go
 
       - name: Build Snap for ${{ matrix.arch }}
         id: build-snap
-        if: steps.check.outputs.skip != 'true'
         uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79  # v1.3.0
         with:
           snapcraft-args: remote-build --build-for=${{ matrix.arch }} --launchpad-accept-public-upload
 
       - name: Attest build provenance
-        if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
+        if: steps.build-snap.outcome == 'success'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: ${{ steps.build-snap.outputs.snap }}
 
       - name: Rename the logs file, for colons are not allowed in the artifact name
-        if: steps.check.outputs.skip != 'true' && always()
+        if: always()
         run: cat snapcraft-pebble-*.txt > snapcraft-logs.txt || echo "no log files"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        if: steps.check.outputs.skip != 'true' && always()
+        if: always()
         with:
           name: snapcraft-logs-${{ matrix.arch }}
           path: |
@@ -300,7 +359,7 @@ jobs:
 
       - name: Attach ${{ steps.build-snap.outputs.snap }} to GH workflow execution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
+        if: steps.build-snap.outcome == 'success'
         with:
           name: pebble-snap-${{ matrix.arch }}
           path: ${{ steps.build-snap.outputs.snap }}
@@ -312,56 +371,23 @@ jobs:
     # build-base), and building inside it with `snapcraft pack
     # --destructive-mode`. This produces an unsigned ("dangerous") .snap,
     # same as any locally-built snap. Opt in per architecture via the
-    # qemu-<arch> inputs; remote-build skips any architecture built this
-    # way (see its "Check if this architecture should be skipped" step).
+    # qemu-<arch> inputs; plan-snap-builds routes any architecture built
+    # this way away from remote-build.
     runs-on: ubuntu-latest
+    needs: [plan-snap-builds]
     permissions:
       id-token: write
       attestations: write
       contents: read
+    # Only runs at all if plan-snap-builds actually selected at least one
+    # architecture for a QEMU build.
     if: |
-      github.event_name != 'pull_request' &&
-      github.event_name != 'release' &&
-      !inputs.skip-build
+      needs.plan-snap-builds.result == 'success' &&
+      needs.plan-snap-builds.outputs.qemu-arch != '[]'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - arch: amd64
-            qemu-pkg: qemu-system-x86
-            qemu-bin: qemu-system-x86_64
-            machine: pc
-            accel-flags: -cpu host -enable-kvm
-          - arch: arm64
-            qemu-pkg: qemu-system-arm
-            qemu-bin: qemu-system-aarch64
-            machine: virt
-            accel-flags: -cpu max
-            firmware-pkg: qemu-efi-aarch64
-            firmware-path: /usr/share/AAVMF/AAVMF_CODE.fd
-          - arch: armhf
-            qemu-pkg: qemu-system-arm
-            qemu-bin: qemu-system-arm
-            machine: virt
-            accel-flags: -cpu cortex-a15
-            firmware-pkg: qemu-efi-arm
-            firmware-path: /usr/share/AAVMF/AAVMF32_CODE.fd
-          - arch: ppc64el
-            qemu-pkg: qemu-system-ppc
-            qemu-bin: qemu-system-ppc64
-            machine: pseries
-            accel-flags: -cpu POWER9
-          - arch: riscv64
-            qemu-pkg: qemu-system-misc
-            qemu-bin: qemu-system-riscv64
-            machine: virt
-            accel-flags: -cpu rv64
-            firmware-flags: -bios default
-          - arch: s390x
-            qemu-pkg: qemu-system-s390x
-            qemu-bin: qemu-system-s390x
-            machine: s390-ccw-virtio
-            accel-flags: -cpu max
+        include: ${{ fromJSON(needs.plan-snap-builds.outputs.qemu-matrix) }}
     steps:
       - name: Checkout Pebble repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -370,45 +396,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.release-tag }}
 
-      # Opt-in gate: only run when the qemu-<arch> input requested a
-      # QEMU-emulated local build for this architecture, and (idempotency)
-      # skip if a snap for this arch is already attached to the release.
-      - name: Check if this architecture should build via QEMU
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.release-tag }}
-          ARCH: ${{ matrix.arch }}
-          QEMU_BUILD: ${{ inputs[format('qemu-{0}', matrix.arch)] }}
-        run: |
-          set -eu
-          if [[ "$QEMU_BUILD" != "true" ]]; then
-            echo "QEMU build for $ARCH not requested."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ -n "$TAG" ]] && gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qE "^pebble.*${ARCH}.*\.snap$"; then
-            echo "Snap for $ARCH already attached to release $TAG, skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
       - name: Set up Go
-        if: steps.check.outputs.skip != 'true'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
           go-version-file: "go.mod"
 
       # Generate the version files on the host; they're copied into the VM
       # along with the rest of the source tree below.
-      - if: steps.check.outputs.skip != 'true'
-        run: go generate ./cmd
+      - run: go generate ./cmd
 
       - name: Install QEMU and supporting tools
-        if: steps.check.outputs.skip != 'true'
         env:
           QEMU_PKG: ${{ matrix.qemu-pkg }}
           FIRMWARE_PKG: ${{ matrix.firmware-pkg }}
@@ -422,7 +419,6 @@ jobs:
       # The target Ubuntu release comes straight from snapcraft.yaml, so the
       # VM matches whatever base the snap actually builds against.
       - name: Determine Ubuntu base image for this build
-        if: steps.check.outputs.skip != 'true'
         id: base
         run: |
           set -eu
@@ -443,7 +439,6 @@ jobs:
           echo "codename=$CODENAME" >> "$GITHUB_OUTPUT"
 
       - name: Download Ubuntu cloud image for ${{ matrix.arch }}
-        if: steps.check.outputs.skip != 'true'
         env:
           CODENAME: ${{ steps.base.outputs.codename }}
           ARCH: ${{ matrix.arch }}
@@ -456,7 +451,6 @@ jobs:
           qemu-img create -f qcow2 -F qcow2 -b vm-base.img vm-disk.qcow2
 
       - name: Prepare cloud-init seed
-        if: steps.check.outputs.skip != 'true'
         run: |
           set -eu
           ssh-keygen -t ed25519 -N "" -f vm-key
@@ -479,7 +473,6 @@ jobs:
           cloud-localds seed.img user-data meta-data
 
       - name: Boot QEMU VM for ${{ matrix.arch }}
-        if: steps.check.outputs.skip != 'true'
         env:
           QEMU_BIN: ${{ matrix.qemu-bin }}
           MACHINE: ${{ matrix.machine }}
@@ -521,7 +514,6 @@ jobs:
           exit 1
 
       - name: Copy Pebble source into the VM
-        if: steps.check.outputs.skip != 'true'
         run: |
           set -eu
           SSH_OPTS=(-i vm-key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
@@ -530,7 +522,6 @@ jobs:
 
       - name: Build snap inside the VM
         id: build-snap
-        if: steps.check.outputs.skip != 'true'
         run: |
           set -eu
           SSH_OPTS=(-i vm-key -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
@@ -541,27 +532,27 @@ jobs:
           echo "snap=${SNAP_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Shut down the VM
-        if: always() && steps.check.outputs.skip != 'true'
+        if: always()
         run: |
           if [[ -f qemu.pid ]]; then
             kill "$(cat qemu.pid)" 2>/dev/null || true
           fi
 
       - name: Attest build provenance
-        if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
+        if: steps.build-snap.outcome == 'success'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: ${{ steps.build-snap.outputs.snap }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        if: steps.check.outputs.skip != 'true' && always()
+        if: always()
         with:
           name: qemu-build-logs-${{ matrix.arch }}
           path: serial.log
 
       - name: Attach ${{ steps.build-snap.outputs.snap }} to GH workflow execution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        if: steps.check.outputs.skip != 'true' && steps.build-snap.outcome == 'success'
+        if: steps.build-snap.outcome == 'success'
         with:
           name: pebble-snap-${{ matrix.arch }}
           path: ${{ steps.build-snap.outputs.snap }}
@@ -613,7 +604,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: snap-build
-    needs: [test]
+    needs: [test, plan-snap-builds]
     permissions:
       contents: write
     # The channel to publish to depends on why we're building: a push to master
@@ -626,55 +617,28 @@ jobs:
       # FIPS releases are tagged with a "-fips" suffix (see cmd/version.go),
       # and published to the separate "fips" track rather than "latest".
       DEFAULT_TRACK: ${{ endsWith(inputs.release-tag, '-fips') && 'fips' || 'latest' }}
+    # Only runs for architectures plan-snap-builds actually selected for a
+    # build this run (via either remote-build or qemu-build) -- it already
+    # excludes anything skipped via input or already attached to the
+    # release, so there's nothing for this job to (no-op) iterate over.
     if: |
-      github.event_name != 'pull_request' &&
-      github.event_name != 'release' &&
-      !inputs.skip-build &&
+      always() &&
       needs.test.result == 'success' &&
-      always()
+      needs.plan-snap-builds.result == 'success' &&
+      needs.plan-snap-builds.outputs.built-arch != '[]'
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"]
+        arch: ${{ fromJSON(needs.plan-snap-builds.outputs.built-arch) }}
     steps:
-      # This check is independent of whether remote-build actually built
-      # anything in this run, so that this job is idempotent whether we're
-      # resuming a run that partially failed (e.g. this step didn't get to
-      # run last time) or starting a brand new run for the same release tag.
-      - name: Check if this architecture should be skipped
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.release-tag }}
-          ARCH: ${{ matrix.arch }}
-          SKIP_ARCH: ${{ inputs[format('skip-{0}', matrix.arch)] }}
-        run: |
-          set -eu
-          if [[ "$SKIP_ARCH" == "true" ]]; then
-            echo "Architecture $ARCH skipped via input."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ -n "$TAG" ]] && gh release view "$TAG" --json assets --jq '.assets[].name' 2>/dev/null | grep -qE "^pebble.*${ARCH}.*\.snap$"; then
-            echo "Snap for $ARCH already attached to release $TAG, skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      - if: steps.check.outputs.skip != 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: pebble-snap-${{ matrix.arch }}
           if-no-artifact-found: ignore
 
       # There's nothing to publish/upload if this architecture's snap
-      # wasn't (re)built above -- e.g. its build failed, or `remote-build`
-      # itself was skipped this run for some other reason.
+      # wasn't actually produced above -- e.g. its build failed.
       - id: get-snap
-        if: steps.check.outputs.skip != 'true'
         env:
           ARCH: ${{ matrix.arch }}
         run: |


### PR DESCRIPTION
This fixes the qemu image downloading as well as changes the binaries and snaps jobs
to run a matrix generate action first then run the required actions based on that rather
than consuming action runners for skipped jobs.