### PR TITLE
fix(metrics): write each metric family once in the metrics response

### DIFF
--- a/internals/daemon/api_metrics.go
+++ b/internals/daemon/api_metrics.go
@@ -44,6 +44,13 @@ func v1GetMetrics(c *Command, r *http.Request, _ *UserState) Response {
 			return
 		}
 
+		err = metricsWriter.Flush()
+		if err != nil {
+			logger.Noticef("Cannot write metrics: %v", err)
+			http.Error(w, "# internal server error", http.StatusInternalServerError)
+			return
+		}
+
 		_, err = buf.WriteTo(w)
 		if err != nil {
 			logger.Noticef("Cannot write to HTTP response: %v", err)

--- a/internals/metrics/metrics.go
+++ b/internals/metrics/metrics.go
@@ -61,31 +61,90 @@ type Writer interface {
 	Write(Metric) error
 }
 
-// OpenTelemetryWriter implements the Writer interface and formats metrics
-// in OpenTelemetryWriter exposition format.
+// OpenTelemetryWriter implements the Writer interface and formats metrics in
+// OpenMetrics exposition format.
+//
+// Metrics are buffered by name and written out by Flush, because the format
+// requires every sample of a metric under a single HELP and TYPE line, while
+// callers hand metrics over one service or check at a time.
 type OpenTelemetryWriter struct {
-	w io.Writer
+	w        io.Writer
+	order    []string
+	families map[string]*metricFamily
+}
+
+// metricFamily holds every sample sharing one metric name, in the order the
+// samples were written.
+type metricFamily struct {
+	metricType MetricType
+	comment    string
+	samples    []Metric
 }
 
 // NewOpenTelemetryWriter creates a new OpenTelemetryWriter.
 func NewOpenTelemetryWriter(w io.Writer) *OpenTelemetryWriter {
-	return &OpenTelemetryWriter{w: w}
+	return &OpenTelemetryWriter{
+		w:        w,
+		families: make(map[string]*metricFamily),
+	}
 }
 
+// Write buffers a metric under its family. Type and Comment are taken from the
+// family's first sample, because they describe the family rather than the
+// sample.
 func (otw *OpenTelemetryWriter) Write(m Metric) error {
-	if m.Comment != "" {
-		_, err := fmt.Fprintf(otw.w, "# HELP %s %s\n", m.Name, m.Comment)
+	family, ok := otw.families[m.Name]
+	if !ok {
+		family = &metricFamily{metricType: m.Type, comment: m.Comment}
+		otw.families[m.Name] = family
+		otw.order = append(otw.order, m.Name)
+	}
+	family.samples = append(family.samples, m)
+	return nil
+}
+
+// Flush writes every buffered metric to the underlying writer, one family at a
+// time in the order the families were first written, then empties the buffer
+// so the writer can be reused.
+func (otw *OpenTelemetryWriter) Flush() error {
+	order := otw.order
+	families := otw.families
+	otw.order = nil
+	otw.families = make(map[string]*metricFamily)
+
+	for _, name := range order {
+		if err := otw.writeFamily(name, families[name]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (otw *OpenTelemetryWriter) writeFamily(name string, family *metricFamily) error {
+	if family.comment != "" {
+		_, err := fmt.Fprintf(otw.w, "# HELP %s %s\n", name, family.comment)
 		if err != nil {
 			return err
 		}
 	}
 
-	_, err := fmt.Fprintf(otw.w, "# TYPE %s %s\n", m.Name, m.Type)
+	_, err := fmt.Fprintf(otw.w, "# TYPE %s %s\n", name, family.metricType)
 	if err != nil {
 		return err
 	}
 
-	_, err = io.WriteString(otw.w, m.Name)
+	for _, m := range family.samples {
+		if err := otw.writeSample(m); err != nil {
+			return err
+		}
+	}
+
+	_, err = io.WriteString(otw.w, "\n")
+	return err
+}
+
+func (otw *OpenTelemetryWriter) writeSample(m Metric) error {
+	_, err := io.WriteString(otw.w, m.Name)
 	if err != nil {
 		return err
 	}
@@ -115,10 +174,6 @@ func (otw *OpenTelemetryWriter) Write(m Metric) error {
 		}
 	}
 
-	_, err = fmt.Fprintf(otw.w, " %d\n\n", m.ValueInt64)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = fmt.Fprintf(otw.w, " %d\n", m.ValueInt64)
+	return err
 }

--- a/internals/metrics/metrics_test.go
+++ b/internals/metrics/metrics_test.go
@@ -114,6 +114,8 @@ special_chars{key_with_underscore="value_with_underscore",key-with-dash="value-w
 		writer := metrics.NewOpenTelemetryWriter(buf)
 		err := writer.Write(tc.metric)
 		c.Assert(err, IsNil)
+		err = writer.Flush()
+		c.Assert(err, IsNil)
 		c.Assert(buf.String(), Equals, tc.expected)
 	}
 }

--- a/internals/overlord/checkstate/manager_test.go
+++ b/internals/overlord/checkstate/manager_test.go
@@ -938,6 +938,7 @@ func (s *ManagerSuite) TestMetricsCheckSuccess(c *C) {
 	buf := new(bytes.Buffer)
 	writer := metrics.NewOpenTelemetryWriter(buf)
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	expectedRegex := `
 # HELP pebble_check_up Whether the health check is up \(1\) or not \(0\)
 # TYPE pebble_check_up gauge
@@ -983,6 +984,7 @@ func (s *ManagerSuite) TestMetricsCheckFailure(c *C) {
 	buf := new(bytes.Buffer)
 	writer := metrics.NewOpenTelemetryWriter(buf)
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	expectedRegex := `
 # HELP pebble_check_up Whether the health check is up \(1\) or not \(0\)
 # TYPE pebble_check_up gauge
@@ -1021,6 +1023,7 @@ func (s *ManagerSuite) TestMetricsInactiveCheck(c *C) {
 	buf := new(bytes.Buffer)
 	writer := metrics.NewOpenTelemetryWriter(buf)
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	// Inactive check's pebble_check_up metric is not reported.
 	expected := `
 # HELP pebble_check_success_count Number of times the check has succeeded

--- a/internals/overlord/servstate/manager_test.go
+++ b/internals/overlord/servstate/manager_test.go
@@ -2317,21 +2317,16 @@ func (s *S) TestMetrics(c *C) {
 	buf := new(bytes.Buffer)
 	writer := metrics.NewOpenTelemetryWriter(buf)
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	expected := `
 # HELP pebble_service_active Whether the service is currently active (1) or not (0)
 # TYPE pebble_service_active gauge
 pebble_service_active{service="test1"} 1
-
-# HELP pebble_service_start_count Number of times the service has started
-# TYPE pebble_service_start_count counter
-pebble_service_start_count{service="test1"} 1
-
-# HELP pebble_service_active Whether the service is currently active (1) or not (0)
-# TYPE pebble_service_active gauge
 pebble_service_active{service="test2"} 1
 
 # HELP pebble_service_start_count Number of times the service has started
 # TYPE pebble_service_start_count counter
+pebble_service_start_count{service="test1"} 1
 pebble_service_start_count{service="test2"} 1
 
 `[1:]
@@ -2340,21 +2335,16 @@ pebble_service_start_count{service="test2"} 1
 	buf.Reset()
 	s.stopTestServices(c)
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	expected = `
 # HELP pebble_service_active Whether the service is currently active (1) or not (0)
 # TYPE pebble_service_active gauge
 pebble_service_active{service="test1"} 0
-
-# HELP pebble_service_start_count Number of times the service has started
-# TYPE pebble_service_start_count counter
-pebble_service_start_count{service="test1"} 1
-
-# HELP pebble_service_active Whether the service is currently active (1) or not (0)
-# TYPE pebble_service_active gauge
 pebble_service_active{service="test2"} 0
 
 # HELP pebble_service_start_count Number of times the service has started
 # TYPE pebble_service_start_count counter
+pebble_service_start_count{service="test1"} 1
 pebble_service_start_count{service="test2"} 1
 
 `[1:]
@@ -2366,21 +2356,16 @@ pebble_service_start_count{service="test2"} 1
 		return
 	}
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	expected = `
 # HELP pebble_service_active Whether the service is currently active (1) or not (0)
 # TYPE pebble_service_active gauge
 pebble_service_active{service="test1"} 1
-
-# HELP pebble_service_start_count Number of times the service has started
-# TYPE pebble_service_start_count counter
-pebble_service_start_count{service="test1"} 2
-
-# HELP pebble_service_active Whether the service is currently active (1) or not (0)
-# TYPE pebble_service_active gauge
 pebble_service_active{service="test2"} 1
 
 # HELP pebble_service_start_count Number of times the service has started
 # TYPE pebble_service_start_count counter
+pebble_service_start_count{service="test1"} 2
 pebble_service_start_count{service="test2"} 2
 
 `[1:]
@@ -2389,21 +2374,16 @@ pebble_service_start_count{service="test2"} 2
 	buf.Reset()
 	s.stopTestServices(c)
 	s.manager.WriteMetrics(writer)
+	c.Assert(writer.Flush(), IsNil)
 	expected = `
 # HELP pebble_service_active Whether the service is currently active (1) or not (0)
 # TYPE pebble_service_active gauge
 pebble_service_active{service="test1"} 0
-
-# HELP pebble_service_start_count Number of times the service has started
-# TYPE pebble_service_start_count counter
-pebble_service_start_count{service="test1"} 2
-
-# HELP pebble_service_active Whether the service is currently active (1) or not (0)
-# TYPE pebble_service_active gauge
 pebble_service_active{service="test2"} 0
 
 # HELP pebble_service_start_count Number of times the service has started
 # TYPE pebble_service_start_count counter
+pebble_service_start_count{service="test1"} 2
 pebble_service_start_count{service="test2"} 2
 
 `[1:]


### PR DESCRIPTION
With two or more services, or two or more checks, `/v1/metrics` is not valid Prometheus text exposition: each service and check writes its own `# HELP` and `# TYPE` lines, so the same family appears several times with other families in between. The Prometheus text parser (`prometheus/common` `expfmt.TextParser`) rejects the response with a second-HELP-line error, so nothing is scraped.

`OpenTelemetryWriter` now buffers samples by metric name and `Flush` writes one HELP and TYPE line per family followed by that family's samples, in first-seen order. `v1GetMetrics` calls `Flush` before writing the response. The `metrics.Writer` interface and both `WriteMetrics` callers are unchanged; the one-service, one-check example in the docs still matches the output.

The servstate `TestMetrics` expectation asserted the duplicated, interleaved form; it now asserts the grouped form with no assertion removed. Both test suites call `Flush`.

`go test -race ./...`, `go build ./cmd/pebble`, `gofmt`, `staticcheck` pass.
