### PR TITLE
docs: document NSS user and group resolution limitation

### DIFF
--- a/client/files.go
+++ b/client/files.go
@@ -105,17 +105,11 @@ func (fi *FileInfo) GroupID() *int {
 }
 
 // User is the string representing the owner user name.
-//
-// Because Pebble is built with CGO_ENABLED=0, user lookups rely on /etc/passwd
-// and will not resolve usernames managed via NSS, SSSD, or LDAP.
 func (fi *FileInfo) User() string {
 	return fi.user
 }
 
 // Group is the string representing the owner user group.
-//
-// Because Pebble is built with CGO_ENABLED=0, group lookups rely on /etc/group
-// and will not resolve group names managed via NSS, SSSD, or LDAP.
 func (fi *FileInfo) Group() string {
 	return fi.group
 }

--- a/client/files.go
+++ b/client/files.go
@@ -105,11 +105,17 @@ func (fi *FileInfo) GroupID() *int {
 }
 
 // User is the string representing the owner user name.
+//
+// Because Pebble is built with CGO_ENABLED=0, user lookups rely on /etc/passwd
+// and will not resolve usernames managed via NSS, SSSD, or LDAP.
 func (fi *FileInfo) User() string {
 	return fi.user
 }
 
 // Group is the string representing the owner user group.
+//
+// Because Pebble is built with CGO_ENABLED=0, group lookups rely on /etc/group
+// and will not resolve group names managed via NSS, SSSD, or LDAP.
 func (fi *FileInfo) Group() string {
 	return fi.group
 }

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -17,3 +17,6 @@ systemd
 UIDs
 Ulrich
 Utils
+NSS
+SSSD
+LDAP

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -116,6 +116,16 @@ A timestamp is a string in the [RFC 3339](https://datatracker.ietf.org/doc/html/
 - "1985-04-12T23:20:50.52Z"
 - "1996-12-19T16:39:57.123456789-08:00"
 
+### User and group resolution
+
+Pebble is statically compiled with `CGO_ENABLED=0`. Consequently, user and
+group lookups in file operations (such as resolving `user` and `group` in
+`GET /v1/files`) use the pure-Go resolver in Go's standard library, which
+reads `/etc/passwd` and `/etc/group` directly. Lookups cannot query NSS, SSSD,
+or LDAP. On systems where users and groups are managed via NSS or network
+directory services, user and group names may be empty in file metadata even
+though the numeric `user-id` and `group-id` are reported correctly.
+
 ## Errors
 
 API endpoints may return errors as 4xx [status codes](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml) (client errors) and 5xx status codes (server errors).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -119,9 +119,9 @@ A timestamp is a string in the [RFC 3339](https://datatracker.ietf.org/doc/html/
 ### User and group resolution
 
 Pebble is statically compiled with `CGO_ENABLED=0`. Consequently, user and
-group lookups in file operations (such as resolving `user` and `group` in
-`GET /v1/files`) use the pure-Go resolver in Go's standard library, which
-reads `/etc/passwd` and `/etc/group` directly. Lookups cannot query NSS, SSSD,
+group lookup in file operations (such as resolving `user` and `group` in
+`GET /v1/files`) uses the pure-Go resolver in Go's standard library, which
+reads `/etc/passwd` and `/etc/group` directly. It cannot query NSS, SSSD,
 or LDAP. On systems where users and groups are managed via NSS or network
 directory services, user and group names may be empty in file metadata even
 though the numeric `user-id` and `group-id` are reported correctly.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -518,6 +518,14 @@ pebble run --verbose
 
 The `ls` command is used to list path contents.
 
+```{note}
+Pebble is statically compiled with `CGO_ENABLED=0`, which means Go's user
+and group lookup uses a pure-Go implementation reading directly from
+`/etc/passwd` and `/etc/group`. On systems where users and groups are managed
+by NSS, SSSD, or LDAP, usernames and group names may not resolve in `pebble ls -l`
+output and will display as numeric IDs or empty fields.
+```
+
 <!-- START AUTOMATED OUTPUT FOR ls -->
 ```{terminal}
 pebble ls --help

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -522,8 +522,8 @@ The `ls` command is used to list path contents.
 Pebble is statically compiled with `CGO_ENABLED=0`, which means Go's user
 and group lookup uses a pure-Go implementation reading directly from
 `/etc/passwd` and `/etc/group`. On systems where users and groups are managed
-by NSS, SSSD, or LDAP, usernames and group names may not resolve in `pebble ls -l`
-output and will display as numeric IDs or empty fields.
+by NSS, SSSD, or LDAP, usernames and group names may not resolve and will
+display as empty fields in `pebble ls -l`.
 ```
 
 <!-- START AUTOMATED OUTPUT FOR ls -->

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -1439,13 +1439,19 @@ components:
           description: User ID of the owner.
         user:
           type: string
-          description: Username of the owner.
+          description: |
+            Username of the owner. Note that because Pebble is built without CGO,
+            lookup relies on /etc/passwd and will not resolve usernames managed
+            externally via NSS, SSSD, or LDAP.
         group-id:
           type: integer
           description: Group ID of the owner.
         group:
           type: string
-          description: Group name of the owner.
+          description: |
+            Group name of the owner. Note that because Pebble is built without CGO,
+            lookup relies on /etc/group and will not resolve group names managed
+            externally via NSS, SSSD, or LDAP.
       required:
         - path
         - name


### PR DESCRIPTION
Because Pebble is statically compiled with CGO_ENABLED=0, user and group
lookups in file operations (such as resolving user and group names in
GET /v1/files and pebble ls -l) use the pure-Go resolver in Go's os/user
package. This resolver reads /etc/passwd and /etc/group directly rather
than querying system NSS plugins, SSSD, or LDAP.

On NSS-managed systems, file metadata queries return numeric IDs (user-id
and group-id) accurately, but usernames and group names may resolve as
empty strings.

This documents this known limitation across:
1. The API reference (reference/api.md under ## Data formats).
2. The CLI reference for the ls command (reference/cli-commands.md).
3. The OpenAPI specification (docs/specs/openapi.yaml on FileInfo).
4. The Go client FileInfo methods (client/files.go on User() and Group()).
5. The docs spelling wordlist (.custom_wordlist.txt).

Closes #868